### PR TITLE
[PR1] feat(reporting-year): schema expansion + backfill for year-int modules

### DIFF
--- a/backend/prisma/kvk/achievements/projects/cfld/budget_utilization_schema.prisma
+++ b/backend/prisma/kvk/achievements/projects/cfld/budget_utilization_schema.prisma
@@ -12,6 +12,7 @@ model KvkBudgetUtilization {
   budgetId              Int                        @id @default(autoincrement()) @map("budget_id")
   kvkId                 Int
   year                  Int                        @map("year")
+  reportingYearDate     DateTime?                  @map("reporting_year_date")
   seasonId              Int?
   cropId                Int?
   overallFundAllocation Float                      @map("overall_crop_wise_fund_allocation")
@@ -26,6 +27,8 @@ model KvkBudgetUtilization {
 
   @@index([kvkId])
   @@index([year])
+  @@index([reportingYearDate])
+  @@index([kvkId, reportingYearDate])
   @@index([seasonId])
   @@index([cropId])
   @@map("kvk_budget_utilization")

--- a/backend/prisma/kvk/achievements/projects/natural_farming/beneficiary_details_schema.prisma
+++ b/backend/prisma/kvk/achievements/projects/natural_farming/beneficiary_details_schema.prisma
@@ -2,6 +2,7 @@ model BeneficiariesDetails {
   beneficiariesDetailsId  Int    @id @default(autoincrement()) @map("beneficiaries_details_id")
   kvkId                   Int
   year                    Int
+  reportingYearDate       DateTime? @map("reporting_year_date")
   blocksCovered           Int    @map("blocks_covered")
   villagesCovered         Int    @map("villages_covered")
   totalTrainedFarmers     Int    @map("total_trained_practicing_nf_farmers")
@@ -12,5 +13,7 @@ model BeneficiariesDetails {
   kvk                     Kvk    @relation(fields: [kvkId], references: [kvkId], onDelete: Cascade)
 
   @@index([kvkId])
+  @@index([reportingYearDate])
+  @@index([kvkId, reportingYearDate])
   @@map("beneficiaries_details")
 }

--- a/backend/prisma/kvk/achievements/projects/natural_farming/financial_info_schema.prisma
+++ b/backend/prisma/kvk/achievements/projects/natural_farming/financial_info_schema.prisma
@@ -2,6 +2,7 @@ model FinancialInformation {
   financialInformationId Int                    @id @default(autoincrement()) @map("financial_information_id")
   kvkId                  Int
   year                   Int
+  reportingYearDate      DateTime?              @map("reporting_year_date")
   activityId             Int?                   @map("activity_id")
   numberOfActivities     Int                    @map("number_of_activities")
   budgetSanction         Float                  @map("budget_sanction")
@@ -11,5 +12,7 @@ model FinancialInformation {
   activityMaster         NaturalFarmingActivityMaster? @relation(fields: [activityId], references: [naturalFarmingActivityId], onDelete: SetNull, onUpdate: Cascade)
 
   @@index([kvkId])
+  @@index([reportingYearDate])
+  @@index([kvkId, reportingYearDate])
   @@map("financial_information")
 }

--- a/backend/prisma/kvk/achievements/projects/natural_farming/soil_data_info_schema.prisma
+++ b/backend/prisma/kvk/achievements/projects/natural_farming/soil_data_info_schema.prisma
@@ -2,6 +2,7 @@ model SoilDataInformation {
   soilDataInformationId Int               @id @default(autoincrement()) @map("soil_data_information_id")
   kvkId                 Int
   year                  Int
+  reportingYearDate     DateTime?         @map("reporting_year_date")
   crop                  String
   seasonId              Int?
   soilParameterId       Int?              @map("soil_parameter_id")
@@ -24,6 +25,8 @@ model SoilDataInformation {
   soilParameterMaster   NaturalFarmingSoilParameterMaster? @relation(fields: [soilParameterId], references: [naturalFarmingSoilParameterId], onDelete: SetNull, onUpdate: Cascade)
 
   @@index([kvkId])
+  @@index([reportingYearDate])
+  @@index([kvkId, reportingYearDate])
   @@map("soil_data_information")
 }
 

--- a/backend/prisma/kvk/misc/ppv_fra/plant_varieties_schema.prisma
+++ b/backend/prisma/kvk/misc/ppv_fra/plant_varieties_schema.prisma
@@ -5,6 +5,7 @@ model PpvFraPlantVarieties {
   kvk   Kvk @relation(fields: [kvkId], references: [kvkId], onDelete: Cascade)
 
   reportingYear   Int     @map("reporting_year")
+  reportingYearDate DateTime? @map("reporting_year_date")
   cropName        String  @map("crop_name")
   farmerName      String  @map("farmer_name")
   mobile          String  @map("mobile")
@@ -15,5 +16,7 @@ model PpvFraPlantVarieties {
   image           String? @map("image")
 
   @@index([kvkId])
+  @@index([reportingYearDate])
+  @@index([kvkId, reportingYearDate])
   @@map("ppv_fra_plant_varieties")
 }

--- a/backend/prisma/kvk/module-images/module_image_schema.prisma
+++ b/backend/prisma/kvk/module-images/module_image_schema.prisma
@@ -9,6 +9,7 @@ model ModuleImage {
   caption           String?
   imageDate         DateTime  @map("image_date")
   reportingYear     Int       @map("reporting_year")
+  reportingYearDate DateTime? @map("reporting_year_date")
   imageData         Bytes     @map("image_data")
   mimeType          String    @map("mime_type")
   fileName          String?   @map("file_name")
@@ -20,7 +21,9 @@ model ModuleImage {
   uploadedBy        User?     @relation(fields: [uploadedByUserId], references: [userId], onDelete: SetNull)
 
   @@index([kvkId, imageDate])
+  @@index([kvkId, reportingYearDate])
   @@index([reportingYear, imageDate])
+  @@index([reportingYearDate, imageDate])
   @@index([moduleId, imageDate])
   @@index([zoneId, imageDate])
   @@index([stateId, imageDate])

--- a/backend/prisma/kvk/targets/target_schema.prisma
+++ b/backend/prisma/kvk/targets/target_schema.prisma
@@ -6,6 +6,7 @@ model Target {
   districtId      Int?     @map("district_id")
   orgId           Int?     @map("org_id")
   reportingYear   Int      @map("reporting_year")
+  reportingYearDate DateTime? @map("reporting_year_date")
   typeName        String   @map("type_name")
   target          Int
   farmerTarget    Int?     @map("farmer_target")
@@ -21,6 +22,8 @@ model Target {
 
   @@index([kvkId, reportingYear])
   @@index([reportingYear])
+  @@index([kvkId, reportingYearDate])
+  @@index([reportingYearDate])
   @@index([typeName])
   @@index([zoneId])
   @@index([stateId])

--- a/backend/prisma/migrations/20260401101500_add_reporting_year_date_columns/migration.sql
+++ b/backend/prisma/migrations/20260401101500_add_reporting_year_date_columns/migration.sql
@@ -1,0 +1,100 @@
+-- Add canonical date column for modules that currently store only integer year.
+-- This is a non-breaking expansion migration; legacy int year columns remain.
+
+ALTER TABLE "kvk_budget_utilization"
+ADD COLUMN IF NOT EXISTS "reporting_year_date" TIMESTAMP(3);
+
+ALTER TABLE "financial_information"
+ADD COLUMN IF NOT EXISTS "reporting_year_date" TIMESTAMP(3);
+
+ALTER TABLE "soil_data_information"
+ADD COLUMN IF NOT EXISTS "reporting_year_date" TIMESTAMP(3);
+
+ALTER TABLE "beneficiaries_details"
+ADD COLUMN IF NOT EXISTS "reporting_year_date" TIMESTAMP(3);
+
+ALTER TABLE "ppv_fra_plant_varieties"
+ADD COLUMN IF NOT EXISTS "reporting_year_date" TIMESTAMP(3);
+
+ALTER TABLE "targets"
+ADD COLUMN IF NOT EXISTS "reporting_year_date" TIMESTAMP(3);
+
+ALTER TABLE "module_images"
+ADD COLUMN IF NOT EXISTS "reporting_year_date" TIMESTAMP(3);
+
+CREATE INDEX IF NOT EXISTS "kvk_budget_utilization_reporting_year_date_idx"
+ON "kvk_budget_utilization" ("reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "kvk_budget_utilization_kvkId_reporting_year_date_idx"
+ON "kvk_budget_utilization" ("kvkId", "reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "financial_information_reporting_year_date_idx"
+ON "financial_information" ("reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "financial_information_kvkId_reporting_year_date_idx"
+ON "financial_information" ("kvkId", "reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "soil_data_information_reporting_year_date_idx"
+ON "soil_data_information" ("reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "soil_data_information_kvkId_reporting_year_date_idx"
+ON "soil_data_information" ("kvkId", "reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "beneficiaries_details_reporting_year_date_idx"
+ON "beneficiaries_details" ("reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "beneficiaries_details_kvkId_reporting_year_date_idx"
+ON "beneficiaries_details" ("kvkId", "reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "ppv_fra_plant_varieties_reporting_year_date_idx"
+ON "ppv_fra_plant_varieties" ("reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "ppv_fra_plant_varieties_kvkId_reporting_year_date_idx"
+ON "ppv_fra_plant_varieties" ("kvkId", "reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "targets_reporting_year_date_idx"
+ON "targets" ("reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "targets_kvk_id_reporting_year_date_idx"
+ON "targets" ("kvk_id", "reporting_year_date");
+
+CREATE INDEX IF NOT EXISTS "module_images_reporting_year_date_image_date_idx"
+ON "module_images" ("reporting_year_date", "image_date");
+
+CREATE INDEX IF NOT EXISTS "module_images_kvk_id_reporting_year_date_idx"
+ON "module_images" ("kvk_id", "reporting_year_date");
+
+UPDATE "kvk_budget_utilization"
+SET "reporting_year_date" = make_date("year", 1, 1)::timestamp
+WHERE "reporting_year_date" IS NULL
+  AND "year" BETWEEN 1900 AND 3000;
+
+UPDATE "financial_information"
+SET "reporting_year_date" = make_date("year", 1, 1)::timestamp
+WHERE "reporting_year_date" IS NULL
+  AND "year" BETWEEN 1900 AND 3000;
+
+UPDATE "soil_data_information"
+SET "reporting_year_date" = make_date("year", 1, 1)::timestamp
+WHERE "reporting_year_date" IS NULL
+  AND "year" BETWEEN 1900 AND 3000;
+
+UPDATE "beneficiaries_details"
+SET "reporting_year_date" = make_date("year", 1, 1)::timestamp
+WHERE "reporting_year_date" IS NULL
+  AND "year" BETWEEN 1900 AND 3000;
+
+UPDATE "ppv_fra_plant_varieties"
+SET "reporting_year_date" = make_date("reporting_year", 1, 1)::timestamp
+WHERE "reporting_year_date" IS NULL
+  AND "reporting_year" BETWEEN 1900 AND 3000;
+
+UPDATE "targets"
+SET "reporting_year_date" = make_date("reporting_year", 1, 1)::timestamp
+WHERE "reporting_year_date" IS NULL
+  AND "reporting_year" BETWEEN 1900 AND 3000;
+
+UPDATE "module_images"
+SET "reporting_year_date" = make_date("reporting_year", 1, 1)::timestamp
+WHERE "reporting_year_date" IS NULL
+  AND "reporting_year" BETWEEN 1900 AND 3000;


### PR DESCRIPTION
## PR1
Schema-first migration foundation for long-term reportingYear date persistence.

## Changes
- add nullable `reporting_year_date` columns to year-int modules
- add indexes for scoped/reporting-year queries
- add non-breaking backfill migration from legacy int year values

## Modules Covered
- CFLD budget utilization
- Natural Farming: financial, soil, beneficiaries
- PPV-FRA plant varieties
- Targets
- Module images

## Notes
- legacy int columns are retained
- app-layer dual read/write will come in PR2

Refs #76
