### PR TITLE
fix(forms): normalize reporting-year persistence across project modules

### DIFF
--- a/backend/repositories/forms/agriDroneDemonstrationRepository.js
+++ b/backend/repositories/forms/agriDroneDemonstrationRepository.js
@@ -178,7 +178,7 @@ const agriDroneDemonstrationRepository = {
             // Link back to intro
             agriDroneId: r.agriDroneId,
             projectImplementingCentre: r.agriDrone?.projectImplementingCentre,
-            reportingYear: r.reportingYear,
+            reportingYear: formatReportingYear(r.reportingYear),
             yearName: formatReportingYear(r.reportingYear),
             districtId: r.districtId,
             district: r.district?.districtName,

--- a/backend/repositories/forms/agriDroneRepository.js
+++ b/backend/repositories/forms/agriDroneRepository.js
@@ -179,7 +179,7 @@ const agriDroneRepository = {
         return {
             ...r,
             id: r.agriDroneId,
-            reportingYear: r.reportingYear,
+            reportingYear: formatReportingYear(r.reportingYear),
             yearName: formatReportingYear(r.reportingYear),
             projectImplementingCentre: r.projectImplementingCentre,
             droneCompany: r.droneCompany,

--- a/backend/repositories/forms/celebrationDayRepository.js
+++ b/backend/repositories/forms/celebrationDayRepository.js
@@ -190,7 +190,7 @@ const celebrationDayRepository = {
         const eventDate = new Date(a.eventDate);
         const month = eventDate.getMonth() + 1;
         const startYear = month >= 4 ? eventDate.getFullYear() : eventDate.getFullYear() - 1;
-        const reportingYear = String(startYear);
+        const reportingYear = `${startYear}-04-01`;
 
         // Handle both camelCase and snake_case field names from Prisma
         const farmersGeneralM = a.farmersGeneralM ?? a.farmers_general_m ?? 0;

--- a/backend/repositories/forms/cfldBudgetUtilizationRepository.js
+++ b/backend/repositories/forms/cfldBudgetUtilizationRepository.js
@@ -1,7 +1,17 @@
 const prisma = require('../../config/prisma.js');
 const { removeIdFieldsForUpdate } = require('../../utils/dataSanitizer.js');
-const { formatReportingYear } = require('../../utils/reportingYearUtils.js');
 const { mapCommonRelations } = require('../../utils/responseMapper.js');
+
+const parseYearFromInput = (value, fallback = null) => {
+    if (value === undefined || value === null || value === '') return fallback;
+    const parsed = parseInt(String(value).trim(), 10);
+    return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+const formatYearAsDate = (yearValue) => {
+    const year = parseYearFromInput(yearValue, null);
+    return year === null ? '' : `${year}-01-01`;
+};
 
 const cfldBudgetUtilizationRepository = {
     create: async (data, opts, user) => {
@@ -67,11 +77,7 @@ const cfldBudgetUtilizationRepository = {
         ].filter(item => item.id !== null);
 
         const rawYear = data.reportingYear || data.year;
-        let numericYear = new Date().getFullYear();
-        if (rawYear) {
-            const parsed = parseInt(String(rawYear).split('-')[0]);
-            numericYear = isNaN(parsed) ? new Date().getFullYear() : parsed;
-        }
+        const numericYear = parseYearFromInput(rawYear, new Date().getFullYear());
 
         const insertResult = await prisma.$queryRawUnsafe(`
             INSERT INTO kvk_budget_utilization (
@@ -154,8 +160,8 @@ const cfldBudgetUtilizationRepository = {
         const updateData = {};
         const rawYear = data.reportingYear || data.year;
         if (rawYear !== undefined) {
-            const parsed = parseInt(String(rawYear).split('-')[0]);
-            if (!isNaN(parsed)) updateData.year = parsed;
+            const parsed = parseYearFromInput(rawYear, null);
+            if (parsed !== null) updateData.year = parsed;
         }
         if (data.seasonId) updateData.seasonId = parseInt(data.seasonId);
 
@@ -259,7 +265,7 @@ function _mapResponse(r) {
         kvkId: r.kvkId,
         ...relations,
         year: r.year,
-        reportingYear: formatReportingYear(r.reportingYear),
+        reportingYear: formatYearAsDate(r.year),
         overallFundAllocation: r.overallFundAllocation,
         areaAllotted: r.areaAllotted,
         areaAchieved: r.areaAchieved,

--- a/backend/repositories/forms/craDetailsRepository.js
+++ b/backend/repositories/forms/craDetailsRepository.js
@@ -156,7 +156,7 @@ function _mapResponse(r) {
     return {
         id: r.craDetailsId,
         kvkName: r.kvk ? r.kvk.kvkName : '',
-        reportingYear: r.reportingYear,
+        reportingYear: formatReportingYear(r.reportingYear),
         yearName: formatReportingYear(r.reportingYear),
         seasonId: r.seasonId,
         season: r.season ? r.season.seasonName : '',

--- a/backend/repositories/forms/extensionActivityRepository.js
+++ b/backend/repositories/forms/extensionActivityRepository.js
@@ -600,7 +600,7 @@ function _mapResponse(r) {
     if (startDate && !isNaN(startDate.getTime())) {
         const month = startDate.getMonth() + 1;
         const startYear = month >= 4 ? startDate.getFullYear() : startDate.getFullYear() - 1;
-        reportingYear = String(startYear);
+        reportingYear = `${startYear}-04-01`;
     }
 
     const activityName = r.fldActivity ? r.fldActivity.activityName : undefined;

--- a/backend/repositories/forms/nariBioFortifiedCropRepository.js
+++ b/backend/repositories/forms/nariBioFortifiedCropRepository.js
@@ -148,7 +148,7 @@ function _mapResponse(r) {
         id: r.nariBioFortifiedCropId,
         kvkId: r.kvkId,
         kvkName: r.kvk?.kvkName,
-        reportingYear: r.reportingYear,
+        reportingYear: formatReportingYear(r.reportingYear),
         yearName: formatReportingYear(r.reportingYear),
         seasonId: r.seasonId,
         seasonName: r.season?.seasonName,

--- a/backend/repositories/forms/nariExtensionActivityRepository.js
+++ b/backend/repositories/forms/nariExtensionActivityRepository.js
@@ -134,7 +134,7 @@ function _mapResponse(r) {
         id: r.nariExtensionActivityId,
         kvkId: r.kvkId,
         kvkName: r.kvk?.kvkName,
-        reportingYear: r.reportingYear,
+        reportingYear: formatReportingYear(r.reportingYear),
         yearName: formatReportingYear(r.reportingYear),
         activityId: r.activityId,
         activityName: r.activity?.activityName,

--- a/backend/repositories/forms/nariNutritionalGardenRepository.js
+++ b/backend/repositories/forms/nariNutritionalGardenRepository.js
@@ -140,7 +140,7 @@ function _mapResponse(r) {
         id: r.nariNutritionalGardenId,
         kvkId: r.kvkId,
         kvkName: r.kvk?.kvkName,
-        reportingYear: r.reportingYear,
+        reportingYear: formatReportingYear(r.reportingYear),
         yearName: formatReportingYear(r.reportingYear),
         activityId: r.activityId,
         activityName: r.activity?.activityName,

--- a/backend/repositories/forms/nariTrainingProgrammeRepository.js
+++ b/backend/repositories/forms/nariTrainingProgrammeRepository.js
@@ -153,7 +153,7 @@ function _mapResponse(r) {
         id: r.nariTrainingProgrammeId,
         kvkId: r.kvkId,
         kvkName: r.kvk?.kvkName,
-        reportingYear: r.reportingYear,
+        reportingYear: formatReportingYear(r.reportingYear),
         yearName: formatReportingYear(r.reportingYear),
         activityId: r.activityId,
         activityName: r.activity?.activityName,

--- a/backend/repositories/forms/nariTrainingRepository.js
+++ b/backend/repositories/forms/nariTrainingRepository.js
@@ -142,7 +142,7 @@ function _mapResponse(r) {
         id: r.nariTrainingProgrammeId,
         kvkId: r.kvkId,
         kvkName: r.kvk?.kvkName,
-        reportingYear: r.reportingYear,
+        reportingYear: formatReportingYear(r.reportingYear),
         yearName: formatReportingYear(r.reportingYear),
         activityId: r.activityId,
         activityName: r.activity?.activityName,

--- a/backend/repositories/forms/nariValueAdditionRepository.js
+++ b/backend/repositories/forms/nariValueAdditionRepository.js
@@ -134,7 +134,7 @@ function _mapResponse(r) {
         id: r.nariValueAdditionId,
         kvkId: r.kvkId,
         kvkName: r.kvk?.kvkName,
-        reportingYear: r.reportingYear,
+        reportingYear: formatReportingYear(r.reportingYear),
         yearName: formatReportingYear(r.reportingYear),
         activityId: r.activityId,
         activityName: r.activity?.activityName,

--- a/backend/repositories/forms/naturalFarmingRepository.js
+++ b/backend/repositories/forms/naturalFarmingRepository.js
@@ -13,6 +13,15 @@ function getKvkId(user, data) {
 
 const safeFloat = (val, d = 0) => { const n = parseFloat(val); return isNaN(n) ? d : n; };
 const safeInt = (val, d = 0) => { const n = parseInt(val, 10); return isNaN(n) ? d : n; };
+const parseYearFromInput = (val, d = null) => {
+    if (val === undefined || val === null || val === '') return d;
+    const n = parseInt(String(val).trim(), 10);
+    return Number.isNaN(n) ? d : n;
+};
+const formatYearAsDate = (val) => {
+    const n = parseYearFromInput(val, null);
+    return n === null ? '' : `${n}-01-01`;
+};
 const isOtherActivityName = (value) => String(value || '').trim().toLowerCase() === 'other activity';
 
 async function resolveNaturalFarmingActivity(rawValue) {
@@ -756,7 +765,7 @@ const beneficiariesRepository = {
         return await prisma.beneficiariesDetails.create({
             data: {
                 kvkId,
-                year: safeInt(data.reportingYear || data.year || new Date().getFullYear()),
+                year: parseYearFromInput(data.reportingYear ?? data.year, new Date().getFullYear()),
                 blocksCovered: safeInt(data.noOfBlocks || data.blocksCovered, 0),
                 villagesCovered: safeInt(data.noOfVillages || data.villagesCovered, 0),
                 totalTrainedFarmers: safeInt(data.totalTrainedFarmers, 0),
@@ -783,7 +792,7 @@ const beneficiariesRepository = {
             kvkName: r.kvk?.kvkName,
             noOfBlocks: r.blocksCovered,
             noOfVillages: r.villagesCovered,
-            reportingYear: String(r.year),
+            reportingYear: formatYearAsDate(r.year),
         }));
     },
     findById: async (id, user) => {
@@ -797,7 +806,7 @@ const beneficiariesRepository = {
             kvkName: r.kvk?.kvkName,
             noOfBlocks: r.blocksCovered,
             noOfVillages: r.villagesCovered,
-            reportingYear: String(r.year),
+            reportingYear: formatYearAsDate(r.year),
         };
     },
     update: async (id, data, user) => {
@@ -808,7 +817,9 @@ const beneficiariesRepository = {
         return await prisma.beneficiariesDetails.update({
             where: { beneficiariesDetailsId: parseInt(id) },
             data: {
-                year: (data.reportingYear || data.year) !== undefined ? parseInt(data.reportingYear || data.year || 0) : existing.year,
+                year: (data.reportingYear !== undefined || data.year !== undefined)
+                    ? parseYearFromInput(data.reportingYear ?? data.year, existing.year)
+                    : existing.year,
                 blocksCovered: (data.noOfBlocks || data.blocksCovered) !== undefined ? parseInt(data.noOfBlocks || data.blocksCovered || 0) : existing.blocksCovered,
                 villagesCovered: (data.noOfVillages || data.villagesCovered) !== undefined ? parseInt(data.noOfVillages || data.villagesCovered || 0) : existing.villagesCovered,
                 totalTrainedFarmers: data.totalTrainedFarmers !== undefined ? parseInt(data.totalTrainedFarmers || 0) : existing.totalTrainedFarmers,
@@ -836,7 +847,7 @@ const soilDataRepository = {
         return await prisma.soilDataInformation.create({
             data: {
                 kvkId,
-                year: safeInt(data.reportingYear || data.year || new Date().getFullYear()),
+                year: parseYearFromInput(data.reportingYear ?? data.year, new Date().getFullYear()),
                 crop: data.crop || '',
                 seasonId: data.seasonId ? safeInt(data.seasonId, null) : null,
                 soilParameterId,
@@ -877,7 +888,7 @@ const soilDataRepository = {
             kvkName: r.kvk?.kvkName,
             season: r.season?.seasonName,
             seasonId: r.seasonId,
-            reportingYear: String(r.year),
+            reportingYear: formatYearAsDate(r.year),
             type: r.soilParameterMaster?.parameterName || null,
             soilParameter: r.soilParameterMaster?.parameterName || null,
             soilParameterId: r.soilParameterId,
@@ -917,7 +928,7 @@ const soilDataRepository = {
             kvkName: r.kvk?.kvkName,
             season: r.season?.seasonName,
             seasonId: r.seasonId,
-            reportingYear: String(r.year),
+            reportingYear: formatYearAsDate(r.year),
             type: r.soilParameterMaster?.parameterName || null,
             soilParameter: r.soilParameterMaster?.parameterName || null,
             soilParameterId: r.soilParameterId,
@@ -949,7 +960,9 @@ const soilDataRepository = {
         return await prisma.soilDataInformation.update({
             where: { soilDataInformationId: parseInt(id) },
             data: {
-                year: (data.reportingYear || data.year) !== undefined ? safeInt(data.reportingYear || data.year, existing.year) : existing.year,
+                year: (data.reportingYear !== undefined || data.year !== undefined)
+                    ? parseYearFromInput(data.reportingYear ?? data.year, existing.year)
+                    : existing.year,
                 crop: data.crop !== undefined ? data.crop : existing.crop,
                 seasonId: data.seasonId !== undefined ? (data.seasonId ? safeInt(data.seasonId, null) : null) : existing.seasonId,
                 soilParameterId: resolvedSoilParameterId,
@@ -987,7 +1000,7 @@ const financialInfoRepository = {
         return await prisma.financialInformation.create({
             data: {
                 kvkId,
-                year: safeInt(data.reportingYear || data.year || new Date().getFullYear()),
+                year: parseYearFromInput(data.reportingYear ?? data.year, new Date().getFullYear()),
                 activityId: resolvedActivity?.naturalFarmingActivityId || null,
                 numberOfActivities: safeInt(data.noOfActivities || data.numberOfActivities, 0),
                 budgetSanction: safeFloat(data.budgetSanction, 0),
@@ -1017,6 +1030,7 @@ const financialInfoRepository = {
             noOfActivities: r.numberOfActivities,
             activityName: r.activityMaster?.activityName || null,
             activityId: r.activityId,
+            reportingYear: formatYearAsDate(r.year),
         }));
     },
     findById: async (id, user) => {
@@ -1038,7 +1052,7 @@ const financialInfoRepository = {
             noOfActivities: r.numberOfActivities,
             activityName: r.activityMaster?.activityName || null,
             activityId: r.activityId,
-            reportingYear: String(r.year),
+            reportingYear: formatYearAsDate(r.year),
         };
     },
     update: async (id, data, user) => {
@@ -1052,7 +1066,9 @@ const financialInfoRepository = {
         return await prisma.financialInformation.update({
             where: { financialInformationId: parseInt(id) },
             data: {
-                year: (data.reportingYear || data.year) !== undefined ? safeInt(data.reportingYear || data.year, existing.year) : existing.year,
+                year: (data.reportingYear !== undefined || data.year !== undefined)
+                    ? parseYearFromInput(data.reportingYear ?? data.year, existing.year)
+                    : existing.year,
                 activityId: resolvedActivity ? resolvedActivity.naturalFarmingActivityId : existing.activityId,
                 numberOfActivities: (data.noOfActivities || data.numberOfActivities) !== undefined ? safeInt(data.noOfActivities || data.numberOfActivities, existing.numberOfActivities) : existing.numberOfActivities,
                 budgetSanction: data.budgetSanction !== undefined ? safeFloat(data.budgetSanction, existing.budgetSanction) : existing.budgetSanction,

--- a/backend/repositories/forms/otherExtensionActivityRepository.js
+++ b/backend/repositories/forms/otherExtensionActivityRepository.js
@@ -336,7 +336,7 @@ function _mapResponse(r) {
     if (startDate && !isNaN(startDate.getTime())) {
         const month = startDate.getMonth() + 1;
         const startYear = month >= 4 ? startDate.getFullYear() : startDate.getFullYear() - 1;
-        reportingYear = String(startYear);
+        reportingYear = `${startYear}-04-01`;
     }
 
     const activityName = r.otherExtensionActivity ? r.otherExtensionActivity.otherExtensionName : undefined;

--- a/backend/repositories/forms/ppvFraPlantVarietiesRepository.js
+++ b/backend/repositories/forms/ppvFraPlantVarietiesRepository.js
@@ -1,5 +1,25 @@
 const prisma = require('../../config/prisma.js');
 
+const parseYearFromInput = (value, fallback = null) => {
+    if (value === undefined || value === null || value === '') return fallback;
+    const parsed = parseInt(String(value).trim(), 10);
+    return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+const formatYearAsDate = (value) => {
+    const year = parseYearFromInput(value, null);
+    return year === null ? '' : `${year}-01-01`;
+};
+
+const mapPlantVarietyRecord = (record) => {
+    if (!record) return null;
+    return {
+        ...record,
+        reportingYear: formatYearAsDate(record.reportingYear),
+        year: record.reportingYear,
+    };
+};
+
 const ppvFraPlantVarietiesRepository = {
     create: async (data, user) => {
         const kvkId = (user && user.kvkId) ? parseInt(user.kvkId) : (data.kvkId ? parseInt(data.kvkId) : null);
@@ -8,7 +28,7 @@ const ppvFraPlantVarietiesRepository = {
         return await prisma.ppvFraPlantVarieties.create({
             data: {
                 kvkId,
-                reportingYear: parseInt(data.reportingYear || new Date().getFullYear()),
+                reportingYear: parseYearFromInput(data.reportingYear ?? data.year, new Date().getFullYear()),
                 cropName: data.cropName || '',
                 farmerName: data.farmerName || '',
                 mobile: data.mobile || '',
@@ -28,7 +48,7 @@ const ppvFraPlantVarietiesRepository = {
         } else if (filters.kvkId) {
             where.kvkId = parseInt(filters.kvkId);
         }
-        return await prisma.ppvFraPlantVarieties.findMany({
+        const records = await prisma.ppvFraPlantVarieties.findMany({
             where,
             include: {
                 kvk: {
@@ -40,12 +60,13 @@ const ppvFraPlantVarietiesRepository = {
             },
             orderBy: { ppvFraPlantVarietiesID: 'desc' }
         });
+        return records.map(mapPlantVarietyRecord);
     },
 
     findById: async (id, user) => {
         const where = { ppvFraPlantVarietiesID: parseInt(id) };
         if (user && user.kvkId) where.kvkId = parseInt(user.kvkId);
-        return await prisma.ppvFraPlantVarieties.findFirst({
+        const record = await prisma.ppvFraPlantVarieties.findFirst({
             where,
             include: {
                 kvk: {
@@ -56,6 +77,7 @@ const ppvFraPlantVarietiesRepository = {
                 }
             }
         });
+        return mapPlantVarietyRecord(record);
     },
 
     update: async (id, data, user) => {
@@ -66,7 +88,9 @@ const ppvFraPlantVarietiesRepository = {
         return await prisma.ppvFraPlantVarieties.update({
             where: { ppvFraPlantVarietiesID: parseInt(id) },
             data: {
-                reportingYear: data.reportingYear !== undefined ? parseInt(data.reportingYear) : existing.reportingYear,
+                reportingYear: (data.reportingYear !== undefined || data.year !== undefined)
+                    ? parseYearFromInput(data.reportingYear ?? data.year, existing.reportingYear)
+                    : existing.reportingYear,
                 cropName: data.cropName !== undefined ? data.cropName : existing.cropName,
                 farmerName: data.farmerName !== undefined ? data.farmerName : existing.farmerName,
                 mobile: data.mobile !== undefined ? data.mobile : existing.mobile,

--- a/backend/repositories/forms/techWeekRepository.js
+++ b/backend/repositories/forms/techWeekRepository.js
@@ -154,7 +154,7 @@ const techWeekRepository = {
         const startDate = new Date(a.startDate);
         const month = startDate.getMonth() + 1;
         const startYear = month >= 4 ? startDate.getFullYear() : startDate.getFullYear() - 1;
-        const reportingYear = String(startYear);
+        const reportingYear = `${startYear}-04-01`;
 
         const farmersGeneralM = a.farmersGeneralM ?? a.farmers_general_m ?? 0;
         const farmersGeneralF = a.farmersGeneralF ?? a.farmers_general_f ?? 0;

--- a/backend/repositories/forms/trainingRepository.js
+++ b/backend/repositories/forms/trainingRepository.js
@@ -84,7 +84,7 @@ const _mapResponse = async (r) => {
     if (startDate && !isNaN(startDate.getTime())) {
         const month = startDate.getMonth() + 1;
         const startYear = month >= 4 ? startDate.getFullYear() : startDate.getFullYear() - 1;
-        reportingYear = String(startYear);
+        reportingYear = `${startYear}-04-01`;
     }
 
     // Calculate total participants

--- a/backend/repositories/forms/tspScspRepository.js
+++ b/backend/repositories/forms/tspScspRepository.js
@@ -275,7 +275,7 @@ function _mapResponse(r) {
         id: r.tspScspId,
         kvkId: r.kvkId,
         kvkName: r.kvk?.kvkName,
-        reportingYear: r.reportingYear,
+        reportingYear: formatReportingYear(r.reportingYear),
         yearName: formatReportingYear(r.reportingYear),
         type: r.type,
         typeName: r.tspScspType?.typeName ?? r.type,

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -481,7 +481,11 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                 setIsFldResultPageOpen(false)
                 setSelectedFldId(null)
             }
-            openForm(item)
+            handleEditItem({
+                item,
+                entityType,
+                onOpenForm: openForm,
+            })
         }
 
         const goAdd = () => {

--- a/frontend/src/utils/dataTransformationUtils.ts
+++ b/frontend/src/utils/dataTransformationUtils.ts
@@ -257,9 +257,24 @@ export function normalizeLegacyReportingYear(data: any): any {
         normalized.year;
 
     if (legacyYear !== undefined && legacyYear !== null && legacyYear !== '') {
+        if (legacyYear instanceof Date && !Number.isNaN(legacyYear.getTime())) {
+            normalized.reportingYear = legacyYear.toISOString().split('T')[0];
+            delete normalized.year;
+            return normalized;
+        }
+
         const asString = String(legacyYear).trim();
         const yearMatch = asString.match(/^\d{4}$/);
-        normalized.reportingYear = yearMatch ? `${asString}-01-01` : asString;
+        if (yearMatch) {
+            normalized.reportingYear = `${asString}-01-01`;
+        } else if (/^\d{4}-\d{2}-\d{2}/.test(asString)) {
+            normalized.reportingYear = asString.slice(0, 10);
+        } else {
+            const parsed = new Date(asString);
+            normalized.reportingYear = Number.isNaN(parsed.getTime())
+                ? asString
+                : parsed.toISOString().split('T')[0];
+        }
     }
 
     delete normalized.year;

--- a/frontend/src/utils/formDataExtractors.ts
+++ b/frontend/src/utils/formDataExtractors.ts
@@ -6,6 +6,64 @@
 import { ENTITY_TYPES } from '@/constants/entityConstants';
 import type { ExtendedEntityType } from './masterUtils';
 
+function toDateInputValue(value: unknown): unknown {
+    if (value === null || value === undefined || value === '') return value;
+
+    if (value instanceof Date) {
+        if (Number.isNaN(value.getTime())) return '';
+        return value.toISOString().split('T')[0];
+    }
+
+    if (typeof value === 'object' && value !== null) {
+        const candidate =
+            (value as any).yearName ??
+            (value as any).reportingYear ??
+            (value as any).year ??
+            (value as any).value;
+        if (candidate !== undefined && candidate !== null && candidate !== value) {
+            return toDateInputValue(candidate);
+        }
+        return value;
+    }
+
+    const asString = String(value).trim();
+    if (!asString) return '';
+
+    if (/^\d{4}$/.test(asString)) {
+        return `${asString}-01-01`;
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}/.test(asString)) {
+        return asString.slice(0, 10);
+    }
+
+    const parsed = new Date(asString);
+    if (!Number.isNaN(parsed.getTime())) {
+        return parsed.toISOString().split('T')[0];
+    }
+
+    return value;
+}
+
+function normalizeCommonDateFields(item: any, formData: any): void {
+    const reportingYearSource =
+        formData.reportingYear ??
+        item.reportingYear ??
+        item.yearName ??
+        item.year;
+
+    if (reportingYearSource !== undefined && reportingYearSource !== null && reportingYearSource !== '') {
+        formData.reportingYear = toDateInputValue(reportingYearSource);
+    }
+
+    Object.keys(formData).forEach((field) => {
+        if (field === 'reportingYear') return;
+        if (!field.toLowerCase().endsWith('date')) return;
+        if (formData[field] === undefined || formData[field] === null || formData[field] === '') return;
+        formData[field] = toDateInputValue(formData[field]);
+    });
+}
+
 /**
  * Common nested field extractors that apply to multiple entity types
  */
@@ -396,6 +454,10 @@ export function extractFormData(item: any, entityType?: ExtendedEntityType | nul
     if (entityType && ENTITY_EXTRACTORS[entityType]) {
         ENTITY_EXTRACTORS[entityType](item, formData);
     }
+
+    // Normalize common date-like fields for entities without dedicated extractors.
+    // This keeps HTML date inputs stable in edit mode across modules.
+    normalizeCommonDateFields(item, formData);
 
     return formData;
 }


### PR DESCRIPTION
## Summary\n- normalize reportingYear mapping for achievement modules to a canonical date-like format\n- add safe year parsing/formatting adapters for year-int backed modules\n- keep API responses consistent so frontend date handling persists correctly\n\n## Scope\n- trainingRepository\n- extensionActivityRepository\n- otherExtensionActivityRepository\n- techWeekRepository\n- celebrationDayRepository\n- naturalFarmingRepository\n- cfldBudgetUtilizationRepository\n- ppvFraPlantVarietiesRepository\n\nRefs #74