### PR TITLE
fix: cache user profile in auth middleware and fix image download

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,5 +1,4 @@
 const { verifyToken } = require('../utils/jwt.js');
-const prisma = require('../config/prisma.js');
 const permissionResolverService = require('../services/auth/permissionResolverService.js');
 
 /**
@@ -18,22 +17,18 @@ async function authenticateToken(req, res, next) {
     // Verify token
     const decoded = verifyToken(token, 'access');
 
-    // Fetch user from database to ensure they still exist and are active.
-    // roleName and permissionsByModule come from the token (embedded at login/refresh).
-    const user = await prisma.user.findUnique({
-      where: { userId: decoded.userId },
-    });
+    // Fetch user profile (Redis-cached, DB fallback).
+    const user = await permissionResolverService.getUserProfile(decoded.userId);
 
     if (!user) {
       return res.status(401).json({ error: 'User not found' });
     }
 
-    // Check if user is soft-deleted
     if (user.deletedAt) {
       return res.status(401).json({ error: 'User account has been deleted' });
     }
 
-    // Resolve effective permissions server-side (DB + cache).
+    // Resolve effective permissions (Redis-cached, DB fallback).
     const permissionsByModule = await permissionResolverService.getEffectivePermissions({
       userId: user.userId,
       roleId: decoded.roleId,

--- a/backend/services/auth/permissionResolverService.js
+++ b/backend/services/auth/permissionResolverService.js
@@ -1,9 +1,26 @@
 const rolePermissionRepository = require('../../repositories/rolePermissionRepository.js');
 const userPermissionRepository = require('../../repositories/userPermissionRepository.js');
+const prisma = require('../../config/prisma.js');
 const cacheService = require('../cache/redisCacheService.js');
 
 const CACHE_VERSION = 'v1';
 const DEFAULT_CACHE_TTL_SECONDS = 3600;
+
+const USER_PROFILE_FIELDS = {
+  userId: true,
+  email: true,
+  name: true,
+  zoneId: true,
+  stateId: true,
+  districtId: true,
+  orgId: true,
+  kvkId: true,
+  deletedAt: true,
+};
+
+function userProfileCacheKey(userId) {
+  return `user:profile:${userId}:${CACHE_VERSION}`;
+}
 
 function getCacheTtlSeconds() {
   const parsed = Number(process.env.PERMISSION_CACHE_TTL_SECONDS);
@@ -46,6 +63,36 @@ function intersectWithUserActions(rolePermissionsByModule, userActions) {
 }
 
 const permissionResolverService = {
+  /**
+   * Fetch user profile fields needed by auth middleware.
+   * Returns null if user does not exist.
+   *
+   * @param {number} userId
+   * @param {{ bypassCache?: boolean }} [options]
+   * @returns {Promise<object|null>}
+   */
+  getUserProfile: async (userId, options = {}) => {
+    const bypassCache = options.bypassCache === true;
+    const key = userProfileCacheKey(userId);
+
+    if (!bypassCache) {
+      const cached = await cacheService.get(key);
+      if (cached !== null) {
+        return cached;
+      }
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { userId },
+      select: USER_PROFILE_FIELDS,
+    });
+
+    if (!user) return null;
+
+    await cacheService.set(key, user, getCacheTtlSeconds());
+    return user;
+  },
+
   /**
    * Resolve role-level permissions grouped by module.
    * Cache-backed with DB fallback.
@@ -136,6 +183,7 @@ const permissionResolverService = {
    */
   invalidateUserPermissions: async (userId) => {
     if (!userId) return;
+    await cacheService.del(userProfileCacheKey(userId));
     await cacheService.delPattern(`perm:user:${userId}:*`);
   },
 

--- a/frontend/src/pages/features/ModuleImages.tsx
+++ b/frontend/src/pages/features/ModuleImages.tsx
@@ -47,6 +47,26 @@ function getFileUrl(path: string): string {
   }
 }
 
+async function downloadImage(downloadUrl: string, fileName?: string | null) {
+  try {
+    const url = getFileUrl(downloadUrl)
+    const res = await fetch(url, { credentials: 'include' })
+    if (!res.ok) throw new Error('Download failed')
+    const blob = await res.blob()
+    const blobUrl = window.URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = blobUrl
+    a.download = fileName || 'image'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    window.URL.revokeObjectURL(blobUrl)
+  } catch {
+    // Fallback: open in new tab
+    window.open(getFileUrl(downloadUrl), '_blank')
+  }
+}
+
 function fileToDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
@@ -476,14 +496,13 @@ export const ModuleImages: React.FC = () => {
                         </td>
                         <td className="px-4 py-3 text-sm text-[#212121]">{row.caption || 'N/A'}</td>
                         <td className="px-4 py-3 text-sm">
-                          <a
-                            href={getFileUrl(row.downloadUrl)}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="text-[#536DFE] hover:underline"
+                          <button
+                            type="button"
+                            onClick={() => downloadImage(row.downloadUrl, row.fileName)}
+                            className="text-[#536DFE] hover:underline cursor-pointer"
                           >
                             Download Image
-                          </a>
+                          </button>
                         </td>
                       </tr>
                     ))


### PR DESCRIPTION
- Add Redis-cached getUserProfile to permissionResolverService (eliminates DB query on every authenticated request when cache is warm)
- Invalidate user profile cache alongside permission cache on user changes
- Fix module image download: replace <a target="_blank"> with fetch-based blob download so cookies are sent through the Vercel rewrite proxy