### PR TITLE
fix: permission-based access for _user roles and aboutKvk operations

### DIFF
--- a/backend/services/forms/aboutKvkService.js
+++ b/backend/services/forms/aboutKvkService.js
@@ -101,19 +101,15 @@ class AboutKvkService {
                 throw new Error('Only super admin can create KVKs');
             }
         } else {
-            // For all other About KVK entities, only KVK roles can create
-            if (!user || !KVK_ROLES.includes(user.roleName)) {
-                throw new Error('Only KVK users can create this resource');
-            }
-            // Auto-fill kvkId for KVK role users - ensure it exists
-            if (!user.kvkId) {
-                throw new Error('KVK ID is missing from user profile. Please contact administrator to assign a KVK to your account.');
-            }
-            data.kvkId = user.kvkId;
+            // For other entities, permission is enforced by route middleware (requirePermission).
+            // Auto-fill kvkId from user profile if available
+            if (user && user.kvkId) {
+                data.kvkId = user.kvkId;
 
-            // For employees: set originalKvkId to the current kvkId (first KVK where staff is created)
-            if ((entityName === 'kvk-employees' || entityName === 'kvk-staff-transferred') && !data.originalKvkId) {
-                data.originalKvkId = user.kvkId;
+                // For employees: set originalKvkId to the current kvkId (first KVK where staff is created)
+                if ((entityName === 'kvk-employees' || entityName === 'kvk-staff-transferred') && !data.originalKvkId) {
+                    data.originalKvkId = user.kvkId;
+                }
             }
         }
 
@@ -164,25 +160,14 @@ class AboutKvkService {
         // Ensure entity exists and user has access (getById enforces geographic scope)
         const currentEntity = await this.getById(entityName, id, user);
 
-        // Authorization checks
-        if (entityName === 'kvks') {
-            // Admin roles can update KVKs (scope already enforced by getById)
-            if (!user || user.kvkId) {
-                throw new Error('Only admin users can update KVKs');
-            }
-        } else {
-            // For all other About KVK entities, only KVK roles can update their own data
-            if (!user || !KVK_ROLES.includes(user.roleName)) {
-                throw new Error('Only KVK users can update this resource');
-            }
-
-            // For employees: prevent source KVKs from updating transferred employees
-            // Only the current KVK (where employee is now) can update
-            if ((entityName === 'kvk-employees' || entityName === 'kvk-staff-transferred') &&
-                currentEntity.transferStatus === 'TRANSFERRED') {
-                if (currentEntity.kvkId !== user.kvkId) {
-                    throw new Error('You cannot update employees that were transferred from your KVK. Only the current KVK can manage this employee.');
-                }
+        // Authorization checks — permission enforced by route middleware (requirePermission).
+        // KVK entity updates: scope already enforced by getById.
+        // For employees: prevent source KVKs from updating transferred employees.
+        if (entityName !== 'kvks' &&
+            (entityName === 'kvk-employees' || entityName === 'kvk-staff-transferred') &&
+            currentEntity.transferStatus === 'TRANSFERRED') {
+            if (user && user.kvkId && currentEntity.kvkId !== user.kvkId) {
+                throw new Error('You cannot update employees that were transferred from your KVK. Only the current KVK can manage this employee.');
             }
         }
 
@@ -211,6 +196,13 @@ class AboutKvkService {
     async delete(entityName, id, user = null) {
         // Ensure entity exists and user has access
         const currentEntity = await this.getById(entityName, id, user);
+
+        // Only super_admin can delete KVKs
+        if (entityName === 'kvks') {
+            if (!user || user.roleName !== 'super_admin') {
+                throw new Error('Only super admin can delete KVKs');
+            }
+        }
 
         // For employees: prevent source KVKs from deleting transferred employees
         // Only the current KVK (where employee is now) can delete

--- a/backend/services/forms/aboutKvkService.js
+++ b/backend/services/forms/aboutKvkService.js
@@ -102,14 +102,29 @@ class AboutKvkService {
             }
         } else {
             // For other entities, permission is enforced by route middleware (requirePermission).
-            // Auto-fill kvkId from user profile if available
-            if (user && user.kvkId) {
-                data.kvkId = user.kvkId;
+            if (!user) {
+                throw new Error('Authentication required');
+            }
 
-                // For employees: set originalKvkId to the current kvkId (first KVK where staff is created)
-                if ((entityName === 'kvk-employees' || entityName === 'kvk-staff-transferred') && !data.originalKvkId) {
-                    data.originalKvkId = user.kvkId;
+            if (user.kvkId) {
+                // KVK-scoped users: auto-fill kvkId from profile
+                data.kvkId = user.kvkId;
+            } else if (user.roleName !== 'super_admin') {
+                // Admin users without kvkId: validate that data.kvkId is within their geographic scope
+                const requestedKvkId = data.kvkId ? Number(data.kvkId) : null;
+                if (!Number.isInteger(requestedKvkId)) {
+                    throw new Error('KVK ID is required');
                 }
+                const scopedKvkIds = await this._getScopedKvkIds(user);
+                if (!scopedKvkIds.includes(requestedKvkId)) {
+                    throw new Error('Access denied: This KVK is outside your geographic scope');
+                }
+                data.kvkId = requestedKvkId;
+            }
+
+            // For employees: set originalKvkId to the current kvkId (first KVK where staff is created)
+            if ((entityName === 'kvk-employees' || entityName === 'kvk-staff-transferred') && !data.originalKvkId && data.kvkId) {
+                data.originalKvkId = data.kvkId;
             }
         }
 


### PR DESCRIPTION
## Summary
- **Permission system as single source of truth**: Removed `requiredRole` gates from frontend routes that already have `requiredModuleCode`, allowing `_user` roles (state_user, district_user, etc.) to access pages when they have proper permissions
- **Fixed aboutKvkService hardcoded role checks**: Replaced `KVK_ROLES` checks in create/update/delete with permission-based access via route middleware. KVK entity create & delete remain super_admin only
- **Fixed empty dropdowns for non-KVK roles**: Removed frontend permission gate on `useMasterData` read queries — backend GETs only require authentication, not module permissions
- **Added USER_SCOPE module to seed script**: Enables storing user-level permission overrides for `_user` roles

## Changes
- `frontend/src/App.tsx` — Removed `requiredRole={ADMIN_ROLES}` from routes that have `requiredModuleCode`
- `frontend/src/hooks/useMasterData.ts` — Removed `all_masters_*` permission check on read queries
- `backend/services/forms/aboutKvkService.js` — Removed hardcoded `KVK_ROLES`/`super_admin` checks from create/update/delete (kept super_admin gate for KVK create & delete only)
- `backend/scripts/permissions.js` — Added `USER_SCOPE` module for user-level permission storage

## Test plan
- [ ] Login as `state_user` with permissions → verify access to User Management, Role Management, etc.
- [ ] Verify `_user` roles can CRUD About KVK entities when given proper permissions
- [ ] Verify only `super_admin` can create/delete KVK entities
- [ ] Verify dropdowns (zone, state, district, org, university) load for all roles when editing KVK details
- [ ] Re-run seed (`node backend/scripts/permissions.js`) to create USER_SCOPE module
- [ ] Verify existing admin role behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Creation flow now auto-fills organization ID when available and relaxes previous strict creation barriers for non-admin users.
  * Update flow simplified while preserving protections for transferred employee records—only the current organization can modify transferred employees.
  * Deletion of organization records is now restricted to administrative accounts only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->