### PR TITLE
fix(forms): normalize underscore labels in shared form components

### DIFF
--- a/frontend/src/pages/dashboard/shared/forms/shared/FormComponents.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/shared/FormComponents.tsx
@@ -1,6 +1,14 @@
 import React from 'react'
 import { DatePicker } from '@/components/ui/date-picker'
 
+function formatFormLabel(label: string): string {
+    return String(label || '')
+        .replace(/_/g, ' ')
+        .replace(/\s+/g, ' ')
+        .replace(/\s+\*/g, '*')
+        .trim()
+}
+
 interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
     label: string
     required?: boolean
@@ -8,16 +16,19 @@ interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
     helperText?: string
 }
 
-export const FormInput: React.FC<FormInputProps> = ({ label, required, error, helperText, className = '', ...props }) => (
-    <div className="relative pt-2">
-        <label className="absolute -top-1.5 left-4 px-1 bg-white text-sm font-semibold text-gray-700 z-10">
-            {label} {required && <span className="text-red-500">*</span>}
-        </label>
-        {(() => {
-            const type = props.type
-            const lowerLabel = String(label || '').toLowerCase()
-            const today = new Date()
-            const todayStr = today.toISOString().slice(0, 10) // YYYY-MM-DD
+export const FormInput: React.FC<FormInputProps> = ({ label, required, error, helperText, className = '', ...props }) => {
+    const displayLabel = formatFormLabel(label)
+
+    return (
+        <div className="relative pt-2">
+            <label className="absolute -top-1.5 left-4 px-1 bg-white text-sm font-semibold text-gray-700 z-10">
+                {displayLabel} {required && <span className="text-red-500">*</span>}
+            </label>
+            {(() => {
+                const type = props.type
+                const lowerLabel = displayLabel.toLowerCase()
+                const today = new Date()
+                const todayStr = today.toISOString().slice(0, 10) // YYYY-MM-DD
 
             const stepFromProps = props.step
             const isInteger =
@@ -67,53 +78,54 @@ export const FormInput: React.FC<FormInputProps> = ({ label, required, error, he
             // Ensure 0 is shown instead of empty string by handling it specifically
             const inputValue = (type === 'number' && props.value === 0) ? '0' : (props.value ?? '');
 
-            if (type === 'date') {
-                const dateValue = String(props.value ?? '')
-                const datePlaceholder =
-                    typeof props.placeholder === 'string' && props.placeholder.trim().length > 0
-                        ? props.placeholder
-                        : `Approx. date (e.g. 15-03-${today.getFullYear()})`
+                if (type === 'date') {
+                    const dateValue = String(props.value ?? '')
+                    const datePlaceholder =
+                        typeof props.placeholder === 'string' && props.placeholder.trim().length > 0
+                            ? props.placeholder
+                            : `Approx. date (e.g. 15-03-${today.getFullYear()})`
+                    return (
+                        <DatePicker
+                            value={dateValue}
+                            onChange={(nextValue) => {
+                                originalOnChange?.({
+                                    target: { value: nextValue },
+                                    currentTarget: { value: nextValue },
+                                } as React.ChangeEvent<HTMLInputElement>)
+                            }}
+                            min={typeof props.min === 'string' ? props.min : undefined}
+                            max={typeof computedMax === 'string' ? computedMax : undefined}
+                            disabled={props.disabled}
+                            placeholder={datePlaceholder}
+                            ariaLabel={displayLabel}
+                            className={className}
+                        />
+                    )
+                }
+
                 return (
-                    <DatePicker
-                        value={dateValue}
-                        onChange={(nextValue) => {
-                            originalOnChange?.({
-                                target: { value: nextValue },
-                                currentTarget: { value: nextValue },
-                            } as React.ChangeEvent<HTMLInputElement>)
-                        }}
-                        min={typeof props.min === 'string' ? props.min : undefined}
-                        max={typeof computedMax === 'string' ? computedMax : undefined}
-                        disabled={props.disabled}
-                        placeholder={datePlaceholder}
-                        ariaLabel={label}
-                        className={className}
+                    <input
+                        {...props}
+                        value={inputValue}
+                        required={required}
+                        step={computedStep}
+                        min={computedMin}
+                        max={computedMax}
+                        onChange={handleChange}
+                        inputMode={type === 'number' ? (isInteger ? 'numeric' : 'decimal') : props.inputMode}
+                        className={`w-full px-4 py-3 border border-[#E0E0E0] ${helperText ? 'rounded-t-xl rounded-b-none' : 'rounded-xl'} focus:outline-none focus:ring-2 focus:ring-[#487749]/20 focus:border-[#487749] transition-all text-base placeholder:text-gray-400 ${className}`}
                     />
                 )
-            }
-
-            return (
-                <input
-                    {...props}
-                    value={inputValue}
-                    required={required}
-                    step={computedStep}
-                    min={computedMin}
-                    max={computedMax}
-                    onChange={handleChange}
-                    inputMode={type === 'number' ? (isInteger ? 'numeric' : 'decimal') : props.inputMode}
-                    className={`w-full px-4 py-3 border border-[#E0E0E0] ${helperText ? 'rounded-t-xl rounded-b-none' : 'rounded-xl'} focus:outline-none focus:ring-2 focus:ring-[#487749]/20 focus:border-[#487749] transition-all text-base placeholder:text-gray-400 ${className}`}
-                />
-            )
-        })()}
-        {helperText && (
-            <div className="-mt-1 border border-t-0 border-[#E0E0E0] rounded-b-xl bg-gray-50 px-4 py-2 text-xs text-gray-600">
-                {helperText}
-            </div>
-        )}
-        {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
-    </div>
-)
+            })()}
+            {helperText && (
+                <div className="-mt-1 border border-t-0 border-[#E0E0E0] rounded-b-xl bg-gray-50 px-4 py-2 text-xs text-gray-600">
+                    {helperText}
+                </div>
+            )}
+            {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
+        </div>
+    )
+}
 
 interface FormSelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
     label: string
@@ -123,26 +135,30 @@ interface FormSelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> 
     placeholder?: string
 }
 
-export const FormSelect: React.FC<FormSelectProps> = ({ label, options, required, error, placeholder, className = '', ...props }) => (
-    <div className="relative pt-2">
-        <label className="absolute -top-1.5 left-4 px-1 bg-white text-sm font-semibold text-gray-700 z-10">
-            {label} {required && <span className="text-red-500">*</span>}
-        </label>
-        <select
-            {...props}
-            required={required}
-            className={`w-full px-4 py-3 border border-[#E0E0E0] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#487749]/20 focus:border-[#487749] transition-all bg-white text-base h-[48px] ${className}`}
-        >
-            <option value="">{placeholder || `Select`}</option>
-            {options.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                </option>
-            ))}
-        </select>
-        {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
-    </div>
-)
+export const FormSelect: React.FC<FormSelectProps> = ({ label, options, required, error, placeholder, className = '', ...props }) => {
+    const displayLabel = formatFormLabel(label)
+
+    return (
+        <div className="relative pt-2">
+            <label className="absolute -top-1.5 left-4 px-1 bg-white text-sm font-semibold text-gray-700 z-10">
+                {displayLabel} {required && <span className="text-red-500">*</span>}
+            </label>
+            <select
+                {...props}
+                required={required}
+                className={`w-full px-4 py-3 border border-[#E0E0E0] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#487749]/20 focus:border-[#487749] transition-all bg-white text-base h-[48px] ${className}`}
+            >
+                <option value="">{placeholder || `Select`}</option>
+                {options.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                    </option>
+                ))}
+            </select>
+            {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
+        </div>
+    )
+}
 
 interface FormSectionProps {
     title: string
@@ -172,16 +188,20 @@ interface FormTextAreaProps extends React.TextareaHTMLAttributes<HTMLTextAreaEle
     error?: string
 }
 
-export const FormTextArea: React.FC<FormTextAreaProps> = ({ label, required, error, className = '', ...props }) => (
-    <div className="relative pt-2">
-        <label className="absolute -top-1.5 left-4 px-1 bg-white text-sm font-semibold text-gray-700 z-10">
-            {label} {required && <span className="text-red-500">*</span>}
-        </label>
-        <textarea
-            {...props}
-            required={required}
-            className={`w-full px-4 py-3 border border-[#E0E0E0] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#487749]/20 focus:border-[#487749] transition-all resize-none text-base placeholder:text-gray-400 ${className}`}
-        />
-        {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
-    </div>
-)
+export const FormTextArea: React.FC<FormTextAreaProps> = ({ label, required, error, className = '', ...props }) => {
+    const displayLabel = formatFormLabel(label)
+
+    return (
+        <div className="relative pt-2">
+            <label className="absolute -top-1.5 left-4 px-1 bg-white text-sm font-semibold text-gray-700 z-10">
+                {displayLabel} {required && <span className="text-red-500">*</span>}
+            </label>
+            <textarea
+                {...props}
+                required={required}
+                className={`w-full px-4 py-3 border border-[#E0E0E0] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#487749]/20 focus:border-[#487749] transition-all resize-none text-base placeholder:text-gray-400 ${className}`}
+            />
+            {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
- format shared form labels by replacing underscores with spaces
- apply formatting in FormInput, FormSelect, and FormTextArea
- keep field keys unchanged; this is display-only

## Examples
- General_M -> General M
- OBC_F -> OBC F
- SC_M -> SC M
- ST_F -> ST F

## Notes
- Branch is based on origin/dev
- This avoids per-form edits and applies across all forms using shared components