### PR TITLE
feat: allow ADD permission for kvk_user and fix user-level permission…

### DIFF
--- a/backend/services/userManagementService.js
+++ b/backend/services/userManagementService.js
@@ -216,20 +216,6 @@ const userManagementService = {
       kvkId: effectiveKvkId,
     };
 
-    // Pre-validate permissions for _user target roles (before DB insert)
-    const requestedRole = await prisma.role.findUnique({ where: { roleId: sanitizedData.roleId } });
-    const targetRoleName = requestedRole?.roleName || '';
-    if (targetRoleName.endsWith('_user')) {
-      if (!options.permissions?.length) {
-        throw new Error('At least one permission (VIEW, ADD, EDIT, DELETE) is required when creating a _user role');
-      }
-      const preNormalized = options.permissions.map((a) => (typeof a === 'string' ? a.toUpperCase().trim() : a));
-      const preInvalid = preNormalized.filter((a) => !VALID_PERMISSION_ACTIONS.includes(a));
-      if (preInvalid.length > 0) {
-        throw new Error(`Invalid permission(s): ${preInvalid.join(', ')}. Allowed: ${VALID_PERMISSION_ACTIONS.join(', ')}`);
-      }
-    }
-
     // Hash password
     const passwordHash = await hashPassword(password);
 

--- a/backend/services/userManagementService.js
+++ b/backend/services/userManagementService.js
@@ -233,21 +233,39 @@ const userManagementService = {
     // Hash password
     const passwordHash = await hashPassword(password);
 
-    // Create user
-    const user = await userRepository.createUserWithPassword(sanitizedData, passwordHash);
-
-    // Assign user-level permissions for _user roles (regardless of who creates them)
+    // Pre-validate and resolve permissions for _user roles before creating the user
+    const targetRoleRecord = await prisma.role.findUnique({ where: { roleId: effectiveRoleId } });
+    const targetRoleName = targetRoleRecord?.roleName || '';
+    const isTargetUserRole = targetRoleName.endsWith('_user');
     let permissionActions = [];
-    const targetRole = user.role?.roleName || '';
-    const isTargetUserRole = targetRole.endsWith('_user');
-    if (isTargetUserRole && options.permissions?.length) {
-      const normalizedPerms = options.permissions.map((a) => (typeof a === 'string' ? a.toUpperCase().trim() : a));
-      const permissionIds = await userManagementService.getPermissionIdsForActions(normalizedPerms);
-       if (permissionIds.length) {
-         await userPermissionRepository.addUserPermissions(user.userId, permissionIds);
-         permissionActions = normalizedPerms;
-       }
+    let resolvedPermissionIds = [];
+
+    if (isTargetUserRole) {
+      if (!options.permissions || !options.permissions.length) {
+        throw new Error('At least one permission (VIEW, ADD, EDIT, DELETE) is required when creating a _user role');
+      }
+      permissionActions = options.permissions.map((a) => (typeof a === 'string' ? a.toUpperCase().trim() : a));
+      const invalid = permissionActions.filter((a) => !VALID_PERMISSION_ACTIONS.includes(a));
+      if (invalid.length > 0) {
+        throw new Error(`Invalid permission(s): ${invalid.join(', ')}. Allowed: ${VALID_PERMISSION_ACTIONS.join(', ')}`);
+      }
+      resolvedPermissionIds = await userManagementService.getPermissionIdsForActions(permissionActions);
     }
+
+    // Create user and assign permissions atomically
+    const user = await prisma.$transaction(async (tx) => {
+      const created = await tx.user.create({
+        data: { ...sanitizedData, passwordHash },
+        include: { role: true, zone: true, state: true, district: true, org: true, kvk: true },
+      });
+      if (isTargetUserRole && resolvedPermissionIds.length) {
+        await tx.userPermission.createMany({
+          data: resolvedPermissionIds.map((permissionId) => ({ userId: created.userId, permissionId })),
+          skipDuplicates: true,
+        });
+      }
+      return created;
+    });
 
     return {
       userId: user.userId,

--- a/frontend/src/components/admin/CreateUserModal.tsx
+++ b/frontend/src/components/admin/CreateUserModal.tsx
@@ -24,8 +24,8 @@ const PERMISSION_ACTIONS: { value: PermissionAction; label: string }[] = [
     { value: 'DELETE', label: 'Delete' },
 ]
 
-/** Permission actions for non-admin users (Add is not allowed) */
-const PERMISSION_ACTIONS_NON_ADMIN = PERMISSION_ACTIONS.filter((a) => a.value !== 'ADD')
+/** Roles that get the ADD permission option even though they are non-admin */
+const NON_ADMIN_ROLES_WITH_ADD = ['kvk_user']
 
 /** Non-admin roles that require custom permissions */
 const NON_ADMIN_ROLES = ['kvk_user', 'state_user', 'district_user', 'org_user']
@@ -510,7 +510,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                             Select at least one permission. The user will only be able to perform the selected actions.
                         </p>
                         <div className="flex flex-wrap gap-4">
-                            {PERMISSION_ACTIONS_NON_ADMIN.map(({ value, label }) => (
+                            {(NON_ADMIN_ROLES_WITH_ADD.includes(selectedRole || '') ? PERMISSION_ACTIONS : PERMISSION_ACTIONS.filter(a => a.value !== 'ADD')).map(({ value, label }) => (
                                 <label
                                     key={value}
                                     className="flex items-center gap-2 cursor-pointer"


### PR DESCRIPTION
… saving

Backend: user-level permissions are now saved for all _user roles regardless of creator (previously only saved when creator was not super_admin). This ensures super_admin creating a kvk_user with ADD permission works correctly.

Frontend: kvk_user now shows the ADD checkbox in the permissions section of CreateUserModal, while other _user roles still only show VIEW, EDIT, DELETE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Pre-validate and normalize permissions for roles that require explicit permissions; missing/invalid permissions now produce clear errors before creation.
  * User creation and permission assignment are atomic to ensure consistency.
  * Admin UI: permission options shown or hidden dynamically based on selected role, with ADD option available for specific non-admin roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->