### PR TITLE
[PR2] feat(reporting-year): dual read/write app layer for migration

### DIFF
--- a/backend/config/prisma.js
+++ b/backend/config/prisma.js
@@ -7,6 +7,154 @@ if (!process.env.DATABASE_URL) {
     throw new Error('DATABASE_URL is required');
 }
 
+const STRICT_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}(?:[Tt].*)?$/;
+const YEAR_PATTERN = /^\d{4}$/;
+
+const DUAL_REPORTING_YEAR_MODEL_CONFIG = {
+    KvkBudgetUtilization: { yearField: 'year', dateField: 'reportingYearDate' },
+    BeneficiariesDetails: { yearField: 'year', dateField: 'reportingYearDate' },
+    SoilDataInformation: { yearField: 'year', dateField: 'reportingYearDate' },
+    FinancialInformation: { yearField: 'year', dateField: 'reportingYearDate' },
+    PpvFraPlantVarieties: { yearField: 'reportingYear', dateField: 'reportingYearDate' },
+    Target: { yearField: 'reportingYear', dateField: 'reportingYearDate' },
+    ModuleImage: { yearField: 'reportingYear', dateField: 'reportingYearDate' },
+};
+
+function isPresent(value) {
+    return value !== undefined && value !== null && value !== '';
+}
+
+function parseDateInput(value) {
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : new Date(value.getTime());
+    }
+
+    if (typeof value === 'number' && Number.isInteger(value) && value >= 1900 && value <= 3000) {
+        return new Date(Date.UTC(value, 0, 1));
+    }
+
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    if (YEAR_PATTERN.test(trimmed)) {
+        return new Date(Date.UTC(parseInt(trimmed, 10), 0, 1));
+    }
+
+    if (!STRICT_DATE_PATTERN.test(trimmed)) {
+        return null;
+    }
+
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function parseYearInput(value) {
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value.getUTCFullYear();
+    }
+
+    if (typeof value === 'number') {
+        if (Number.isInteger(value) && value >= 1900 && value <= 3000) return value;
+        return null;
+    }
+
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    if (YEAR_PATTERN.test(trimmed)) {
+        return parseInt(trimmed, 10);
+    }
+
+    if (!STRICT_DATE_PATTERN.test(trimmed)) {
+        return null;
+    }
+
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.getUTCFullYear();
+}
+
+function getModelConfig(model) {
+    return DUAL_REPORTING_YEAR_MODEL_CONFIG[model] || null;
+}
+
+function normalizeDualReportingYearData(data, config, mode) {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        return data;
+    }
+
+    const normalized = { ...data };
+    const { yearField, dateField } = config;
+
+    if (yearField === 'year' && !isPresent(normalized.year) && isPresent(normalized.reportingYear)) {
+        normalized.year = normalized.reportingYear;
+    }
+
+    if (yearField === 'reportingYear' && !isPresent(normalized.reportingYear) && isPresent(normalized.year)) {
+        normalized.reportingYear = normalized.year;
+    }
+
+    const rawDateInput = isPresent(normalized[dateField]) ? normalized[dateField] : normalized.reportingYearDate;
+    const rawYearInput = isPresent(normalized[yearField])
+        ? normalized[yearField]
+        : (isPresent(normalized.reportingYear) ? normalized.reportingYear : normalized.year);
+
+    const parsedDate = parseDateInput(rawDateInput) || parseDateInput(rawYearInput);
+    const parsedYear = parseYearInput(rawYearInput) ?? (parsedDate ? parsedDate.getUTCFullYear() : null);
+
+    if (parsedDate) {
+        normalized[dateField] = parsedDate;
+    } else if (
+        mode === 'create' &&
+        parsedYear !== null &&
+        !isPresent(normalized[dateField]) &&
+        !isPresent(normalized.reportingYearDate)
+    ) {
+        normalized[dateField] = new Date(Date.UTC(parsedYear, 0, 1));
+    }
+
+    if (parsedYear !== null) {
+        normalized[yearField] = parsedYear;
+    }
+
+    // During update, when only numeric year is sent, preserve existing stored date.
+    if (mode === 'update' && !parseDateInput(rawDateInput) && !parseDateInput(rawYearInput)) {
+        delete normalized[dateField];
+    }
+
+    if (yearField !== 'year') {
+        delete normalized.year;
+    }
+    if (yearField !== 'reportingYear') {
+        delete normalized.reportingYear;
+    }
+    if (dateField !== 'reportingYearDate') {
+        delete normalized.reportingYearDate;
+    }
+
+    return normalized;
+}
+
+function normalizeArgsForModel(model, args, mode) {
+    const config = getModelConfig(model);
+    if (!config || !args || !args.data) return args;
+
+    if (Array.isArray(args.data)) {
+        args.data = args.data.map((entry) => normalizeDualReportingYearData(entry, config, mode));
+        return args;
+    }
+
+    args.data = normalizeDualReportingYearData(args.data, config, mode);
+    return args;
+}
+
 // Check if using Prisma Accelerate or direct connection
 const isAccelerate = process.env.DATABASE_URL.startsWith('prisma+');
 
@@ -50,5 +198,37 @@ if (isAccelerate) {
         log: process.env.NODE_ENV === 'development' ? ['error', 'warn'] : ['error'],
     });
 }
+
+prisma = prisma.$extends({
+    name: 'reportingYearBridge',
+    query: {
+        $allModels: {
+            create({ model, args, query }) {
+                return query(normalizeArgsForModel(model, args, 'create'));
+            },
+            createMany({ model, args, query }) {
+                return query(normalizeArgsForModel(model, args, 'create'));
+            },
+            update({ model, args, query }) {
+                return query(normalizeArgsForModel(model, args, 'update'));
+            },
+            updateMany({ model, args, query }) {
+                return query(normalizeArgsForModel(model, args, 'update'));
+            },
+            upsert({ model, args, query }) {
+                const config = getModelConfig(model);
+                if (config && args) {
+                    if (args.create) {
+                        args.create = normalizeDualReportingYearData(args.create, config, 'create');
+                    }
+                    if (args.update) {
+                        args.update = normalizeDualReportingYearData(args.update, config, 'update');
+                    }
+                }
+                return query(args);
+            },
+        },
+    },
+});
 
 module.exports = prisma;

--- a/backend/repositories/forms/cfldBudgetUtilizationRepository.js
+++ b/backend/repositories/forms/cfldBudgetUtilizationRepository.js
@@ -14,6 +14,19 @@ const buildDateFromYear = (yearValue) => {
     return year === null ? null : new Date(Date.UTC(year, 0, 1));
 };
 
+const resolveDateFromYearWithFallback = (yearValue, fallbackDate = null) => {
+    const year = parseYearFromInput(yearValue, null);
+    if (year === null) return fallbackDate || null;
+
+    if (fallbackDate instanceof Date && !Number.isNaN(fallbackDate.getTime())) {
+        if (fallbackDate.getUTCFullYear() === year) {
+            return new Date(fallbackDate.getTime());
+        }
+    }
+
+    return new Date(Date.UTC(year, 0, 1));
+};
+
 const resolveReportingYearInput = (rawValue, fallbackYear = null, fallbackDate = null) => {
     if (rawValue === undefined || rawValue === null || rawValue === '') {
         return {
@@ -34,7 +47,9 @@ const resolveReportingYearInput = (rawValue, fallbackYear = null, fallbackDate =
     const parsedYear = parseYearFromInput(rawValue, fallbackYear);
     return {
         year: parsedYear,
-        reportingYearDate: buildDateFromYear(parsedYear) || fallbackDate,
+        // For legacy clients that still send only numeric year during update,
+        // preserve existing exact date when the year did not change.
+        reportingYearDate: resolveDateFromYearWithFallback(parsedYear, fallbackDate),
     };
 };
 

--- a/backend/repositories/forms/cfldBudgetUtilizationRepository.js
+++ b/backend/repositories/forms/cfldBudgetUtilizationRepository.js
@@ -1,7 +1,48 @@
 const prisma = require('../../config/prisma.js');
 const { removeIdFieldsForUpdate } = require('../../utils/dataSanitizer.js');
-const { formatReportingYear } = require('../../utils/reportingYearUtils.js');
+const { parseReportingYearDate, ensureNotFutureDate, formatReportingYear } = require('../../utils/reportingYearUtils.js');
 const { mapCommonRelations } = require('../../utils/responseMapper.js');
+
+const parseYearFromInput = (value, fallback = null) => {
+    if (value === undefined || value === null || value === '') return fallback;
+    const parsed = parseInt(String(value).trim(), 10);
+    return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+const buildDateFromYear = (yearValue) => {
+    const year = parseYearFromInput(yearValue, null);
+    return year === null ? null : new Date(Date.UTC(year, 0, 1));
+};
+
+const resolveReportingYearInput = (rawValue, fallbackYear = null, fallbackDate = null) => {
+    if (rawValue === undefined || rawValue === null || rawValue === '') {
+        return {
+            year: fallbackYear,
+            reportingYearDate: fallbackDate || buildDateFromYear(fallbackYear),
+        };
+    }
+
+    if (rawValue instanceof Date || (typeof rawValue === 'string' && rawValue.trim().includes('-'))) {
+        const parsedDate = parseReportingYearDate(rawValue);
+        ensureNotFutureDate(parsedDate);
+        return {
+            year: parsedDate.getUTCFullYear(),
+            reportingYearDate: parsedDate,
+        };
+    }
+
+    const parsedYear = parseYearFromInput(rawValue, fallbackYear);
+    return {
+        year: parsedYear,
+        reportingYearDate: buildDateFromYear(parsedYear) || fallbackDate,
+    };
+};
+
+const formatBudgetReportingYear = (reportingYearDate, yearValue) => {
+    if (reportingYearDate) return formatReportingYear(reportingYearDate);
+    const fallbackDate = buildDateFromYear(yearValue);
+    return fallbackDate ? formatReportingYear(fallbackDate) : '';
+};
 
 const cfldBudgetUtilizationRepository = {
     create: async (data, opts, user) => {
@@ -66,22 +107,18 @@ const cfldBudgetUtilizationRepository = {
             { id: getItemIdByPattern('Publication'), r: data.publicationReceived, u: data.publicationUtilized }
         ].filter(item => item.id !== null);
 
-        const rawYear = data.reportingYear || data.year;
-        let numericYear = new Date().getFullYear();
-        if (rawYear) {
-            const parsed = parseInt(String(rawYear).split('-')[0]);
-            numericYear = isNaN(parsed) ? new Date().getFullYear() : parsed;
-        }
+        const yearInfo = resolveReportingYearInput(data.reportingYear ?? data.year, new Date().getUTCFullYear(), null);
+        const numericYear = yearInfo.year ?? new Date().getUTCFullYear();
 
         const insertResult = await prisma.$queryRawUnsafe(`
             INSERT INTO kvk_budget_utilization (
-                "kvkId", year, "seasonId", "cropId",
+                "kvkId", year, reporting_year_date, "seasonId", "cropId",
                 overall_crop_wise_fund_allocation,
                 area_ha_allotted, area_ha_achieved,
                 created_at, updated_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
             RETURNING budget_id
-        `, kvkId, numericYear, parseInt(data.seasonId || 1), cropId,
+        `, kvkId, numericYear, yearInfo.reportingYearDate, parseInt(data.seasonId || 1), cropId,
             parseFloat(data.overallFundAllocation || 0),
             parseFloat(data.areaAllotted || 0),
             parseFloat(data.areaAchieved || 0)
@@ -152,10 +189,11 @@ const cfldBudgetUtilizationRepository = {
         }
 
         const updateData = {};
-        const rawYear = data.reportingYear || data.year;
+        const rawYear = data.reportingYear ?? data.year;
         if (rawYear !== undefined) {
-            const parsed = parseInt(String(rawYear).split('-')[0]);
-            if (!isNaN(parsed)) updateData.year = parsed;
+            const yearInfo = resolveReportingYearInput(rawYear, existing.year, existing.reportingYearDate || null);
+            if (yearInfo.year !== null && yearInfo.year !== undefined) updateData.year = yearInfo.year;
+            updateData.reportingYearDate = yearInfo.reportingYearDate || null;
         }
         if (data.seasonId) updateData.seasonId = parseInt(data.seasonId);
 
@@ -259,7 +297,7 @@ function _mapResponse(r) {
         kvkId: r.kvkId,
         ...relations,
         year: r.year,
-        reportingYear: formatReportingYear(r.reportingYear),
+        reportingYear: formatBudgetReportingYear(r.reportingYearDate, r.year),
         overallFundAllocation: r.overallFundAllocation,
         areaAllotted: r.areaAllotted,
         areaAchieved: r.areaAchieved,

--- a/backend/repositories/forms/naturalFarmingRepository.js
+++ b/backend/repositories/forms/naturalFarmingRepository.js
@@ -13,6 +13,42 @@ function getKvkId(user, data) {
 
 const safeFloat = (val, d = 0) => { const n = parseFloat(val); return isNaN(n) ? d : n; };
 const safeInt = (val, d = 0) => { const n = parseInt(val, 10); return isNaN(n) ? d : n; };
+
+const buildDateFromYear = (yearValue) => {
+    const year = safeInt(yearValue, null);
+    return year === null ? null : new Date(Date.UTC(year, 0, 1));
+};
+
+const resolveYearDateInput = (rawValue, fallbackYear = null, fallbackDate = null) => {
+    if (rawValue === undefined || rawValue === null || rawValue === '') {
+        return {
+            year: fallbackYear,
+            reportingYearDate: fallbackDate || buildDateFromYear(fallbackYear),
+        };
+    }
+
+    if (rawValue instanceof Date || (typeof rawValue === 'string' && rawValue.trim().includes('-'))) {
+        const parsedDate = parseReportingYearDate(rawValue);
+        ensureNotFutureDate(parsedDate);
+        return {
+            year: parsedDate.getUTCFullYear(),
+            reportingYearDate: parsedDate,
+        };
+    }
+
+    const parsedYear = safeInt(rawValue, fallbackYear);
+    return {
+        year: parsedYear,
+        reportingYearDate: buildDateFromYear(parsedYear) || fallbackDate,
+    };
+};
+
+const formatLegacyYearResponse = (reportingYearDate, yearValue) => {
+    if (reportingYearDate) return formatReportingYear(reportingYearDate);
+    const fallbackDate = buildDateFromYear(yearValue);
+    return fallbackDate ? formatReportingYear(fallbackDate) : '';
+};
+
 const isOtherActivityName = (value) => String(value || '').trim().toLowerCase() === 'other activity';
 
 async function resolveNaturalFarmingActivity(rawValue) {
@@ -753,10 +789,12 @@ const demonstrationInfoRepository = {
 const beneficiariesRepository = {
     create: async (data, user) => {
         const kvkId = getKvkId(user, data);
+        const yearInfo = resolveYearDateInput(data.reportingYear ?? data.year, new Date().getUTCFullYear(), null);
         return await prisma.beneficiariesDetails.create({
             data: {
                 kvkId,
-                year: safeInt(data.reportingYear || data.year || new Date().getFullYear()),
+                year: yearInfo.year ?? new Date().getUTCFullYear(),
+                reportingYearDate: yearInfo.reportingYearDate,
                 blocksCovered: safeInt(data.noOfBlocks || data.blocksCovered, 0),
                 villagesCovered: safeInt(data.noOfVillages || data.villagesCovered, 0),
                 totalTrainedFarmers: safeInt(data.totalTrainedFarmers, 0),
@@ -783,7 +821,7 @@ const beneficiariesRepository = {
             kvkName: r.kvk?.kvkName,
             noOfBlocks: r.blocksCovered,
             noOfVillages: r.villagesCovered,
-            reportingYear: String(r.year),
+            reportingYear: formatLegacyYearResponse(r.reportingYearDate, r.year),
         }));
     },
     findById: async (id, user) => {
@@ -797,7 +835,7 @@ const beneficiariesRepository = {
             kvkName: r.kvk?.kvkName,
             noOfBlocks: r.blocksCovered,
             noOfVillages: r.villagesCovered,
-            reportingYear: String(r.year),
+            reportingYear: formatLegacyYearResponse(r.reportingYearDate, r.year),
         };
     },
     update: async (id, data, user) => {
@@ -805,10 +843,15 @@ const beneficiariesRepository = {
         if (isKvkUser(user)) where.kvkId = parseInt(user.kvkId);
         const existing = await prisma.beneficiariesDetails.findFirst({ where });
         if (!existing) throw new Error('Record not found or unauthorized');
+        const yearInfo = (data.reportingYear !== undefined || data.year !== undefined)
+            ? resolveYearDateInput(data.reportingYear ?? data.year, existing.year, existing.reportingYearDate || null)
+            : { year: existing.year, reportingYearDate: existing.reportingYearDate || buildDateFromYear(existing.year) };
+
         return await prisma.beneficiariesDetails.update({
             where: { beneficiariesDetailsId: parseInt(id) },
             data: {
-                year: (data.reportingYear || data.year) !== undefined ? parseInt(data.reportingYear || data.year || 0) : existing.year,
+                year: yearInfo.year ?? existing.year,
+                reportingYearDate: yearInfo.reportingYearDate || null,
                 blocksCovered: (data.noOfBlocks || data.blocksCovered) !== undefined ? parseInt(data.noOfBlocks || data.blocksCovered || 0) : existing.blocksCovered,
                 villagesCovered: (data.noOfVillages || data.villagesCovered) !== undefined ? parseInt(data.noOfVillages || data.villagesCovered || 0) : existing.villagesCovered,
                 totalTrainedFarmers: data.totalTrainedFarmers !== undefined ? parseInt(data.totalTrainedFarmers || 0) : existing.totalTrainedFarmers,
@@ -833,10 +876,12 @@ const soilDataRepository = {
     create: async (data, user) => {
         const kvkId = getKvkId(user, data);
         const soilParameterId = await resolveNaturalFarmingSoilParameterId(data.soilParameterId ?? data.soilParameter ?? data.type);
+        const yearInfo = resolveYearDateInput(data.reportingYear ?? data.year, new Date().getUTCFullYear(), null);
         return await prisma.soilDataInformation.create({
             data: {
                 kvkId,
-                year: safeInt(data.reportingYear || data.year || new Date().getFullYear()),
+                year: yearInfo.year ?? new Date().getUTCFullYear(),
+                reportingYearDate: yearInfo.reportingYearDate,
                 crop: data.crop || '',
                 seasonId: data.seasonId ? safeInt(data.seasonId, null) : null,
                 soilParameterId,
@@ -877,7 +922,7 @@ const soilDataRepository = {
             kvkName: r.kvk?.kvkName,
             season: r.season?.seasonName,
             seasonId: r.seasonId,
-            reportingYear: String(r.year),
+            reportingYear: formatLegacyYearResponse(r.reportingYearDate, r.year),
             type: r.soilParameterMaster?.parameterName || null,
             soilParameter: r.soilParameterMaster?.parameterName || null,
             soilParameterId: r.soilParameterId,
@@ -917,7 +962,7 @@ const soilDataRepository = {
             kvkName: r.kvk?.kvkName,
             season: r.season?.seasonName,
             seasonId: r.seasonId,
-            reportingYear: String(r.year),
+            reportingYear: formatLegacyYearResponse(r.reportingYearDate, r.year),
             type: r.soilParameterMaster?.parameterName || null,
             soilParameter: r.soilParameterMaster?.parameterName || null,
             soilParameterId: r.soilParameterId,
@@ -946,10 +991,15 @@ const soilDataRepository = {
         const resolvedSoilParameterId = (data.soilParameterId !== undefined || data.soilParameter !== undefined || data.type !== undefined)
             ? await resolveNaturalFarmingSoilParameterId(data.soilParameterId ?? data.soilParameter ?? data.type)
             : existing.soilParameterId;
+        const yearInfo = (data.reportingYear !== undefined || data.year !== undefined)
+            ? resolveYearDateInput(data.reportingYear ?? data.year, existing.year, existing.reportingYearDate || null)
+            : { year: existing.year, reportingYearDate: existing.reportingYearDate || buildDateFromYear(existing.year) };
+
         return await prisma.soilDataInformation.update({
             where: { soilDataInformationId: parseInt(id) },
             data: {
-                year: (data.reportingYear || data.year) !== undefined ? safeInt(data.reportingYear || data.year, existing.year) : existing.year,
+                year: yearInfo.year ?? existing.year,
+                reportingYearDate: yearInfo.reportingYearDate || null,
                 crop: data.crop !== undefined ? data.crop : existing.crop,
                 seasonId: data.seasonId !== undefined ? (data.seasonId ? safeInt(data.seasonId, null) : null) : existing.seasonId,
                 soilParameterId: resolvedSoilParameterId,
@@ -984,10 +1034,12 @@ const financialInfoRepository = {
     create: async (data, user) => {
         const kvkId = getKvkId(user, data);
         const resolvedActivity = await resolveNaturalFarmingActivity(data.activityId ?? data.activityName ?? data.activity);
+        const yearInfo = resolveYearDateInput(data.reportingYear ?? data.year, new Date().getUTCFullYear(), null);
         return await prisma.financialInformation.create({
             data: {
                 kvkId,
-                year: safeInt(data.reportingYear || data.year || new Date().getFullYear()),
+                year: yearInfo.year ?? new Date().getUTCFullYear(),
+                reportingYearDate: yearInfo.reportingYearDate,
                 activityId: resolvedActivity?.naturalFarmingActivityId || null,
                 numberOfActivities: safeInt(data.noOfActivities || data.numberOfActivities, 0),
                 budgetSanction: safeFloat(data.budgetSanction, 0),
@@ -1017,6 +1069,7 @@ const financialInfoRepository = {
             noOfActivities: r.numberOfActivities,
             activityName: r.activityMaster?.activityName || null,
             activityId: r.activityId,
+            reportingYear: formatLegacyYearResponse(r.reportingYearDate, r.year),
         }));
     },
     findById: async (id, user) => {
@@ -1038,7 +1091,7 @@ const financialInfoRepository = {
             noOfActivities: r.numberOfActivities,
             activityName: r.activityMaster?.activityName || null,
             activityId: r.activityId,
-            reportingYear: String(r.year),
+            reportingYear: formatLegacyYearResponse(r.reportingYearDate, r.year),
         };
     },
     update: async (id, data, user) => {
@@ -1049,10 +1102,16 @@ const financialInfoRepository = {
         const resolvedActivity = (data.activityId !== undefined || data.activityName !== undefined || data.activity !== undefined)
             ? await resolveNaturalFarmingActivity(data.activityId ?? data.activityName ?? data.activity)
             : null;
+
+        const yearInfo = (data.reportingYear !== undefined || data.year !== undefined)
+            ? resolveYearDateInput(data.reportingYear ?? data.year, existing.year, existing.reportingYearDate || null)
+            : { year: existing.year, reportingYearDate: existing.reportingYearDate || buildDateFromYear(existing.year) };
+
         return await prisma.financialInformation.update({
             where: { financialInformationId: parseInt(id) },
             data: {
-                year: (data.reportingYear || data.year) !== undefined ? safeInt(data.reportingYear || data.year, existing.year) : existing.year,
+                year: yearInfo.year ?? existing.year,
+                reportingYearDate: yearInfo.reportingYearDate || null,
                 activityId: resolvedActivity ? resolvedActivity.naturalFarmingActivityId : existing.activityId,
                 numberOfActivities: (data.noOfActivities || data.numberOfActivities) !== undefined ? safeInt(data.noOfActivities || data.numberOfActivities, existing.numberOfActivities) : existing.numberOfActivities,
                 budgetSanction: data.budgetSanction !== undefined ? safeFloat(data.budgetSanction, existing.budgetSanction) : existing.budgetSanction,

--- a/backend/repositories/forms/ppvFraPlantVarietiesRepository.js
+++ b/backend/repositories/forms/ppvFraPlantVarietiesRepository.js
@@ -1,14 +1,67 @@
 const prisma = require('../../config/prisma.js');
+const { parseReportingYearDate, ensureNotFutureDate, formatReportingYear } = require('../../utils/reportingYearUtils.js');
+
+const parseYearFromInput = (value, fallback = null) => {
+    if (value === undefined || value === null || value === '') return fallback;
+    const parsed = parseInt(String(value).trim(), 10);
+    return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+const buildDateFromYear = (value) => {
+    const year = parseYearFromInput(value, null);
+    return year === null ? null : new Date(Date.UTC(year, 0, 1));
+};
+
+const resolveReportingYearInput = (rawValue, fallbackYear = null, fallbackDate = null) => {
+    if (rawValue === undefined || rawValue === null || rawValue === '') {
+        return {
+            year: fallbackYear,
+            reportingYearDate: fallbackDate || buildDateFromYear(fallbackYear),
+        };
+    }
+
+    if (rawValue instanceof Date || (typeof rawValue === 'string' && rawValue.trim().includes('-'))) {
+        const parsedDate = parseReportingYearDate(rawValue);
+        ensureNotFutureDate(parsedDate);
+        return {
+            year: parsedDate.getUTCFullYear(),
+            reportingYearDate: parsedDate,
+        };
+    }
+
+    const parsedYear = parseYearFromInput(rawValue, fallbackYear);
+    return {
+        year: parsedYear,
+        reportingYearDate: buildDateFromYear(parsedYear) || fallbackDate,
+    };
+};
+
+const mapPlantVarietyRecord = (record) => {
+    if (!record) return null;
+
+    const reportingYear = record.reportingYearDate
+        ? formatReportingYear(record.reportingYearDate)
+        : formatReportingYear(buildDateFromYear(record.reportingYear));
+
+    return {
+        ...record,
+        reportingYear,
+        year: record.reportingYear,
+    };
+};
 
 const ppvFraPlantVarietiesRepository = {
     create: async (data, user) => {
         const kvkId = (user && user.kvkId) ? parseInt(user.kvkId) : (data.kvkId ? parseInt(data.kvkId) : null);
         if (!kvkId) throw new Error('KVK ID is required');
 
-        return await prisma.ppvFraPlantVarieties.create({
+        const yearInfo = resolveReportingYearInput(data.reportingYear ?? data.year, new Date().getUTCFullYear(), null);
+
+        const record = await prisma.ppvFraPlantVarieties.create({
             data: {
                 kvkId,
-                reportingYear: parseInt(data.reportingYear || new Date().getFullYear()),
+                reportingYear: yearInfo.year ?? new Date().getUTCFullYear(),
+                reportingYearDate: yearInfo.reportingYearDate,
                 cropName: data.cropName || '',
                 farmerName: data.farmerName || '',
                 mobile: data.mobile || '',
@@ -19,6 +72,7 @@ const ppvFraPlantVarietiesRepository = {
                 image: data.image || null,
             }
         });
+        return mapPlantVarietyRecord(record);
     },
 
     findAll: async (filters = {}, user) => {
@@ -28,7 +82,7 @@ const ppvFraPlantVarietiesRepository = {
         } else if (filters.kvkId) {
             where.kvkId = parseInt(filters.kvkId);
         }
-        return await prisma.ppvFraPlantVarieties.findMany({
+        const records = await prisma.ppvFraPlantVarieties.findMany({
             where,
             include: {
                 kvk: {
@@ -40,12 +94,13 @@ const ppvFraPlantVarietiesRepository = {
             },
             orderBy: { ppvFraPlantVarietiesID: 'desc' }
         });
+        return records.map(mapPlantVarietyRecord);
     },
 
     findById: async (id, user) => {
         const where = { ppvFraPlantVarietiesID: parseInt(id) };
         if (user && user.kvkId) where.kvkId = parseInt(user.kvkId);
-        return await prisma.ppvFraPlantVarieties.findFirst({
+        const record = await prisma.ppvFraPlantVarieties.findFirst({
             where,
             include: {
                 kvk: {
@@ -56,6 +111,7 @@ const ppvFraPlantVarietiesRepository = {
                 }
             }
         });
+        return mapPlantVarietyRecord(record);
     },
 
     update: async (id, data, user) => {
@@ -63,10 +119,16 @@ const ppvFraPlantVarietiesRepository = {
         if (user && user.kvkId) where.kvkId = parseInt(user.kvkId);
         const existing = await prisma.ppvFraPlantVarieties.findFirst({ where });
         if (!existing) throw new Error('Record not found or unauthorized');
-        return await prisma.ppvFraPlantVarieties.update({
+
+        const yearInfo = (data.reportingYear !== undefined || data.year !== undefined)
+            ? resolveReportingYearInput(data.reportingYear ?? data.year, existing.reportingYear, existing.reportingYearDate || null)
+            : { year: existing.reportingYear, reportingYearDate: existing.reportingYearDate || buildDateFromYear(existing.reportingYear) };
+
+        const record = await prisma.ppvFraPlantVarieties.update({
             where: { ppvFraPlantVarietiesID: parseInt(id) },
             data: {
-                reportingYear: data.reportingYear !== undefined ? parseInt(data.reportingYear) : existing.reportingYear,
+                reportingYear: yearInfo.year ?? existing.reportingYear,
+                reportingYearDate: yearInfo.reportingYearDate || null,
                 cropName: data.cropName !== undefined ? data.cropName : existing.cropName,
                 farmerName: data.farmerName !== undefined ? data.farmerName : existing.farmerName,
                 mobile: data.mobile !== undefined ? data.mobile : existing.mobile,
@@ -77,6 +139,7 @@ const ppvFraPlantVarietiesRepository = {
                 image: data.image !== undefined ? data.image : existing.image,
             }
         });
+        return mapPlantVarietyRecord(record);
     },
 
     delete: async (id, user) => {

--- a/backend/services/moduleImageService.js
+++ b/backend/services/moduleImageService.js
@@ -1,4 +1,5 @@
 const moduleImageRepository = require('../repositories/moduleImageRepository.js');
+const { parseReportingYearDate, ensureNotFutureDate, formatReportingYear } = require('../utils/reportingYearUtils.js');
 
 const ALLOWED_CATEGORY_MENUS = [
   'About KVKs',
@@ -62,6 +63,31 @@ function parseModuleId(value) {
     throw new Error('Invalid category');
   }
   return moduleId;
+}
+
+function parseReportingYearInput(value, fieldName = 'Reporting Year') {
+  if (value === undefined || value === null || value === '') {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  if (value instanceof Date || (typeof value === 'string' && value.trim().includes('-'))) {
+    const parsedDate = parseReportingYearDate(value);
+    ensureNotFutureDate(parsedDate);
+    return {
+      year: parsedDate.getUTCFullYear(),
+      reportingYearDate: parsedDate,
+    };
+  }
+
+  const year = Number(value);
+  if (!Number.isInteger(year) || year < 1900 || year > 3000) {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+
+  return {
+    year,
+    reportingYearDate: new Date(Date.UTC(year, 0, 1)),
+  };
 }
 
 function parseImageDataUrl(imageBase64) {
@@ -129,6 +155,7 @@ function mapListRow(row) {
     caption: row.caption || '',
     imageDate: row.imageDate,
     reportingYear: row.reportingYear,
+    reportingYearDate: row.reportingYearDate ? formatReportingYear(row.reportingYearDate) : null,
     mimeType: row.mimeType,
     fileName: row.fileName || null,
     fileUrl: `/api/admin/module-images/${row.imageId}/file`,
@@ -197,7 +224,9 @@ const moduleImageService = {
 
     const moduleId = parseModuleId(payload?.moduleId);
     const imageDate = parseImageDate(payload?.imageDate);
-    const reportingYear = imageDate.getUTCFullYear();
+    const reportingYear = payload?.reportingYear !== undefined && payload?.reportingYear !== null && payload?.reportingYear !== ''
+      ? parseReportingYearInput(payload.reportingYear, 'reportingYear')
+      : parseReportingYearInput(imageDate, 'reportingYear');
     const caption = String(payload?.caption || '').trim();
     if (!caption) {
       throw new Error('Caption is required');
@@ -230,7 +259,8 @@ const moduleImageService = {
       moduleId,
       caption,
       imageDate,
-      reportingYear,
+      reportingYear: reportingYear.year,
+      reportingYearDate: reportingYear.reportingYearDate,
       imageData,
       mimeType,
       fileName,
@@ -244,6 +274,7 @@ const moduleImageService = {
       caption: created.caption,
       imageDate: created.imageDate,
       reportingYear: created.reportingYear,
+      reportingYearDate: created.reportingYearDate ? formatReportingYear(created.reportingYearDate) : null,
       createdAt: created.createdAt,
     };
   },
@@ -261,11 +292,16 @@ const moduleImageService = {
     const where = { ...scopeFilter };
 
     if (filters.reportingYear !== undefined && filters.reportingYear !== null && filters.reportingYear !== '') {
-      const year = Number(filters.reportingYear);
-      if (!Number.isInteger(year) || year < 1900 || year > 3000) {
-        throw new Error('Invalid reportingYear');
-      }
-      where.reportingYear = year;
+      const reportingYear = parseReportingYearInput(filters.reportingYear, 'reportingYear');
+      const start = new Date(Date.UTC(reportingYear.year, 0, 1));
+      const endExclusive = new Date(Date.UTC(reportingYear.year + 1, 0, 1));
+      if (!Array.isArray(where.AND)) where.AND = [];
+      where.AND.push({
+        OR: [
+          { reportingYearDate: { gte: start, lt: endExclusive } },
+          { reportingYear: reportingYear.year },
+        ],
+      });
     }
 
     if (filters.kvkId !== undefined && filters.kvkId !== null && filters.kvkId !== '') {
@@ -286,12 +322,15 @@ const moduleImageService = {
 
     const search = String(filters.search || '').trim();
     if (search) {
-      where.OR = [
-        { caption: { contains: search, mode: 'insensitive' } },
-        { kvk: { kvkName: { contains: search, mode: 'insensitive' } } },
-        { module: { menuName: { contains: search, mode: 'insensitive' } } },
-        { module: { subMenuName: { contains: search, mode: 'insensitive' } } },
-      ];
+      if (!Array.isArray(where.AND)) where.AND = [];
+      where.AND.push({
+        OR: [
+          { caption: { contains: search, mode: 'insensitive' } },
+          { kvk: { kvkName: { contains: search, mode: 'insensitive' } } },
+          { module: { menuName: { contains: search, mode: 'insensitive' } } },
+          { module: { subMenuName: { contains: search, mode: 'insensitive' } } },
+        ],
+      });
     }
 
     const { rows, total } = await moduleImageRepository.list({

--- a/backend/services/targetService.js
+++ b/backend/services/targetService.js
@@ -1,4 +1,5 @@
 const targetRepository = require('../repositories/targetRepository.js');
+const { parseReportingYearDate, ensureNotFutureDate, formatReportingYear } = require('../utils/reportingYearUtils.js');
 
 const TARGET_TYPES = [
   'OFT',
@@ -92,6 +93,31 @@ function parsePositiveInt(value, fieldName) {
   return parsed;
 }
 
+function parseReportingYearInput(value, fieldName = 'Reporting Year') {
+  if (value === undefined || value === null || value === '') {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  if (value instanceof Date || (typeof value === 'string' && value.trim().includes('-'))) {
+    const parsedDate = parseReportingYearDate(value);
+    ensureNotFutureDate(parsedDate);
+    return {
+      year: parsedDate.getUTCFullYear(),
+      reportingYearDate: parsedDate,
+    };
+  }
+
+  const year = parsePositiveInt(value, fieldName);
+  if (year < 1900 || year > 3000) {
+    throw new Error('Invalid reporting year');
+  }
+
+  return {
+    year,
+    reportingYearDate: new Date(Date.UTC(year, 0, 1)),
+  };
+}
+
 const targetService = {
   getTypeOptions: () => {
     return TARGET_TYPES.map((typeName) => ({
@@ -118,11 +144,16 @@ const targetService = {
     const where = { ...scopeFilter };
 
     if (filters.reportingYear !== undefined && filters.reportingYear !== null && filters.reportingYear !== '') {
-      const year = Number(filters.reportingYear);
-      if (!Number.isInteger(year) || year < 1900 || year > 3000) {
-        throw new Error('Invalid reportingYear');
-      }
-      where.reportingYear = year;
+      const reportingYear = parseReportingYearInput(filters.reportingYear, 'reportingYear');
+      const start = new Date(Date.UTC(reportingYear.year, 0, 1));
+      const endExclusive = new Date(Date.UTC(reportingYear.year + 1, 0, 1));
+      if (!Array.isArray(where.AND)) where.AND = [];
+      where.AND.push({
+        OR: [
+          { reportingYearDate: { gte: start, lt: endExclusive } },
+          { reportingYear: reportingYear.year },
+        ],
+      });
     }
 
     if (filters.kvkId !== undefined && filters.kvkId !== null && filters.kvkId !== '') {
@@ -152,7 +183,7 @@ const targetService = {
       where,
       skip,
       take: limit,
-      orderBy: [{ reportingYear: 'desc' }, { targetId: 'desc' }],
+      orderBy: [{ reportingYearDate: 'desc' }, { reportingYear: 'desc' }, { targetId: 'desc' }],
     });
 
     return {
@@ -161,6 +192,7 @@ const targetService = {
         kvkId: row.kvkId,
         kvkName: row.kvk?.kvkName || `KVK ${row.kvkId}`,
         reportingYear: row.reportingYear,
+        reportingYearDate: row.reportingYearDate ? formatReportingYear(row.reportingYearDate) : null,
         typeName: row.typeName,
         target: row.target,
         farmerTarget: row.farmerTarget,
@@ -202,10 +234,7 @@ const targetService = {
     }
 
     const typeName = validateTypeName(payload.typeName);
-    const reportingYear = parsePositiveInt(payload.reportingYear, 'Reporting Year');
-    if (reportingYear < 1900 || reportingYear > 3000) {
-      throw new Error('Invalid reporting year');
-    }
+    const reportingYear = parseReportingYearInput(payload.reportingYear, 'Reporting Year');
 
     const target = parsePositiveInt(payload.target, 'Target');
 
@@ -215,7 +244,8 @@ const targetService = {
       stateId: kvk.stateId,
       districtId: kvk.districtId,
       orgId: kvk.orgId,
-      reportingYear,
+      reportingYear: reportingYear.year,
+      reportingYearDate: reportingYear.reportingYearDate,
       typeName,
       target,
       createdByUserId: actor.userId,
@@ -255,15 +285,13 @@ const targetService = {
     }
 
     const typeName = validateTypeName(payload.typeName);
-    const reportingYear = parsePositiveInt(payload.reportingYear, 'Reporting Year');
-    if (reportingYear < 1900 || reportingYear > 3000) {
-      throw new Error('Invalid reporting year');
-    }
+    const reportingYear = parseReportingYearInput(payload.reportingYear, 'Reporting Year');
 
     const target = parsePositiveInt(payload.target, 'Target');
 
     const data = {
-      reportingYear,
+      reportingYear: reportingYear.year,
+      reportingYearDate: reportingYear.reportingYearDate,
       typeName,
       target,
       farmerTarget: null,

--- a/frontend/src/utils/dataTransformationUtils.ts
+++ b/frontend/src/utils/dataTransformationUtils.ts
@@ -22,6 +22,49 @@ export interface TransformationRule {
     transform?: (data: any) => any;
 }
 
+const STRICT_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}(?:T.*)?$/;
+const YEAR_PATTERN = /^\d{4}$/;
+
+function toDateOnlyString(value: any): string | null {
+    if (value === null || value === undefined || value === '') return null;
+
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value.toISOString().split('T')[0];
+    }
+
+    if (typeof value === 'number' && Number.isInteger(value) && value >= 1900 && value <= 3000) {
+        return `${value}-01-01`;
+    }
+
+    if (typeof value === 'object') {
+        if (value.reportingYearDate !== undefined) return toDateOnlyString(value.reportingYearDate);
+        if (value.reportingYear !== undefined) return toDateOnlyString(value.reportingYear);
+        if (value.yearName !== undefined) return toDateOnlyString(value.yearName);
+        if (value.year !== undefined) return toDateOnlyString(value.year);
+        return null;
+    }
+
+    if (typeof value !== 'string') return null;
+
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    if (YEAR_PATTERN.test(trimmed)) {
+        return `${trimmed}-01-01`;
+    }
+
+    if (!STRICT_DATE_PATTERN.test(trimmed)) {
+        return null;
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+        return trimmed;
+    }
+
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString().split('T')[0];
+}
+
 // ============================================
 // Configuration: Entity-Specific Rules
 // ============================================
@@ -252,9 +295,7 @@ export function normalizeLegacyReportingYear(data: any): any {
     if (!data || typeof data !== 'object') return data;
 
     const normalized = { ...data };
-    const legacyYear =
-        normalized.reportingYear ??
-        normalized.year;
+    const legacyYear = normalized.reportingYear ?? normalized.year;
 
     if (legacyYear !== undefined && legacyYear !== null && legacyYear !== '') {
         const asString = String(legacyYear).trim();
@@ -263,6 +304,28 @@ export function normalizeLegacyReportingYear(data: any): any {
     }
 
     delete normalized.year;
+
+    return normalized;
+}
+
+/**
+ * Canonicalizes reporting year aliases to a single date string field.
+ * Prefers reportingYearDate (exact date) over legacy integer year.
+ */
+export function normalizeReportingYearDateAlias(data: any): any {
+    if (!data || typeof data !== 'object') return data;
+
+    const normalized = { ...data };
+    const dateFromAlias =
+        toDateOnlyString(normalized.reportingYearDate) ??
+        toDateOnlyString(normalized.reportingYear) ??
+        toDateOnlyString(normalized.year);
+
+    if (dateFromAlias) {
+        normalized.reportingYear = dateFromAlias;
+    }
+
+    delete normalized.reportingYearDate;
 
     return normalized;
 }
@@ -444,6 +507,7 @@ export function transformDataForCreate(
     formData: any
 ): any {
     let transformed = removeNestedObjects(formData);
+    transformed = normalizeReportingYearDateAlias(transformed);
     transformed = normalizeReportingYearFields(transformed);
     transformed = removeCategoryIfNeeded(entityType, transformed);
     transformed = applyEntityTransformation(entityType, transformed);
@@ -463,6 +527,7 @@ export function transformDataForUpdate(
 ): any {
     let transformed = removeIdField(entityType, idField, formData);
     transformed = removeNestedObjects(transformed);
+    transformed = normalizeReportingYearDateAlias(transformed);
     transformed = normalizeReportingYearFields(transformed);
     transformed = removeCategoryIfNeeded(entityType, transformed);
     transformed = applyEntityTransformation(entityType, transformed);

--- a/frontend/src/utils/formDataExtractors.ts
+++ b/frontend/src/utils/formDataExtractors.ts
@@ -6,6 +6,49 @@
 import { ENTITY_TYPES } from '@/constants/entityConstants';
 import type { ExtendedEntityType } from './masterUtils';
 
+const STRICT_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}(?:T.*)?$/;
+const YEAR_PATTERN = /^\d{4}$/;
+
+function toDateInputValue(value: any): string | null {
+    if (value === null || value === undefined || value === '') return null;
+
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value.toISOString().split('T')[0];
+    }
+
+    if (typeof value === 'number' && Number.isInteger(value) && value >= 1900 && value <= 3000) {
+        return `${value}-01-01`;
+    }
+
+    if (typeof value === 'object') {
+        if (value.reportingYearDate !== undefined) return toDateInputValue(value.reportingYearDate);
+        if (value.reportingYear !== undefined) return toDateInputValue(value.reportingYear);
+        if (value.yearName !== undefined) return toDateInputValue(value.yearName);
+        if (value.year !== undefined) return toDateInputValue(value.year);
+        return null;
+    }
+
+    if (typeof value !== 'string') return null;
+
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    if (YEAR_PATTERN.test(trimmed)) {
+        return `${trimmed}-01-01`;
+    }
+
+    if (!STRICT_DATE_PATTERN.test(trimmed)) {
+        return null;
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+        return trimmed;
+    }
+
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString().split('T')[0];
+}
+
 /**
  * Common nested field extractors that apply to multiple entity types
  */
@@ -23,6 +66,16 @@ const COMMON_EXTRACTORS = {
     kvkId: (item: any, formData: any) => {
         if (item.kvk?.kvkId) {
             formData.kvkId = item.kvk.kvkId;
+        }
+    },
+    reportingYear: (item: any, formData: any) => {
+        const dateValue =
+            toDateInputValue(item.reportingYearDate) ??
+            toDateInputValue(item.reportingYear) ??
+            toDateInputValue(item.year) ??
+            toDateInputValue(item.yearName);
+        if (dateValue) {
+            formData.reportingYear = dateValue;
         }
     },
 };
@@ -304,7 +357,8 @@ const ENTITY_EXTRACTORS: Record<string, (item: any, formData: any) => void> = {
     [ENTITY_TYPES.PROJECT_NATURAL_FARMING_GEO]: (item: any, formData: any) => {
         if (item.startDate) formData.startDate = new Date(item.startDate).toISOString().split('T')[0];
         if (item.endDate) formData.endDate = new Date(item.endDate).toISOString().split('T')[0];
-        if (item.reportingYear) formData.reportingYear = new Date(item.reportingYear).toISOString().split('T')[0];
+        const reportingYear = toDateInputValue(item.reportingYearDate ?? item.reportingYear ?? item.year);
+        if (reportingYear) formData.reportingYear = reportingYear;
     },
     [ENTITY_TYPES.PROJECT_NATURAL_FARMING_PHYSICAL]: (item: any, formData: any) => {
         if (item.trainingDate) formData.trainingDate = new Date(item.trainingDate).toISOString().split('T')[0];
@@ -335,16 +389,14 @@ const ENTITY_EXTRACTORS: Record<string, (item: any, formData: any) => void> = {
         if (item.farmerFeedback) formData.farmersFeedback = item.farmerFeedback;
     },
     [ENTITY_TYPES.PROJECT_NATURAL_FARMING_BENEFICIARIES]: (item: any, formData: any) => {
-        if (item.reportingYear !== undefined) {
-            formData.reportingYear = String(item.reportingYear).slice(0, 10);
-        }
+        const reportingYear = toDateInputValue(item.reportingYearDate ?? item.reportingYear ?? item.year);
+        if (reportingYear) formData.reportingYear = reportingYear;
         if (item.blocksCovered !== undefined) formData.noOfBlocks = item.blocksCovered;
         if (item.villagesCovered !== undefined) formData.noOfVillages = item.villagesCovered;
     },
     [ENTITY_TYPES.PROJECT_NATURAL_FARMING_SOIL]: (item: any, formData: any) => {
-        if (item.reportingYear !== undefined) {
-            formData.reportingYear = String(item.reportingYear).slice(0, 10);
-        }
+        const reportingYear = toDateInputValue(item.reportingYearDate ?? item.reportingYear ?? item.year);
+        if (reportingYear) formData.reportingYear = reportingYear;
         if (item.season?.seasonId) formData.seasonId = item.season.seasonId;
         else if (item.seasonId) formData.seasonId = item.seasonId;
         if (item.phBefore !== undefined) formData.beforePh = item.phBefore;
@@ -363,9 +415,8 @@ const ENTITY_EXTRACTORS: Record<string, (item: any, formData: any) => void> = {
         if (item.soilMicrobesAfter !== undefined) formData.afterMicrobes = item.soilMicrobesAfter;
     },
     [ENTITY_TYPES.PROJECT_NATURAL_FARMING_BUDGET]: (item: any, formData: any) => {
-        if (item.reportingYear !== undefined) {
-            formData.reportingYear = String(item.reportingYear).slice(0, 10);
-        }
+        const reportingYear = toDateInputValue(item.reportingYearDate ?? item.reportingYear ?? item.year);
+        if (reportingYear) formData.reportingYear = reportingYear;
         if (item.activity) formData.activityName = item.activity;
         if (item.numberOfActivities !== undefined) formData.noOfActivities = item.numberOfActivities;
     },


### PR DESCRIPTION
## PR2
App-layer dual read/write for reporting year migration.

## Depends On
- PR1: #78

## Changes
- dual-write canonical date + legacy int year on create/update
- dual-read with fallback for legacy rows
- preserve backwards compatibility while enabling exact date persistence

## Modules Updated
- CFLD budget utilization repository
- Natural Farming repositories (beneficiaries, soil, financial)
- PPV-FRA plant varieties repository
- Target service (accept date/int input + dual-read filter)
- Module image service (accept date/int input + dual-read filter)

## Notes
- base branch is PR1 branch to keep review clean
- after PR1 merges, this PR should be retargeted to `dev`

Refs #76
