### PR TITLE
fix: stabilize reporting-year persistence across date-format migration

### DIFF
--- a/backend/middleware/reportingYearNormalizer.js
+++ b/backend/middleware/reportingYearNormalizer.js
@@ -1,5 +1,6 @@
 const prisma = require('../config/prisma.js');
-const { normalizeReportingYearPayload } = require('../utils/reportingYearUtils.js');
+const { normalizeReportingYearPayload, isStrictDateString } = require('../utils/reportingYearUtils.js');
+const { ValidationError } = require('../utils/errorHandler.js');
 
 const CACHE_TTL_MS = 60 * 1000;
 let cachedYears = null;
@@ -61,21 +62,73 @@ async function normalizeReportingYearRequest(req, _res, next) {
         const yearRows = await fetchYearRows();
 
         if (shouldProcessBody) {
-            normalizeReportingYearPayload(req.body, yearRows, {
-                stripUnresolvedLegacyFields: true,
+            const result = normalizeReportingYearPayload(req.body, yearRows, {
+                stripUnresolvedLegacyFields: false,
             });
+            validateStrictReportingYear(req.body, result);
         }
 
         if (shouldProcessQuery) {
-            normalizeReportingYearPayload(req.query, yearRows, {
+            const result = normalizeReportingYearPayload(req.query, yearRows, {
                 stripUnresolvedLegacyFields: false,
             });
+            validateStrictReportingYear(req.query, result);
         }
 
         return next();
     } catch (error) {
         return next(error);
     }
+}
+
+function hasReportingYearKeys(payload) {
+    return (
+        Object.prototype.hasOwnProperty.call(payload, 'reportingYear') ||
+        Object.prototype.hasOwnProperty.call(payload, 'reportingYearId') ||
+        Object.prototype.hasOwnProperty.call(payload, 'year') ||
+        Object.prototype.hasOwnProperty.call(payload, 'yearId')
+    );
+}
+
+function isExplicitClearValue(value) {
+    return value === null || value === '';
+}
+
+function isClearIntent(payload) {
+    const values = [
+        payload.reportingYearId,
+        payload.yearId,
+        payload.reportingYear,
+        payload.year,
+    ].filter((value) => value !== undefined);
+
+    return values.length > 0 && values.every(isExplicitClearValue);
+}
+
+function validateStrictReportingYear(payload, normalizationResult) {
+    if (!payload || typeof payload !== 'object') return;
+    if (!hasReportingYearKeys(payload)) return;
+    if (isClearIntent(payload)) return;
+    if (normalizationResult && normalizationResult.resolvedId !== null) return;
+    if (typeof payload.reportingYear === 'string' && isStrictDateString(payload.reportingYear)) return;
+    if (typeof payload.year === 'string' && isStrictDateString(payload.year)) return;
+    if (
+        payload.reportingYearId !== undefined &&
+        payload.reportingYearId !== null &&
+        payload.reportingYearId !== '' &&
+        !Number.isNaN(parseInt(payload.reportingYearId, 10))
+    ) return;
+    if (
+        payload.yearId !== undefined &&
+        payload.yearId !== null &&
+        payload.yearId !== '' &&
+        !Number.isNaN(parseInt(payload.yearId, 10))
+    ) return;
+
+    throw new ValidationError(
+        'reportingYear must be a valid date in YYYY-MM-DD format (or provide a valid reportingYearId)',
+        'reportingYear'
+    );
 }
 
 module.exports = {

--- a/backend/middleware/reportingYearNormalizer.js
+++ b/backend/middleware/reportingYearNormalizer.js
@@ -1,0 +1,83 @@
+const prisma = require('../config/prisma.js');
+const { normalizeReportingYearPayload } = require('../utils/reportingYearUtils.js');
+
+const CACHE_TTL_MS = 60 * 1000;
+let cachedYears = null;
+let cacheExpiresAt = 0;
+let inFlightFetch = null;
+
+function shouldSkipNormalization(req) {
+    const path = req.path || '';
+    return path.startsWith('/miscellaneous/ppv-fra');
+}
+
+async function fetchYearRows() {
+    const now = Date.now();
+    if (cachedYears && now < cacheExpiresAt) {
+        return cachedYears;
+    }
+
+    if (inFlightFetch) {
+        return inFlightFetch;
+    }
+
+    inFlightFetch = prisma.yearMaster.findMany({
+        select: { yearId: true, yearName: true },
+        orderBy: { yearId: 'asc' },
+    })
+        .then((rows) => {
+            cachedYears = rows;
+            cacheExpiresAt = Date.now() + CACHE_TTL_MS;
+            return rows;
+        })
+        .finally(() => {
+            inFlightFetch = null;
+        });
+
+    return inFlightFetch;
+}
+
+async function normalizeReportingYearRequest(req, _res, next) {
+    try {
+        if (shouldSkipNormalization(req)) {
+            return next();
+        }
+
+        const shouldProcessBody =
+            (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH') &&
+            req.body &&
+            typeof req.body === 'object' &&
+            !Array.isArray(req.body);
+
+        const shouldProcessQuery =
+            req.query &&
+            typeof req.query === 'object' &&
+            Object.keys(req.query).length > 0;
+
+        if (!shouldProcessBody && !shouldProcessQuery) {
+            return next();
+        }
+
+        const yearRows = await fetchYearRows();
+
+        if (shouldProcessBody) {
+            normalizeReportingYearPayload(req.body, yearRows, {
+                stripUnresolvedLegacyFields: true,
+            });
+        }
+
+        if (shouldProcessQuery) {
+            normalizeReportingYearPayload(req.query, yearRows, {
+                stripUnresolvedLegacyFields: false,
+            });
+        }
+
+        return next();
+    } catch (error) {
+        return next(error);
+    }
+}
+
+module.exports = {
+    normalizeReportingYearRequest,
+};

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const { normalizeReportingYearRequest } = require('../middleware/reportingYearNormalizer.js');
 
 const userRoutes = require('./userRoutes.js');
 const authRoutes = require('./authRoutes.js');
@@ -69,7 +70,7 @@ router.use('/admin/masters', exportRoutes);
 router.use('/users', userRoutes);
 // Robust payload validation for all form saves (numbers + dates).
 router.use('/forms', validateFormRobustness);
-
+router.use('/forms', normalizeReportingYearRequest);
 router.use('/forms/about-kvk', aboutKvkRoutes);
 router.use('/forms/achievements/kvk-awards', kvkAwardRoutes);
 router.use('/forms/achievements/scientist-awards', scientistAwardRoutes);

--- a/backend/tests/reportingYearUtils.test.js
+++ b/backend/tests/reportingYearUtils.test.js
@@ -1,0 +1,54 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    resolveReportingYearId,
+    normalizeReportingYearPayload,
+    formatReportingYearLabel,
+} = require('../utils/reportingYearUtils.js');
+
+const YEAR_ROWS = [
+    { yearId: 1, yearName: '2023-24' },
+    { yearId: 2, yearName: '2024-25' },
+    { yearId: 3, yearName: '2024-04-01T00:00:00.000Z' },
+];
+
+test('resolveReportingYearId resolves a valid numeric ID directly', () => {
+    assert.equal(resolveReportingYearId('2', YEAR_ROWS), 2);
+});
+
+test('resolveReportingYearId resolves exact legacy year-name strings', () => {
+    assert.equal(resolveReportingYearId('2024-25', YEAR_ROWS), 2);
+});
+
+test('resolveReportingYearId resolves date-like year names by date prefix', () => {
+    assert.equal(resolveReportingYearId('2024-04-01', YEAR_ROWS), 3);
+});
+
+test('resolveReportingYearId resolves start-year values to matching fiscal rows', () => {
+    assert.equal(resolveReportingYearId('2023', YEAR_ROWS), 1);
+});
+
+test('normalizeReportingYearPayload sets reportingYearId/yearId from legacy reportingYear string', () => {
+    const payload = { reportingYear: '2024-25' };
+    const result = normalizeReportingYearPayload(payload, YEAR_ROWS);
+
+    assert.equal(result.resolvedId, 2);
+    assert.equal(payload.reportingYearId, 2);
+    assert.equal(payload.yearId, 2);
+});
+
+test('normalizeReportingYearPayload strips unresolved legacy reportingYear strings when configured', () => {
+    const payload = { reportingYear: 'not-a-real-year' };
+    normalizeReportingYearPayload(payload, YEAR_ROWS, { stripUnresolvedLegacyFields: true });
+
+    assert.equal(payload.reportingYear, undefined);
+});
+
+test('formatReportingYearLabel returns start year for date-like strings', () => {
+    assert.equal(formatReportingYearLabel('2024-04-01T00:00:00.000Z'), '2024');
+});
+
+test('formatReportingYearLabel preserves fiscal year strings', () => {
+    assert.equal(formatReportingYearLabel('2024-25'), '2024-25');
+});

--- a/backend/tests/reportingYearUtils.test.js
+++ b/backend/tests/reportingYearUtils.test.js
@@ -8,8 +8,8 @@ const {
 } = require('../utils/reportingYearUtils.js');
 
 const YEAR_ROWS = [
-    { yearId: 1, yearName: '2023-24' },
-    { yearId: 2, yearName: '2024-25' },
+    { yearId: 1, yearName: '2023-04-01T00:00:00.000Z' },
+    { yearId: 2, yearName: '2024-01-01T00:00:00.000Z' },
     { yearId: 3, yearName: '2024-04-01T00:00:00.000Z' },
 ];
 
@@ -17,25 +17,25 @@ test('resolveReportingYearId resolves a valid numeric ID directly', () => {
     assert.equal(resolveReportingYearId('2', YEAR_ROWS), 2);
 });
 
-test('resolveReportingYearId resolves exact legacy year-name strings', () => {
-    assert.equal(resolveReportingYearId('2024-25', YEAR_ROWS), 2);
+test('resolveReportingYearId rejects legacy fiscal-year strings', () => {
+    assert.equal(resolveReportingYearId('2024-25', YEAR_ROWS), null);
 });
 
 test('resolveReportingYearId resolves date-like year names by date prefix', () => {
     assert.equal(resolveReportingYearId('2024-04-01', YEAR_ROWS), 3);
 });
 
-test('resolveReportingYearId resolves start-year values to matching fiscal rows', () => {
-    assert.equal(resolveReportingYearId('2023', YEAR_ROWS), 1);
+test('resolveReportingYearId rejects year-only values (strict date mode)', () => {
+    assert.equal(resolveReportingYearId('2023', YEAR_ROWS), null);
 });
 
-test('normalizeReportingYearPayload sets reportingYearId/yearId from legacy reportingYear string', () => {
-    const payload = { reportingYear: '2024-25' };
+test('normalizeReportingYearPayload sets reportingYearId/yearId from date reportingYear string', () => {
+    const payload = { reportingYear: '2024-04-01' };
     const result = normalizeReportingYearPayload(payload, YEAR_ROWS);
 
-    assert.equal(result.resolvedId, 2);
-    assert.equal(payload.reportingYearId, 2);
-    assert.equal(payload.yearId, 2);
+    assert.equal(result.resolvedId, 3);
+    assert.equal(payload.reportingYearId, 3);
+    assert.equal(payload.yearId, 3);
 });
 
 test('normalizeReportingYearPayload strips unresolved legacy reportingYear strings when configured', () => {
@@ -45,10 +45,10 @@ test('normalizeReportingYearPayload strips unresolved legacy reportingYear strin
     assert.equal(payload.reportingYear, undefined);
 });
 
-test('formatReportingYearLabel returns start year for date-like strings', () => {
-    assert.equal(formatReportingYearLabel('2024-04-01T00:00:00.000Z'), '2024');
+test('formatReportingYearLabel returns ISO date for date-like strings', () => {
+    assert.equal(formatReportingYearLabel('2024-04-01T00:00:00.000Z'), '2024-04-01');
 });
 
-test('formatReportingYearLabel preserves fiscal year strings', () => {
-    assert.equal(formatReportingYearLabel('2024-25'), '2024-25');
+test('formatReportingYearLabel rejects non-date strings in strict mode', () => {
+    assert.equal(formatReportingYearLabel('2024-25'), '');
 });

--- a/backend/tests/responseMapper.test.js
+++ b/backend/tests/responseMapper.test.js
@@ -7,14 +7,14 @@ test('mapCommonRelations maps reportingYear relation object with IDs', () => {
     const mapped = mapCommonRelations(
         {
             reportingYearId: 5,
-            reportingYear: { yearId: 5, yearName: '2024-25' },
+            reportingYear: { yearId: 5, yearName: '2024-04-01T00:00:00.000Z' },
         },
         { includeYear: true }
     );
 
     assert.equal(mapped.reportingYearId, 5);
     assert.equal(mapped.yearId, 5);
-    assert.equal(mapped.reportingYear, '2024-25');
+    assert.equal(mapped.reportingYear, '2024-04-01');
 });
 
 test('mapCommonRelations maps date-like reportingYear strings safely', () => {
@@ -28,5 +28,5 @@ test('mapCommonRelations maps date-like reportingYear strings safely', () => {
 
     assert.equal(mapped.reportingYearId, 7);
     assert.equal(mapped.yearId, 7);
-    assert.equal(mapped.reportingYear, '2024');
+    assert.equal(mapped.reportingYear, '2024-04-01');
 });

--- a/backend/tests/responseMapper.test.js
+++ b/backend/tests/responseMapper.test.js
@@ -1,0 +1,32 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { mapCommonRelations } = require('../utils/responseMapper.js');
+
+test('mapCommonRelations maps reportingYear relation object with IDs', () => {
+    const mapped = mapCommonRelations(
+        {
+            reportingYearId: 5,
+            reportingYear: { yearId: 5, yearName: '2024-25' },
+        },
+        { includeYear: true }
+    );
+
+    assert.equal(mapped.reportingYearId, 5);
+    assert.equal(mapped.yearId, 5);
+    assert.equal(mapped.reportingYear, '2024-25');
+});
+
+test('mapCommonRelations maps date-like reportingYear strings safely', () => {
+    const mapped = mapCommonRelations(
+        {
+            reportingYearId: 7,
+            reportingYear: '2024-04-01T00:00:00.000Z',
+        },
+        { includeYear: true }
+    );
+
+    assert.equal(mapped.reportingYearId, 7);
+    assert.equal(mapped.yearId, 7);
+    assert.equal(mapped.reportingYear, '2024');
+});

--- a/backend/utils/formRepositoryHelpers.js
+++ b/backend/utils/formRepositoryHelpers.js
@@ -163,7 +163,17 @@ function validateOptionalInteger(data, fieldDef) {
         const fieldValue = safeGet(data, fieldName);
         if (fieldValue !== undefined && fieldValue !== null && fieldValue !== '') {
             rawValue = fieldValue;
-            value = sanitizeInteger(fieldValue);
+
+            if (typeof fieldValue === 'string') {
+                const trimmed = fieldValue.trim();
+                if (!/^-?\d+$/.test(trimmed)) {
+                    value = null;
+                    break;
+                }
+                value = parseInt(trimmed, 10);
+            } else {
+                value = sanitizeInteger(fieldValue);
+            }
             break;
         }
     }

--- a/backend/utils/reportingYearUtils.js
+++ b/backend/utils/reportingYearUtils.js
@@ -1,21 +1,52 @@
 const { ValidationError } = require('./errorHandler.js');
 
+const INTEGER_PATTERN = /^\d+$/;
+const STRICT_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}(?:[Tt].*)?$/;
+
 function toDate(input) {
-    if (input instanceof Date) return new Date(input.getTime());
+    if (input instanceof Date) {
+        return Number.isNaN(input.getTime()) ? null : new Date(input.getTime());
+    }
+
     if (typeof input === 'string' || typeof input === 'number') {
         const parsed = new Date(input);
-        if (!Number.isNaN(parsed.getTime())) return parsed;
+        if (!Number.isNaN(parsed.getTime())) {
+            return parsed;
+        }
     }
+
     return null;
+}
+
+function toIsoDate(date) {
+    return date.toISOString().split('T')[0];
 }
 
 function parseReportingYearDate(input) {
     if (input === null || input === undefined || input === '') return null;
-    const date = toDate(input);
-    if (!date) {
+
+    if (input instanceof Date) {
+        if (Number.isNaN(input.getTime())) {
+            throw new ValidationError('Invalid reportingYear date');
+        }
+        return new Date(input.getTime());
+    }
+
+    if (typeof input !== 'string') {
         throw new ValidationError('Invalid reportingYear date');
     }
-    return date;
+
+    const trimmed = input.trim();
+    if (!STRICT_DATE_PATTERN.test(trimmed)) {
+        throw new ValidationError('Invalid reportingYear date');
+    }
+
+    const parsed = new Date(trimmed);
+    if (Number.isNaN(parsed.getTime())) {
+        throw new ValidationError('Invalid reportingYear date');
+    }
+
+    return parsed;
 }
 
 function ensureNotFutureDate(date) {
@@ -35,10 +66,12 @@ function normalizeDateRange({ from, to }) {
         gteDate.setHours(0, 0, 0, 0);
         ensureNotFutureDate(gteDate);
     }
+
     if (lteDate) {
         lteDate.setHours(23, 59, 59, 999);
         ensureNotFutureDate(lteDate);
     }
+
     if (gteDate && lteDate && gteDate.getTime() > lteDate.getTime()) {
         throw new ValidationError('reportingYearFrom cannot be greater than reportingYearTo');
     }
@@ -52,7 +85,177 @@ function normalizeDateRange({ from, to }) {
 function formatReportingYear(value) {
     const date = toDate(value);
     if (!date) return '';
-    return String(date.getUTCFullYear());
+    return toIsoDate(date);
+}
+
+function isPlainObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isPositiveInteger(value) {
+    if (typeof value === 'number') {
+        return Number.isInteger(value) && value > 0;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return INTEGER_PATTERN.test(trimmed) && parseInt(trimmed, 10) > 0;
+    }
+
+    return false;
+}
+
+function parsePositiveInteger(value) {
+    if (!isPositiveInteger(value)) return null;
+    return typeof value === 'number' ? value : parseInt(value.trim(), 10);
+}
+
+function normalizeYearName(value) {
+    if (value === null || value === undefined) return '';
+    return String(value).trim();
+}
+
+function parseStrictDate(value) {
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value;
+    }
+
+    if (typeof value !== 'string') return null;
+
+    const trimmed = value.trim();
+    if (!STRICT_DATE_PATTERN.test(trimmed)) return null;
+
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function resolveReportingYearId(inputValue, yearRows = []) {
+    if (!Array.isArray(yearRows) || yearRows.length === 0) {
+        return null;
+    }
+
+    const numericInput = parsePositiveInteger(inputValue);
+    if (numericInput !== null) {
+        const idMatch = yearRows.find((row) => row && row.yearId === numericInput);
+        if (idMatch) return idMatch.yearId;
+    }
+
+    const parsedInputDate = parseStrictDate(inputValue);
+    if (!parsedInputDate) return null;
+
+    const inputIsoDate = toIsoDate(parsedInputDate).toLowerCase();
+
+    const normalizedRows = yearRows
+        .filter((row) => row && row.yearId !== undefined && row.yearId !== null)
+        .map((row) => {
+            const normalizedName = normalizeYearName(row.yearName);
+            const rowDate = toDate(row.yearName);
+            const rowIsoDate = rowDate ? toIsoDate(rowDate).toLowerCase() : '';
+
+            return {
+                yearId: row.yearId,
+                yearNameLower: normalizedName.toLowerCase(),
+                rowIsoDate,
+            };
+        });
+
+    if (normalizedRows.length === 0) return null;
+
+    const matched = normalizedRows.find(
+        (row) =>
+            row.rowIsoDate === inputIsoDate ||
+            row.yearNameLower === inputIsoDate ||
+            row.yearNameLower.startsWith(`${inputIsoDate}t`) ||
+            row.yearNameLower.startsWith(inputIsoDate)
+    );
+
+    return matched ? matched.yearId : null;
+}
+
+function normalizeReportingYearPayload(payload, yearRows = [], options = {}) {
+    const { stripUnresolvedLegacyFields = false } = options;
+
+    if (!isPlainObject(payload)) {
+        return { changed: false, resolvedId: null };
+    }
+
+    const hasReportingYearField =
+        payload.reportingYearId !== undefined ||
+        payload.yearId !== undefined ||
+        payload.reportingYear !== undefined ||
+        payload.year !== undefined;
+
+    if (!hasReportingYearField) {
+        return { changed: false, resolvedId: null };
+    }
+
+    const rawValue =
+        payload.reportingYearId ??
+        payload.yearId ??
+        payload.reportingYear ??
+        payload.year;
+
+    const resolvedId = resolveReportingYearId(rawValue, yearRows);
+    let changed = false;
+
+    if (resolvedId !== null) {
+        if (payload.reportingYearId !== resolvedId) {
+            payload.reportingYearId = resolvedId;
+            changed = true;
+        }
+
+        if (
+            payload.yearId !== undefined ||
+            payload.reportingYear !== undefined ||
+            payload.year !== undefined
+        ) {
+            if (payload.yearId !== resolvedId) {
+                payload.yearId = resolvedId;
+                changed = true;
+            }
+        }
+    } else if (stripUnresolvedLegacyFields && typeof rawValue === 'string') {
+        const trimmedRaw = rawValue.trim();
+        const isLegacyString = trimmedRaw !== '' && !INTEGER_PATTERN.test(trimmedRaw) && !STRICT_DATE_PATTERN.test(trimmedRaw);
+
+        if (
+            isLegacyString &&
+            payload.reportingYearId === undefined &&
+            payload.yearId === undefined
+        ) {
+            if (Object.prototype.hasOwnProperty.call(payload, 'reportingYear')) {
+                delete payload.reportingYear;
+                changed = true;
+            }
+            if (
+                Object.prototype.hasOwnProperty.call(payload, 'year') &&
+                typeof payload.year === 'string'
+            ) {
+                delete payload.year;
+                changed = true;
+            }
+        }
+    }
+
+    return { changed, resolvedId };
+}
+
+function formatReportingYearLabel(value) {
+    if (value === null || value === undefined || value === '') return '';
+
+    if (isPlainObject(value)) {
+        if (value.yearName !== undefined) {
+            return formatReportingYearLabel(value.yearName);
+        }
+        return '';
+    }
+
+    const date = toDate(value);
+    if (date) {
+        return toIsoDate(date);
+    }
+
+    return '';
 }
 
 module.exports = {
@@ -60,4 +263,7 @@ module.exports = {
     ensureNotFutureDate,
     normalizeDateRange,
     formatReportingYear,
+    resolveReportingYearId,
+    normalizeReportingYearPayload,
+    formatReportingYearLabel,
 };

--- a/backend/utils/reportingYearUtils.js
+++ b/backend/utils/reportingYearUtils.js
@@ -22,6 +22,10 @@ function toIsoDate(date) {
     return date.toISOString().split('T')[0];
 }
 
+function isStrictDateString(value) {
+    return typeof value === 'string' && STRICT_DATE_PATTERN.test(value.trim());
+}
+
 function parseReportingYearDate(input) {
     if (input === null || input === undefined || input === '') return null;
 
@@ -32,16 +36,11 @@ function parseReportingYearDate(input) {
         return new Date(input.getTime());
     }
 
-    if (typeof input !== 'string') {
+    if (typeof input !== 'string' || !isStrictDateString(input)) {
         throw new ValidationError('Invalid reportingYear date');
     }
 
-    const trimmed = input.trim();
-    if (!STRICT_DATE_PATTERN.test(trimmed)) {
-        throw new ValidationError('Invalid reportingYear date');
-    }
-
-    const parsed = new Date(trimmed);
+    const parsed = new Date(input.trim());
     if (Number.isNaN(parsed.getTime())) {
         throw new ValidationError('Invalid reportingYear date');
     }
@@ -120,12 +119,9 @@ function parseStrictDate(value) {
         return Number.isNaN(value.getTime()) ? null : value;
     }
 
-    if (typeof value !== 'string') return null;
+    if (!isStrictDateString(value)) return null;
 
-    const trimmed = value.trim();
-    if (!STRICT_DATE_PATTERN.test(trimmed)) return null;
-
-    const parsed = new Date(trimmed);
+    const parsed = new Date(value.trim());
     return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
@@ -148,25 +144,23 @@ function resolveReportingYearId(inputValue, yearRows = []) {
     const normalizedRows = yearRows
         .filter((row) => row && row.yearId !== undefined && row.yearId !== null)
         .map((row) => {
-            const normalizedName = normalizeYearName(row.yearName);
+            const normalizedName = normalizeYearName(row.yearName).toLowerCase();
             const rowDate = toDate(row.yearName);
             const rowIsoDate = rowDate ? toIsoDate(rowDate).toLowerCase() : '';
 
             return {
                 yearId: row.yearId,
-                yearNameLower: normalizedName.toLowerCase(),
+                normalizedName,
                 rowIsoDate,
             };
         });
 
-    if (normalizedRows.length === 0) return null;
-
     const matched = normalizedRows.find(
         (row) =>
             row.rowIsoDate === inputIsoDate ||
-            row.yearNameLower === inputIsoDate ||
-            row.yearNameLower.startsWith(`${inputIsoDate}t`) ||
-            row.yearNameLower.startsWith(inputIsoDate)
+            row.normalizedName === inputIsoDate ||
+            row.normalizedName.startsWith(`${inputIsoDate}t`) ||
+            row.normalizedName.startsWith(inputIsoDate)
     );
 
     return matched ? matched.yearId : null;
@@ -216,7 +210,10 @@ function normalizeReportingYearPayload(payload, yearRows = [], options = {}) {
         }
     } else if (stripUnresolvedLegacyFields && typeof rawValue === 'string') {
         const trimmedRaw = rawValue.trim();
-        const isLegacyString = trimmedRaw !== '' && !INTEGER_PATTERN.test(trimmedRaw) && !STRICT_DATE_PATTERN.test(trimmedRaw);
+        const isLegacyString =
+            trimmedRaw !== '' &&
+            !INTEGER_PATTERN.test(trimmedRaw) &&
+            !STRICT_DATE_PATTERN.test(trimmedRaw);
 
         if (
             isLegacyString &&
@@ -266,4 +263,5 @@ module.exports = {
     resolveReportingYearId,
     normalizeReportingYearPayload,
     formatReportingYearLabel,
+    isStrictDateString,
 };

--- a/backend/utils/responseMapper.js
+++ b/backend/utils/responseMapper.js
@@ -3,6 +3,7 @@
  * Provides reusable functions for mapping database responses to frontend-friendly formats
  * Removes redundant fields and table labels to optimize response size
  */
+const { formatReportingYearLabel } = require('./reportingYearUtils.js');
 
 /**
  * Extract participant counts from database record with fallback support
@@ -71,11 +72,27 @@ function mapCommonRelations(record, options = {}) {
         mapped.season = record.season.seasonName; // Alias for backward compatibility
     }
     
-    if (includeYear && record.reportingYear) {
-        const reportingDate = record.reportingYear instanceof Date ? record.reportingYear : new Date(record.reportingYear);
-        mapped.reportingYear = Number.isNaN(reportingDate.getTime())
-            ? ''
-            : String(reportingDate.getFullYear());
+    if (includeYear) {
+        const reportingYearId =
+            record.reportingYearId ??
+            record.yearId ??
+            record.reportingYear?.yearId ??
+            null;
+
+        if (reportingYearId !== null && reportingYearId !== undefined) {
+            mapped.reportingYearId = reportingYearId;
+            mapped.yearId = reportingYearId; // Alias
+        }
+
+        const rawReportingYearValue =
+            record.reportingYear && typeof record.reportingYear === 'object' && !(record.reportingYear instanceof Date)
+                ? record.reportingYear.yearName
+                : record.reportingYear;
+
+        const formattedReportingYear = formatReportingYearLabel(rawReportingYearValue);
+        if (formattedReportingYear) {
+            mapped.reportingYear = formattedReportingYear;
+        }
     }
     
     if (includeStaff && record.kvkStaff) {

--- a/frontend/src/utils/dataTransformationUtils.ts
+++ b/frontend/src/utils/dataTransformationUtils.ts
@@ -296,6 +296,54 @@ export function sanitizeEnumFields(
 }
 
 /**
+ * Normalizes reporting year aliases and strips ambiguous legacy year strings
+ * when a canonical year ID is already present.
+ */
+export function normalizeReportingYearFields(data: any): any {
+    if (!data || typeof data !== 'object') return data;
+
+    const normalized = { ...data };
+
+    const hasReportingYearId =
+        normalized.reportingYearId !== undefined &&
+        normalized.reportingYearId !== null &&
+        normalized.reportingYearId !== '';
+
+    const hasYearId =
+        normalized.yearId !== undefined &&
+        normalized.yearId !== null &&
+        normalized.yearId !== '';
+
+    if (!hasReportingYearId && hasYearId) {
+        normalized.reportingYearId = normalized.yearId;
+    }
+
+    if (normalized.reportingYearId !== undefined && normalized.reportingYearId !== null && normalized.reportingYearId !== '') {
+        if (normalized.yearId === undefined || normalized.yearId === null || normalized.yearId === '') {
+            normalized.yearId = normalized.reportingYearId;
+        }
+
+        if (
+            typeof normalized.reportingYear === 'string' &&
+            normalized.reportingYear.trim() !== '' &&
+            !/^\d+$/.test(normalized.reportingYear.trim())
+        ) {
+            delete normalized.reportingYear;
+        }
+
+        if (
+            typeof normalized.year === 'string' &&
+            normalized.year.trim() !== '' &&
+            !/^\d+$/.test(normalized.year.trim())
+        ) {
+            delete normalized.year;
+        }
+    }
+
+    return normalized;
+}
+
+/**
  * Removes category field conditionally
  * Category is a direct field for KVK employees, not a nested object
  */
@@ -376,6 +424,7 @@ export function transformDataForCreate(
     formData: any
 ): any {
     let transformed = removeNestedObjects(formData);
+    transformed = normalizeReportingYearFields(transformed);
     transformed = removeCategoryIfNeeded(entityType, transformed);
     transformed = applyEntityTransformation(entityType, transformed);
     transformed = normalizeLegacyReportingYear(transformed);
@@ -394,6 +443,7 @@ export function transformDataForUpdate(
 ): any {
     let transformed = removeIdField(entityType, idField, formData);
     transformed = removeNestedObjects(transformed);
+    transformed = normalizeReportingYearFields(transformed);
     transformed = removeCategoryIfNeeded(entityType, transformed);
     transformed = applyEntityTransformation(entityType, transformed);
     transformed = normalizeLegacyReportingYear(transformed);

--- a/frontend/src/utils/dataTransformationUtils.ts
+++ b/frontend/src/utils/dataTransformationUtils.ts
@@ -303,6 +303,7 @@ export function normalizeReportingYearFields(data: any): any {
     if (!data || typeof data !== 'object') return data;
 
     const normalized = { ...data };
+    const strictDatePattern = /^\d{4}-\d{2}-\d{2}(?:T.*)?$/;
 
     const hasReportingYearId =
         normalized.reportingYearId !== undefined &&
@@ -336,6 +337,25 @@ export function normalizeReportingYearFields(data: any): any {
             normalized.year.trim() !== '' &&
             !/^\d+$/.test(normalized.year.trim())
         ) {
+            delete normalized.year;
+        }
+    }
+
+    const hasCanonicalYearId =
+        normalized.reportingYearId !== undefined &&
+        normalized.reportingYearId !== null &&
+        normalized.reportingYearId !== '';
+
+    if (normalized.reportingYear !== undefined && typeof normalized.reportingYear === 'string') {
+        const value = normalized.reportingYear.trim();
+        if (value && !strictDatePattern.test(value) && !hasCanonicalYearId) {
+            delete normalized.reportingYear;
+        }
+    }
+
+    if (normalized.year !== undefined && typeof normalized.year === 'string') {
+        const value = normalized.year.trim();
+        if (value && !strictDatePattern.test(value) && !hasCanonicalYearId) {
             delete normalized.year;
         }
     }


### PR DESCRIPTION
## Summary
Fixes `date-persistence-regression` while enforcing **strict date-based** reporting year behavior.

## Root Cause
- Form/reporting-year payloads arrived in mixed shapes during migration.
- Non-date strings could be coerced incorrectly in update paths, causing mismatched `reportingYearId` and broken save/reload behavior.

## Final Behavior (Strict)
- `reportingYear` must be a valid date (`YYYY-MM-DD` or ISO datetime) or a valid `reportingYearId`.
- Legacy fiscal-year strings (for example `2024-25`) are rejected.
- Canonical `reportingYearId`/`yearId` mapping is preserved for seamless persistence.

## Changes
- Added strict reporting-year resolver/formatter in `backend/utils/reportingYearUtils.js`.
- Added form-route middleware validation/normalization in `backend/middleware/reportingYearNormalizer.js`.
- Updated `responseMapper` to emit normalized date labels for reporting year values.
- Kept integer parsing hardened to prevent accidental date-string coercion.
- Updated frontend transform to avoid sending legacy non-date reporting-year strings.
- Added/updated tests for strict date-mode semantics.

## Validation
- `node --test backend/tests/reportingYearUtils.test.js backend/tests/responseMapper.test.js` (pass)

Closes date-persistence-regression


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reporting-year normalization applied to form endpoints and frontend data transformations

* **Improvements**
  * Smarter resolution and consistent formatting of year fields; clearer handling of legacy vs canonical year inputs
  * Stricter validation and parsing for numeric year inputs; safer population/syncing of yearId/reportingYearId

* **Tests**
  * New unit tests covering reporting-year utilities and response mapping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->