### PR TITLE
feat(reports): add OFT report generation (sections 2.1 & 2.2)

### DIFF
--- a/backend/config/reportConfig.js
+++ b/backend/config/reportConfig.js
@@ -248,6 +248,35 @@ const reportConfig = {
                 { dbField: 'presentStatus', displayName: 'Present status' },
             ],
         },
+        // ── OFT (On-Farm Testing) ───────────────────────────────────
+        {
+            id: '2.1',
+            title: 'OFT Summary',
+            description: 'Technology Assessed by KVK - sector-wise thematic area summary',
+            subsection: true,
+            parentSectionId: '2',
+            dataSource: 'oftSummary',
+            format: 'custom',
+            customTemplate: 'oft-summary',
+            filters: {
+                dateFields: ['createdAt'],
+            },
+            fields: [],
+        },
+        {
+            id: '2.2',
+            title: 'OFT Details',
+            description: 'Individual OFT trial detail cards with results',
+            subsection: true,
+            parentSectionId: '2',
+            dataSource: 'oftDetailCards',
+            format: 'custom',
+            customTemplate: 'oft-detail-cards',
+            filters: {
+                dateFields: ['createdAt'],
+            },
+            fields: [],
+        },
     ],
 };
 

--- a/backend/controllers/exportController.js
+++ b/backend/controllers/exportController.js
@@ -32,7 +32,7 @@ const exportData = async (req, res) => {
         switch (format.toLowerCase()) {
             case 'pdf':
                 const html = templateKey
-                    ? generateCustomTemplateHTML(templateKey, rawData, title)
+                    ? await generateCustomTemplateHTML(templateKey, rawData, title)
                     : generateHTML(title, headers, rows);
 
                 buffer = await exportHelper.generatePDF(html);
@@ -63,7 +63,7 @@ const exportData = async (req, res) => {
     }
 };
 
-function generateCustomTemplateHTML(templateKey, rawData, title) {
+async function generateCustomTemplateHTML(templateKey, rawData, title) {
     const normalizedData = Array.isArray(rawData)
         ? rawData
         : (rawData ? [rawData] : []);
@@ -71,7 +71,7 @@ function generateCustomTemplateHTML(templateKey, rawData, title) {
     // Look up the matching section for correct sectionId
     const matchedSection = getAllSections().find(section => section.customTemplate === templateKey);
 
-    return reportTemplateService.generateStandaloneCustomTemplateHTML(
+    return await reportTemplateService.generateStandaloneCustomTemplateHTML(
         templateKey,
         normalizedData,
         {

--- a/backend/controllers/exportController.js
+++ b/backend/controllers/exportController.js
@@ -68,12 +68,16 @@ function generateCustomTemplateHTML(templateKey, rawData, title) {
         ? rawData
         : (rawData ? [rawData] : []);
 
+    // Look up the matching section for correct sectionId
+    const matchedSection = getAllSections().find(section => section.customTemplate === templateKey);
+
     return reportTemplateService.generateStandaloneCustomTemplateHTML(
         templateKey,
         normalizedData,
         {
-            sectionId: '1.1',
-            title,
+            sectionId: matchedSection?.id || '1.1',
+            title: matchedSection?.title || title,
+            customSectionLabel: matchedSection?.customSectionLabel,
         }
     );
 }

--- a/backend/prisma/kvk/achievements/oft_schema.prisma
+++ b/backend/prisma/kvk/achievements/oft_schema.prisma
@@ -50,6 +50,7 @@ model Kvkoft {
   numberOfLocation         Int                @map("number_of_location")
   numberOfTrialReplication Int                @map("number_of_trial_replication")
   oftStartDate             DateTime           @map("oft_start_date")
+  oftEndDate               DateTime?          @map("oft_end_date")
   criticalInput            String             @map("critical_input")
   costOfOft                Float              @map("cost_of_oft")
   farmersGeneralM          Int                @map("farmers_general_m")

--- a/backend/prisma/migrations/20260403120000_add_oft_end_date/migration.sql
+++ b/backend/prisma/migrations/20260403120000_add_oft_end_date/migration.sql
@@ -1,0 +1,2 @@
+-- Add optional end date for OFT trials
+ALTER TABLE "kvk_oft" ADD COLUMN IF NOT EXISTS "oft_end_date" TIMESTAMP(3);

--- a/backend/repositories/reports/oftReport/index.js
+++ b/backend/repositories/reports/oftReport/index.js
@@ -1,0 +1,6 @@
+const { getOftSummaryData, getOftDetailCards } = require('./oftReportRepository.js');
+
+module.exports = {
+    getOftSummaryData,
+    getOftDetailCards,
+};

--- a/backend/repositories/reports/oftReport/index.js
+++ b/backend/repositories/reports/oftReport/index.js
@@ -1,6 +1,7 @@
-const { getOftSummaryData, getOftDetailCards } = require('./oftReportRepository.js');
+const { getOftSummaryData, getOftDetailCards, getOftSubjectsWithThematicAreas } = require('./oftReportRepository.js');
 
 module.exports = {
     getOftSummaryData,
     getOftDetailCards,
+    getOftSubjectsWithThematicAreas,
 };

--- a/backend/repositories/reports/oftReport/oftReportRepository.js
+++ b/backend/repositories/reports/oftReport/oftReportRepository.js
@@ -1,0 +1,100 @@
+const prisma = require('../../../config/prisma.js');
+const { applyCreatedAtFilters } = require('../aboutkvkReport/commonFilters.js');
+
+async function getOftSummaryData(kvkId, filters = {}) {
+    const where = { kvkId };
+    applyCreatedAtFilters(where, filters);
+
+    return await prisma.kvkoft.findMany({
+        where,
+        select: {
+            kvkOftId: true,
+            numberOfLocation: true,
+            numberOfTrialReplication: true,
+            oftSubjectId: true,
+            oftThematicAreaId: true,
+            oftSubject: {
+                select: { oftSubjectId: true, subjectName: true },
+            },
+            oftThematicArea: {
+                select: { oftThematicAreaId: true, thematicAreaName: true },
+            },
+            kvk: {
+                select: {
+                    kvkId: true,
+                    kvkName: true,
+                    stateId: true,
+                    state: {
+                        select: { stateId: true, stateName: true },
+                    },
+                },
+            },
+        },
+        orderBy: [
+            { oftSubject: { subjectName: 'asc' } },
+            { oftThematicArea: { thematicAreaName: 'asc' } },
+        ],
+    });
+}
+
+async function getOftDetailCards(kvkId, filters = {}) {
+    const where = { kvkId };
+    applyCreatedAtFilters(where, filters);
+
+    return await prisma.kvkoft.findMany({
+        where,
+        include: {
+            kvk: {
+                select: { kvkId: true, kvkName: true },
+            },
+            discipline: {
+                select: { disciplineId: true, disciplineName: true },
+            },
+            oftSubject: {
+                select: { oftSubjectId: true, subjectName: true },
+            },
+            oftThematicArea: {
+                select: { oftThematicAreaId: true, thematicAreaName: true },
+            },
+            season: {
+                select: { seasonId: true, seasonName: true },
+            },
+            technologies: {
+                orderBy: { optionKey: 'asc' },
+                include: {
+                    oftTechnologyType: {
+                        select: { name: true },
+                    },
+                },
+            },
+            resultReport: {
+                include: {
+                    tables: {
+                        orderBy: { sortOrder: 'asc' },
+                        include: {
+                            columns: {
+                                orderBy: { sortOrder: 'asc' },
+                            },
+                            rows: {
+                                orderBy: { sortOrder: 'asc' },
+                                include: {
+                                    cells: true,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        orderBy: [
+            { discipline: { disciplineName: 'asc' } },
+            { oftThematicArea: { thematicAreaName: 'asc' } },
+            { title: 'asc' },
+        ],
+    });
+}
+
+module.exports = {
+    getOftSummaryData,
+    getOftDetailCards,
+};

--- a/backend/repositories/reports/oftReport/oftReportRepository.js
+++ b/backend/repositories/reports/oftReport/oftReportRepository.js
@@ -94,7 +94,24 @@ async function getOftDetailCards(kvkId, filters = {}) {
     });
 }
 
+/**
+ * Get all OFT subjects with their thematic areas (master data).
+ * Used to render ALL rows in the summary table even with 0 data.
+ */
+async function getOftSubjectsWithThematicAreas() {
+    return await prisma.oftSubject.findMany({
+        include: {
+            thematicAreas: {
+                select: { oftThematicAreaId: true, thematicAreaName: true },
+                orderBy: { thematicAreaName: 'asc' },
+            },
+        },
+        orderBy: { subjectName: 'asc' },
+    });
+}
+
 module.exports = {
     getOftSummaryData,
     getOftDetailCards,
+    getOftSubjectsWithThematicAreas,
 };

--- a/backend/services/reports/formsTemplate/oftTemplates/oftCombinedTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftCombinedTemplate.js
@@ -1,0 +1,44 @@
+/**
+ * OFT Combined Template
+ *
+ * Renders BOTH Section 2.1 (Summary) and Section 2.2 (Detail Cards)
+ * in a single PDF, matching the original ATARI website KVK-side report.
+ *
+ * Used by the module-level export (DataManagementView → exportController).
+ * The all-reports flow uses the individual templates separately.
+ *
+ * Bound to reportTemplateService (`this`).
+ */
+
+const { renderOftSummarySection } = require('./oftSummaryTemplate.js');
+const { renderOftDetailCardsSection } = require('./oftDetailCardsTemplate.js');
+
+function renderOftCombinedSection(section, data, sectionId, isFirstSection) {
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+        return this._generateEmptySection(section, null, sectionId, isFirstSection);
+    }
+
+    const records = Array.isArray(data) ? data : [data];
+
+    // Section 2.1 — OFT Summary
+    const summaryHtml = renderOftSummarySection.call(
+        this,
+        { id: '2.1', title: 'OFT Summary' },
+        records,
+        'section-2-1',
+        isFirstSection
+    );
+
+    // Section 2.2 — OFT Detail Cards
+    const detailHtml = renderOftDetailCardsSection.call(
+        this,
+        { id: '2.2', title: 'OFT' },
+        records,
+        'section-2-2',
+        false
+    );
+
+    return summaryHtml + detailHtml;
+}
+
+module.exports = { renderOftCombinedSection };

--- a/backend/services/reports/formsTemplate/oftTemplates/oftCombinedTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftCombinedTemplate.js
@@ -5,26 +5,35 @@
  * in a single PDF, matching the original ATARI website KVK-side report.
  *
  * Used by the module-level export (DataManagementView → exportController).
- * The all-reports flow uses the individual templates separately.
+ * Fetches OFT subjects from DB so the summary shows all thematic areas.
  *
  * Bound to reportTemplateService (`this`).
  */
 
 const { renderOftSummarySection } = require('./oftSummaryTemplate.js');
 const { renderOftDetailCardsSection } = require('./oftDetailCardsTemplate.js');
+const { getOftSubjectsWithThematicAreas } = require('../../../../repositories/reports/oftReport/index.js');
 
-function renderOftCombinedSection(section, data, sectionId, isFirstSection) {
+async function renderOftCombinedSection(section, data, sectionId, isFirstSection) {
     if (!data || (Array.isArray(data) && data.length === 0)) {
         return this._generateEmptySection(section, null, sectionId, isFirstSection);
     }
 
     const records = Array.isArray(data) ? data : [data];
 
-    // Section 2.1 — OFT Summary
+    // Fetch subjects from DB for the summary to show all thematic areas
+    let subjects = [];
+    try {
+        subjects = await getOftSubjectsWithThematicAreas();
+    } catch (e) {
+        // If DB fetch fails, summary will still work with data-driven areas
+    }
+
+    // Section 2.1 — OFT Summary (pass { records, subjects })
     const summaryHtml = renderOftSummarySection.call(
         this,
         { id: '2.1', title: 'OFT Summary' },
-        records,
+        { records, subjects },
         'section-2-1',
         isFirstSection
     );

--- a/backend/services/reports/formsTemplate/oftTemplates/oftDetailCardsTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftDetailCardsTemplate.js
@@ -1,17 +1,16 @@
 /**
  * OFT Detail Cards Template (Section 2.2)
  *
- * Renders individual OFT trial cards with 16 labeled fields and dynamic
- * result tables. Supports both single-KVK and multi-KVK (superadmin) views.
+ * Renders individual OFT trial cards matching the original ATARI website layout:
+ *   - Card header: "2.2.N. OFT (Discipline)" with bullet-style thematic area
+ *     and problem definition lines
+ *   - 16 fields in a 2-column table (# + label | value), no header row
+ *   - Result tables with "Tehcnology Options | Proposed | Actual | …" columns
+ *   - Superadmin: cards grouped under large centered KVK name headings
  *
- * Bound to reportTemplateService instance — uses this._escapeHtml(),
- * this._generateEmptySection(), this._toDisplayValue().
+ * Bound to reportTemplateService (`this`).
  */
 
-/**
- * Format a date value as "Mon YYYY" (e.g., "Feb 2024").
- * Returns '-' when the input is falsy or unparseable.
- */
 function _formatMonthYear(dateValue) {
     if (!dateValue) return '-'
     const d = new Date(dateValue)
@@ -23,41 +22,26 @@ function _formatMonthYear(dateValue) {
     return `${months[d.getMonth()]} ${d.getFullYear()}`
 }
 
-/**
- * Build the "Details of technologies selected" display string from the
- * technologies array.  FP → "Farmer Practice", everything else keeps its
- * optionName (TO1, TO2, …).
- */
 function _formatTechnologies(technologies) {
     if (!Array.isArray(technologies) || technologies.length === 0) return '-'
-
-    const lines = technologies.map(tech => {
-        const label = tech.optionKey === 'FP' ? 'Farmer Practice' : (tech.optionName || tech.optionKey || '-')
-        const details = tech.details || '-'
-        return `${label}: ${details}`
-    })
-
-    return lines.join('\n')
+    return technologies.map(tech => {
+        const label = tech.optionKey === 'FP'
+            ? 'Farmer Practice'
+            : (tech.optionName || tech.optionKey || '-')
+        return `${label}:${tech.details || '-'}`
+    }).join('\n')
 }
 
-/**
- * Group an array of records by kvk.kvkName, preserving insertion order.
- */
 function _groupByKvk(records) {
     const map = new Map()
-    for (const record of records) {
-        const kvkName = (record.kvk && record.kvk.kvkName) || 'Unknown KVK'
-        if (!map.has(kvkName)) {
-            map.set(kvkName, [])
-        }
-        map.get(kvkName).push(record)
+    for (const r of records) {
+        const name = (r.kvk && r.kvk.kvkName) || 'Unknown KVK'
+        if (!map.has(name)) map.set(name, [])
+        map.get(name).push(r)
     }
     return map
 }
 
-/**
- * Determine whether the dataset spans multiple KVKs (superadmin scope).
- */
 function _isMultiKvk(records) {
     const names = new Set()
     for (const r of records) {
@@ -68,7 +52,7 @@ function _isMultiKvk(records) {
     return false
 }
 
-// ─── Main renderer ───────────────────────────────────────────────────────────
+// ─── Main renderer ──────────────────────────────────────────────────────────
 
 function renderOftDetailCardsSection(section, data, sectionId, isFirstSection) {
     if (!data || (Array.isArray(data) && data.length === 0)) {
@@ -86,7 +70,7 @@ function renderOftDetailCardsSection(section, data, sectionId, isFirstSection) {
 
     let html = `
 <div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>`
+    <h1 class="section-title">${section.id} OFT</h1>`
 
     const multiKvk = _isMultiKvk(records)
     let cardIndex = 0
@@ -95,9 +79,9 @@ function renderOftDetailCardsSection(section, data, sectionId, isFirstSection) {
         const grouped = _groupByKvk(records)
         for (const [kvkName, kvkRecords] of grouped) {
             html += `
-    <h2 style="margin-top:24px;margin-bottom:12px;font-size:14px;font-weight:bold;color:#1a1a1a;">
-        KVK ${this._escapeHtml(kvkName)}
-    </h2>`
+    <div style="text-align:center;margin:32px 0 20px 0;">
+        <h2 style="font-size:16px;font-weight:bold;color:#000;margin:0;">${this._escapeHtml(kvkName)}</h2>
+    </div>`
             for (const record of kvkRecords) {
                 cardIndex++
                 html += _renderCard.call(this, record, cardIndex)
@@ -116,46 +100,43 @@ function renderOftDetailCardsSection(section, data, sectionId, isFirstSection) {
     return html
 }
 
-// ─── Single card renderer ────────────────────────────────────────────────────
+// ─── Single card ────────────────────────────────────────────────────────────
 
 function _renderCard(record, cardNumber) {
-    const esc = (v) => this._escapeHtml(this._toDisplayValue(v))
+    const esc = (v) => this._escapeHtml(v != null && v !== '' ? String(v) : '-')
     const resultReport = record.resultReport || {}
 
     const disciplineName = (record.discipline && record.discipline.disciplineName) || '-'
     const thematicAreaName = (record.oftThematicArea && record.oftThematicArea.thematicAreaName) || '-'
     const title = record.title || '-'
 
-    // Card header
+    // Card header — matches original: bold numbered title, bullet-style sub-lines
     let html = `
-    <div style="page-break-inside:avoid;margin-bottom:28px;border:1px solid #ccc;border-radius:4px;padding:16px;">
-        <h3 style="margin:0 0 4px 0;font-size:13px;font-weight:bold;color:#333;">
-            2.2.${cardNumber}. OFT (${esc(disciplineName)})
-        </h3>
-        <p style="margin:0 0 2px 0;font-size:12px;color:#555;">
-            Thematic area: ${esc(thematicAreaName)}
+    <div style="margin-bottom:28px;">
+        <p style="margin:0 0 6px 0;font-size:11px;font-weight:bold;">
+            ${section_id(cardNumber)} OFT (${esc(disciplineName)})
         </p>
-        <p style="margin:0 0 12px 0;font-size:12px;color:#555;">
-            Problem definition/Name of OFT: ${esc(title)}
+        <p style="margin:0 0 2px 0;font-size:10px;">
+            &bull; <strong>Thematic area:</strong> ${esc(thematicAreaName)}
+        </p>
+        <p style="margin:0 0 12px 0;font-size:10px;">
+            &bull; <strong>Problem definition/Name of OFT:</strong> ${esc(title)}
         </p>`
 
-    // 16-field key-value table
+    // 16-field table — 2 columns, no header row, number inline with label
     const techDetails = _formatTechnologies(record.technologies)
 
     const fields = [
         ['Title of On farm Trial', record.title],
         ['Problem diagnosed', record.problemDiagnosed],
-        [
-            'Details of technologies selected for assessment/refinement (Mention either Assessed)',
-            techDetails,
-        ],
+        ['Details of technologies selected for assessment/refinement (Mention either Assessed)', techDetails],
         ['Source of Technology (ICAR/ AICRP/SAU/other, please specify)', record.sourceOfTechnology],
         ['Production system', record.productionSystem],
         ['Thematic area', thematicAreaName],
         ['Performance indicators of the technology', record.performanceIndicators],
-        ['Final recommendation for micro level situation', resultReport.finalRecommendation || '-'],
-        ['Constraints identified and feedback for research', resultReport.constraintsFeedback || '-'],
-        ['Process of farmers participation and their reaction', resultReport.farmersParticipationProcess || '-'],
+        ['Final recommendation for micro level situation', resultReport.finalRecommendation],
+        ['Constraints identified and feedback for research', resultReport.constraintsFeedback],
+        ['Process of farmers participation and their reaction', resultReport.farmersParticipationProcess],
         ['Area (ha)/ No of units', record.areaHaNumber],
         ['No. of Trial/Replication', record.numberOfTrialReplication],
         ['OFT Start on', _formatMonthYear(record.oftStartDate)],
@@ -166,28 +147,18 @@ function _renderCard(record, cardNumber) {
 
     html += `
         <table class="data-table" style="width:100%;margin-bottom:16px;">
-            <thead>
-                <tr>
-                    <th style="width:30px;text-align:center;">Sl.</th>
-                    <th style="width:40%;">Particulars</th>
-                    <th>Details</th>
-                </tr>
-            </thead>
             <tbody>`
 
     fields.forEach(([label, value], idx) => {
-        const rowClass = idx % 2 === 0 ? 'even' : 'odd'
-        const displayValue = (value !== null && value !== undefined && value !== '')
-            ? String(value)
-            : '-'
-        // Preserve newlines in the technology details field
+        const displayValue = (value != null && value !== '') ? String(value) : '-'
         const escapedValue = this._escapeHtml(displayValue).replace(/\n/g, '<br/>')
 
         html += `
-                <tr class="${rowClass}">
-                    <td style="text-align:center;">${idx + 1}.</td>
-                    <td>${this._escapeHtml(label)}</td>
-                    <td>${escapedValue}</td>
+                <tr class="${idx % 2 === 0 ? 'even' : 'odd'}">
+                    <td style="width:45%;vertical-align:top;padding:5px 6px;">
+                        <strong>${idx + 1}.</strong>&nbsp;&nbsp;${this._escapeHtml(label)}
+                    </td>
+                    <td style="vertical-align:top;padding:5px 6px;">${escapedValue}</td>
                 </tr>`
     })
 
@@ -204,31 +175,36 @@ function _renderCard(record, cardNumber) {
     return html
 }
 
-// ─── Results section (tables + result text) ──────────────────────────────────
+function section_id(n) {
+    return `2.2.${n}.`
+}
+
+// ─── Results section ────────────────────────────────────────────────────────
 
 function _renderResultsSection(resultReport) {
     if (!resultReport) return ''
 
+    const tables = resultReport.tables
+    const hasContent = (Array.isArray(tables) && tables.length > 0) || resultReport.resultText
+
+    if (!hasContent) return ''
+
     let html = `
         <div style="margin-top:12px;">
-            <h4 style="margin:0 0 8px 0;font-size:12px;font-weight:bold;">
+            <p style="margin:0 0 8px 0;font-size:11px;font-weight:bold;">
                 B. Results with Table and good quality photographs in jpg.
-            </h4>`
+            </p>`
 
-    const tables = resultReport.tables
     if (Array.isArray(tables) && tables.length > 0) {
-        // Sort tables by sortOrder if available
         const sorted = [...tables].sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
-
         sorted.forEach((table, tIdx) => {
             html += _renderResultTable.call(this, table, tIdx + 1)
         })
     }
 
-    // Result text
     if (resultReport.resultText) {
         html += `
-            <p style="margin:8px 0 0 0;font-size:11px;">
+            <p style="margin:8px 0 0 0;font-size:10px;">
                 <strong>Result:</strong> ${this._escapeHtml(resultReport.resultText)}
             </p>`
     }
@@ -245,24 +221,41 @@ function _renderResultTable(table, tableNumber) {
 
     if (columns.length === 0 && rows.length === 0) return ''
 
-    // Sort columns and rows by sortOrder
     columns.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
     rows.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
+
+    // Separate "Proposed" and "Actual" columns from the rest
+    const proposedCol = columns.find(c =>
+        (c.columnLabel || '').toLowerCase() === 'proposed' ||
+        (c.columnKey || '').toLowerCase() === 'proposed'
+    )
+    const actualCol = columns.find(c =>
+        (c.columnLabel || '').toLowerCase() === 'actual' ||
+        (c.columnKey || '').toLowerCase() === 'actual'
+    )
+    const dataColumns = columns.filter(c => c !== proposedCol && c !== actualCol)
 
     const tableTitle = table.tableTitle || ''
 
     let html = `
-            <p style="margin:12px 0 4px 0;font-size:11px;font-weight:bold;">
+            <p style="margin:12px 0 4px 0;font-size:10px;font-weight:bold;">
                 Table ${tableNumber} : ${this._escapeHtml(tableTitle)}
             </p>
-            <table class="data-table" style="width:100%;margin-bottom:12px;">
+            <table class="data-table" style="width:100%;margin-bottom:12px;font-size:8pt;">
                 <thead>
                     <tr>
-                        <th>Technology Options</th>`
+                        <th>Tehcnology Options</th>`
 
-    for (const col of columns) {
-        html += `
-                        <th>${this._escapeHtml(col.columnLabel || col.columnKey || '-')}</th>`
+    // "Proposed" and "Actual" columns come right after Technology Options
+    if (proposedCol) {
+        html += `<th>${this._escapeHtml(proposedCol.columnLabel || 'Proposed')}</th>`
+    }
+    if (actualCol) {
+        html += `<th>${this._escapeHtml(actualCol.columnLabel || 'Actual')}</th>`
+    }
+
+    for (const col of dataColumns) {
+        html += `<th>${this._escapeHtml(col.columnLabel || col.columnKey || '-')}</th>`
     }
 
     html += `
@@ -270,15 +263,15 @@ function _renderResultTable(table, tableNumber) {
                 </thead>
                 <tbody>`
 
+    // Build ordered column list for cell rendering
+    const orderedColumns = []
+    if (proposedCol) orderedColumns.push(proposedCol)
+    if (actualCol) orderedColumns.push(actualCol)
+    orderedColumns.push(...dataColumns)
+
     rows.forEach((row, rIdx) => {
-        const rowClass = rIdx % 2 === 0 ? 'even' : 'odd'
         const rowLabel = row.rowLabel || row.optionKey || '-'
 
-        html += `
-                    <tr class="${rowClass}">
-                        <td>${this._escapeHtml(rowLabel)}</td>`
-
-        // Build a map from column ID to cell value for fast lookup
         const cellMap = new Map()
         if (Array.isArray(row.cells)) {
             for (const cell of row.cells) {
@@ -288,17 +281,17 @@ function _renderResultTable(table, tableNumber) {
             }
         }
 
-        for (const col of columns) {
+        html += `
+                    <tr class="${rIdx % 2 === 0 ? 'even' : 'odd'}">
+                        <td>${this._escapeHtml(rowLabel)}</td>`
+
+        for (const col of orderedColumns) {
             const cellValue = cellMap.get(col.oftResultTableColumnId)
-            const display = (cellValue !== null && cellValue !== undefined && cellValue !== '')
-                ? String(cellValue)
-                : '-'
-            html += `
-                        <td>${this._escapeHtml(display)}</td>`
+            const display = (cellValue != null && cellValue !== '') ? String(cellValue) : '-'
+            html += `<td>${this._escapeHtml(display)}</td>`
         }
 
-        html += `
-                    </tr>`
+        html += `</tr>`
     })
 
     html += `

--- a/backend/services/reports/formsTemplate/oftTemplates/oftDetailCardsTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftDetailCardsTemplate.js
@@ -1,0 +1,313 @@
+/**
+ * OFT Detail Cards Template (Section 2.2)
+ *
+ * Renders individual OFT trial cards with 16 labeled fields and dynamic
+ * result tables. Supports both single-KVK and multi-KVK (superadmin) views.
+ *
+ * Bound to reportTemplateService instance — uses this._escapeHtml(),
+ * this._generateEmptySection(), this._toDisplayValue().
+ */
+
+/**
+ * Format a date value as "Mon YYYY" (e.g., "Feb 2024").
+ * Returns '-' when the input is falsy or unparseable.
+ */
+function _formatMonthYear(dateValue) {
+    if (!dateValue) return '-'
+    const d = new Date(dateValue)
+    if (isNaN(d.getTime())) return '-'
+    const months = [
+        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ]
+    return `${months[d.getMonth()]} ${d.getFullYear()}`
+}
+
+/**
+ * Build the "Details of technologies selected" display string from the
+ * technologies array.  FP → "Farmer Practice", everything else keeps its
+ * optionName (TO1, TO2, …).
+ */
+function _formatTechnologies(technologies) {
+    if (!Array.isArray(technologies) || technologies.length === 0) return '-'
+
+    const lines = technologies.map(tech => {
+        const label = tech.optionKey === 'FP' ? 'Farmer Practice' : (tech.optionName || tech.optionKey || '-')
+        const details = tech.details || '-'
+        return `${label}: ${details}`
+    })
+
+    return lines.join('\n')
+}
+
+/**
+ * Group an array of records by kvk.kvkName, preserving insertion order.
+ */
+function _groupByKvk(records) {
+    const map = new Map()
+    for (const record of records) {
+        const kvkName = (record.kvk && record.kvk.kvkName) || 'Unknown KVK'
+        if (!map.has(kvkName)) {
+            map.set(kvkName, [])
+        }
+        map.get(kvkName).push(record)
+    }
+    return map
+}
+
+/**
+ * Determine whether the dataset spans multiple KVKs (superadmin scope).
+ */
+function _isMultiKvk(records) {
+    const names = new Set()
+    for (const r of records) {
+        const name = (r.kvk && r.kvk.kvkName) || ''
+        if (name) names.add(name)
+        if (names.size > 1) return true
+    }
+    return false
+}
+
+// ─── Main renderer ───────────────────────────────────────────────────────────
+
+function renderOftDetailCardsSection(section, data, sectionId, isFirstSection) {
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+        return this._generateEmptySection(section, null, sectionId, isFirstSection)
+    }
+
+    const records = Array.isArray(data) ? data : [data]
+    if (records.length === 0) {
+        return this._generateEmptySection(section, null, sectionId, isFirstSection)
+    }
+
+    const pageClass = isFirstSection
+        ? 'section-page section-page-first'
+        : 'section-page section-page-continued'
+
+    let html = `
+<div id="${sectionId}" class="${pageClass}">
+    <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>`
+
+    const multiKvk = _isMultiKvk(records)
+    let cardIndex = 0
+
+    if (multiKvk) {
+        const grouped = _groupByKvk(records)
+        for (const [kvkName, kvkRecords] of grouped) {
+            html += `
+    <h2 style="margin-top:24px;margin-bottom:12px;font-size:14px;font-weight:bold;color:#1a1a1a;">
+        KVK ${this._escapeHtml(kvkName)}
+    </h2>`
+            for (const record of kvkRecords) {
+                cardIndex++
+                html += _renderCard.call(this, record, cardIndex)
+            }
+        }
+    } else {
+        for (const record of records) {
+            cardIndex++
+            html += _renderCard.call(this, record, cardIndex)
+        }
+    }
+
+    html += `
+</div>`
+
+    return html
+}
+
+// ─── Single card renderer ────────────────────────────────────────────────────
+
+function _renderCard(record, cardNumber) {
+    const esc = (v) => this._escapeHtml(this._toDisplayValue(v))
+    const resultReport = record.resultReport || {}
+
+    const disciplineName = (record.discipline && record.discipline.disciplineName) || '-'
+    const thematicAreaName = (record.oftThematicArea && record.oftThematicArea.thematicAreaName) || '-'
+    const title = record.title || '-'
+
+    // Card header
+    let html = `
+    <div style="page-break-inside:avoid;margin-bottom:28px;border:1px solid #ccc;border-radius:4px;padding:16px;">
+        <h3 style="margin:0 0 4px 0;font-size:13px;font-weight:bold;color:#333;">
+            2.2.${cardNumber}. OFT (${esc(disciplineName)})
+        </h3>
+        <p style="margin:0 0 2px 0;font-size:12px;color:#555;">
+            Thematic area: ${esc(thematicAreaName)}
+        </p>
+        <p style="margin:0 0 12px 0;font-size:12px;color:#555;">
+            Problem definition/Name of OFT: ${esc(title)}
+        </p>`
+
+    // 16-field key-value table
+    const techDetails = _formatTechnologies(record.technologies)
+
+    const fields = [
+        ['Title of On farm Trial', record.title],
+        ['Problem diagnosed', record.problemDiagnosed],
+        [
+            'Details of technologies selected for assessment/refinement (Mention either Assessed)',
+            techDetails,
+        ],
+        ['Source of Technology (ICAR/ AICRP/SAU/other, please specify)', record.sourceOfTechnology],
+        ['Production system', record.productionSystem],
+        ['Thematic area', thematicAreaName],
+        ['Performance indicators of the technology', record.performanceIndicators],
+        ['Final recommendation for micro level situation', resultReport.finalRecommendation || '-'],
+        ['Constraints identified and feedback for research', resultReport.constraintsFeedback || '-'],
+        ['Process of farmers participation and their reaction', resultReport.farmersParticipationProcess || '-'],
+        ['Area (ha)/ No of units', record.areaHaNumber],
+        ['No. of Trial/Replication', record.numberOfTrialReplication],
+        ['OFT Start on', _formatMonthYear(record.oftStartDate)],
+        ['OFT End on', _formatMonthYear(record.oftEndDate)],
+        ['Critical Input', record.criticalInput],
+        ['Cost of OFT', record.costOfOft],
+    ]
+
+    html += `
+        <table class="data-table" style="width:100%;margin-bottom:16px;">
+            <thead>
+                <tr>
+                    <th style="width:30px;text-align:center;">Sl.</th>
+                    <th style="width:40%;">Particulars</th>
+                    <th>Details</th>
+                </tr>
+            </thead>
+            <tbody>`
+
+    fields.forEach(([label, value], idx) => {
+        const rowClass = idx % 2 === 0 ? 'even' : 'odd'
+        const displayValue = (value !== null && value !== undefined && value !== '')
+            ? String(value)
+            : '-'
+        // Preserve newlines in the technology details field
+        const escapedValue = this._escapeHtml(displayValue).replace(/\n/g, '<br/>')
+
+        html += `
+                <tr class="${rowClass}">
+                    <td style="text-align:center;">${idx + 1}.</td>
+                    <td>${this._escapeHtml(label)}</td>
+                    <td>${escapedValue}</td>
+                </tr>`
+    })
+
+    html += `
+            </tbody>
+        </table>`
+
+    // Results section
+    html += _renderResultsSection.call(this, resultReport)
+
+    html += `
+    </div>`
+
+    return html
+}
+
+// ─── Results section (tables + result text) ──────────────────────────────────
+
+function _renderResultsSection(resultReport) {
+    if (!resultReport) return ''
+
+    let html = `
+        <div style="margin-top:12px;">
+            <h4 style="margin:0 0 8px 0;font-size:12px;font-weight:bold;">
+                B. Results with Table and good quality photographs in jpg.
+            </h4>`
+
+    const tables = resultReport.tables
+    if (Array.isArray(tables) && tables.length > 0) {
+        // Sort tables by sortOrder if available
+        const sorted = [...tables].sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
+
+        sorted.forEach((table, tIdx) => {
+            html += _renderResultTable.call(this, table, tIdx + 1)
+        })
+    }
+
+    // Result text
+    if (resultReport.resultText) {
+        html += `
+            <p style="margin:8px 0 0 0;font-size:11px;">
+                <strong>Result:</strong> ${this._escapeHtml(resultReport.resultText)}
+            </p>`
+    }
+
+    html += `
+        </div>`
+
+    return html
+}
+
+function _renderResultTable(table, tableNumber) {
+    const columns = Array.isArray(table.columns) ? [...table.columns] : []
+    const rows = Array.isArray(table.rows) ? [...table.rows] : []
+
+    if (columns.length === 0 && rows.length === 0) return ''
+
+    // Sort columns and rows by sortOrder
+    columns.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
+    rows.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
+
+    const tableTitle = table.tableTitle || ''
+
+    let html = `
+            <p style="margin:12px 0 4px 0;font-size:11px;font-weight:bold;">
+                Table ${tableNumber} : ${this._escapeHtml(tableTitle)}
+            </p>
+            <table class="data-table" style="width:100%;margin-bottom:12px;">
+                <thead>
+                    <tr>
+                        <th>Technology Options</th>`
+
+    for (const col of columns) {
+        html += `
+                        <th>${this._escapeHtml(col.columnLabel || col.columnKey || '-')}</th>`
+    }
+
+    html += `
+                    </tr>
+                </thead>
+                <tbody>`
+
+    rows.forEach((row, rIdx) => {
+        const rowClass = rIdx % 2 === 0 ? 'even' : 'odd'
+        const rowLabel = row.rowLabel || row.optionKey || '-'
+
+        html += `
+                    <tr class="${rowClass}">
+                        <td>${this._escapeHtml(rowLabel)}</td>`
+
+        // Build a map from column ID to cell value for fast lookup
+        const cellMap = new Map()
+        if (Array.isArray(row.cells)) {
+            for (const cell of row.cells) {
+                if (cell.oftResultTableColumnId !== undefined) {
+                    cellMap.set(cell.oftResultTableColumnId, cell.value)
+                }
+            }
+        }
+
+        for (const col of columns) {
+            const cellValue = cellMap.get(col.oftResultTableColumnId)
+            const display = (cellValue !== null && cellValue !== undefined && cellValue !== '')
+                ? String(cellValue)
+                : '-'
+            html += `
+                        <td>${this._escapeHtml(display)}</td>`
+        }
+
+        html += `
+                    </tr>`
+    })
+
+    html += `
+                </tbody>
+            </table>`
+
+    return html
+}
+
+module.exports = {
+    renderOftDetailCardsSection,
+}

--- a/backend/services/reports/formsTemplate/oftTemplates/oftDetailCardsTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftDetailCardsTemplate.js
@@ -1,306 +1,312 @@
 /**
  * OFT Detail Cards Template (Section 2.2)
  *
- * Renders individual OFT trial cards matching the original ATARI website layout:
- *   - Card header: "2.2.N. OFT (Discipline)" with bullet-style thematic area
- *     and problem definition lines
- *   - 16 fields in a 2-column table (# + label | value), no header row
- *   - Result tables with "Tehcnology Options | Proposed | Actual | …" columns
- *   - Superadmin: cards grouped under large centered KVK name headings
+ * Matches the original ATARI website layout exactly:
+ *   - "2.2. OFT" heading
+ *   - Superadmin: large centered bold KVK name headings
+ *   - Card header: "2.2.N. OFT (Discipline)"
+ *   - Bullet lines: • Thematic area: … / • Problem definition/Name of OFT: …
+ *   - 16 fields in 3-column table: narrow # | bold label | value (NO header row)
+ *   - Technology field 3: bold option names (Farmer Practice:, TO1:, TO2:)
+ *   - Result table: "Tehcnology Options | Proposed | Actual | …" (original spelling)
+ *   - Result: text paragraph after table
  *
  * Bound to reportTemplateService (`this`).
  */
 
 function _formatMonthYear(dateValue) {
-    if (!dateValue) return '-'
-    const d = new Date(dateValue)
-    if (isNaN(d.getTime())) return '-'
-    const months = [
-        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
-    ]
-    return `${months[d.getMonth()]} ${d.getFullYear()}`
+    if (!dateValue) return '-';
+    const d = new Date(dateValue);
+    if (isNaN(d.getTime())) return '-';
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    return `${months[d.getMonth()]} ${d.getFullYear()}`;
 }
 
-function _formatTechnologies(technologies) {
-    if (!Array.isArray(technologies) || technologies.length === 0) return '-'
+/**
+ * Format technologies with bold option names matching original:
+ * **Farmer Practice:**details
+ * **TO1:**details
+ * **TO2:**details
+ */
+function _formatTechnologiesHtml(technologies, escapeHtml) {
+    if (!Array.isArray(technologies) || technologies.length === 0) return '-';
     return technologies.map(tech => {
         const label = tech.optionKey === 'FP'
             ? 'Farmer Practice'
-            : (tech.optionName || tech.optionKey || '-')
-        return `${label}:${tech.details || '-'}`
-    }).join('\n')
+            : (tech.optionName || tech.optionKey || '-');
+        const details = tech.details || '';
+        return `<strong>${escapeHtml(label)}:</strong>${escapeHtml(details)}`;
+    }).join('<br/>');
 }
 
 function _groupByKvk(records) {
-    const map = new Map()
+    const map = new Map();
     for (const r of records) {
-        const name = (r.kvk && r.kvk.kvkName) || 'Unknown KVK'
-        if (!map.has(name)) map.set(name, [])
-        map.get(name).push(r)
+        const name = (r.kvk && r.kvk.kvkName) || 'Unknown KVK';
+        if (!map.has(name)) map.set(name, []);
+        map.get(name).push(r);
     }
-    return map
+    return map;
 }
 
 function _isMultiKvk(records) {
-    const names = new Set()
+    const names = new Set();
     for (const r of records) {
-        const name = (r.kvk && r.kvk.kvkName) || ''
-        if (name) names.add(name)
-        if (names.size > 1) return true
+        const name = (r.kvk && r.kvk.kvkName) || '';
+        if (name) names.add(name);
+        if (names.size > 1) return true;
     }
-    return false
+    return false;
 }
 
 // ─── Main renderer ──────────────────────────────────────────────────────────
 
 function renderOftDetailCardsSection(section, data, sectionId, isFirstSection) {
     if (!data || (Array.isArray(data) && data.length === 0)) {
-        return this._generateEmptySection(section, null, sectionId, isFirstSection)
+        return this._generateEmptySection(section, null, sectionId, isFirstSection);
     }
 
-    const records = Array.isArray(data) ? data : [data]
+    const records = Array.isArray(data) ? data : [data];
     if (records.length === 0) {
-        return this._generateEmptySection(section, null, sectionId, isFirstSection)
+        return this._generateEmptySection(section, null, sectionId, isFirstSection);
     }
 
     const pageClass = isFirstSection
         ? 'section-page section-page-first'
-        : 'section-page section-page-continued'
+        : 'section-page section-page-continued';
 
     let html = `
 <div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title">${section.id} OFT</h1>`
+    <h1 class="section-title" style="font-size:12px;font-weight:bold;border-bottom:none;margin-bottom:16px;">2.2. OFT</h1>`;
 
-    const multiKvk = _isMultiKvk(records)
-    let cardIndex = 0
+    const multiKvk = _isMultiKvk(records);
+    let cardIndex = 0;
 
     if (multiKvk) {
-        const grouped = _groupByKvk(records)
+        const grouped = _groupByKvk(records);
         for (const [kvkName, kvkRecords] of grouped) {
+            // Large centered bold KVK heading — matches original
             html += `
-    <div style="text-align:center;margin:32px 0 20px 0;">
-        <h2 style="font-size:16px;font-weight:bold;color:#000;margin:0;">${this._escapeHtml(kvkName)}</h2>
-    </div>`
+    <div style="text-align:center;margin:36px 0 24px 0;">
+        <p style="font-size:18px;font-weight:bold;color:#000;margin:0;">${this._escapeHtml(kvkName)}</p>
+    </div>`;
             for (const record of kvkRecords) {
-                cardIndex++
-                html += _renderCard.call(this, record, cardIndex)
+                cardIndex++;
+                html += _renderCard.call(this, record, cardIndex);
             }
         }
     } else {
         for (const record of records) {
-            cardIndex++
-            html += _renderCard.call(this, record, cardIndex)
+            cardIndex++;
+            html += _renderCard.call(this, record, cardIndex);
         }
     }
 
     html += `
-</div>`
+</div>`;
 
-    return html
+    return html;
 }
 
 // ─── Single card ────────────────────────────────────────────────────────────
 
 function _renderCard(record, cardNumber) {
-    const esc = (v) => this._escapeHtml(v != null && v !== '' ? String(v) : '-')
-    const resultReport = record.resultReport || {}
+    const esc = (v) => this._escapeHtml(v != null && v !== '' ? String(v) : '-');
+    const resultReport = record.resultReport || {};
 
-    const disciplineName = (record.discipline && record.discipline.disciplineName) || '-'
-    const thematicAreaName = (record.oftThematicArea && record.oftThematicArea.thematicAreaName) || '-'
-    const title = record.title || '-'
+    const disciplineName = (record.discipline && record.discipline.disciplineName) || '-';
+    const thematicAreaName = (record.oftThematicArea && record.oftThematicArea.thematicAreaName) || '-';
+    const title = record.title || '-';
 
-    // Card header — matches original: bold numbered title, bullet-style sub-lines
+    // Card header — bold section number, bullet sub-lines
     let html = `
-    <div style="margin-bottom:28px;">
-        <p style="margin:0 0 6px 0;font-size:11px;font-weight:bold;">
-            ${section_id(cardNumber)} OFT (${esc(disciplineName)})
+    <div style="margin-bottom:32px;">
+        <p style="margin:0 0 8px 0;font-size:11px;font-weight:bold;">
+            2.2.${cardNumber}. OFT (${esc(disciplineName)})
         </p>
-        <p style="margin:0 0 2px 0;font-size:10px;">
+        <p style="margin:0 0 4px 16px;font-size:10px;">
             &bull; <strong>Thematic area:</strong> ${esc(thematicAreaName)}
         </p>
-        <p style="margin:0 0 12px 0;font-size:10px;">
+        <p style="margin:0 0 14px 16px;font-size:10px;">
             &bull; <strong>Problem definition/Name of OFT:</strong> ${esc(title)}
-        </p>`
+        </p>`;
 
-    // 16-field table — 2 columns, no header row, number inline with label
-    const techDetails = _formatTechnologies(record.technologies)
+    // Technology field — HTML with bold labels
+    const techHtml = _formatTechnologiesHtml(record.technologies, this._escapeHtml.bind(this));
 
+    // 16-field table: 3 columns — narrow #, bold label, value. NO header row.
     const fields = [
-        ['Title of On farm Trial', record.title],
-        ['Problem diagnosed', record.problemDiagnosed],
-        ['Details of technologies selected for assessment/refinement (Mention either Assessed)', techDetails],
-        ['Source of Technology (ICAR/ AICRP/SAU/other, please specify)', record.sourceOfTechnology],
-        ['Production system', record.productionSystem],
-        ['Thematic area', thematicAreaName],
-        ['Performance indicators of the technology', record.performanceIndicators],
-        ['Final recommendation for micro level situation', resultReport.finalRecommendation],
-        ['Constraints identified and feedback for research', resultReport.constraintsFeedback],
-        ['Process of farmers participation and their reaction', resultReport.farmersParticipationProcess],
-        ['Area (ha)/ No of units', record.areaHaNumber],
-        ['No. of Trial/Replication', record.numberOfTrialReplication],
-        ['OFT Start on', _formatMonthYear(record.oftStartDate)],
-        ['OFT End on', _formatMonthYear(record.oftEndDate)],
-        ['Critical Input', record.criticalInput],
-        ['Cost of OFT', record.costOfOft],
-    ]
+        ['Title of On farm Trial', esc(record.title)],
+        ['Problem diagnosed', esc(record.problemDiagnosed)],
+        ['Details of technologies selected for assessment/refinement (Mention either Assessed)', techHtml],
+        ['Source of Technology (ICAR/ AICRP/SAU/other, please specify)', esc(record.sourceOfTechnology)],
+        ['Production system', esc(record.productionSystem)],
+        ['Thematic area', esc(thematicAreaName)],
+        ['Performance indicators of the technology', esc(record.performanceIndicators)],
+        ['Final recommendation for micro level situation', esc(resultReport.finalRecommendation)],
+        ['Constraints identified and feedback for research', esc(resultReport.constraintsFeedback)],
+        ['Process of farmers participation and their reaction', esc(resultReport.farmersParticipationProcess)],
+        ['Area (ha)/ No of units', esc(record.areaHaNumber)],
+        ['No. of Trial/Replication', esc(record.numberOfTrialReplication)],
+        ['OFT Start on', this._escapeHtml(_formatMonthYear(record.oftStartDate))],
+        ['OFT End on', this._escapeHtml(_formatMonthYear(record.oftEndDate))],
+        ['Critical Input', esc(record.criticalInput)],
+        ['Cost of OFT', esc(record.costOfOft)],
+    ];
 
     html += `
         <table class="data-table" style="width:100%;margin-bottom:16px;">
-            <tbody>`
+            <tbody>`;
 
-    fields.forEach(([label, value], idx) => {
-        const displayValue = (value != null && value !== '') ? String(value) : '-'
-        const escapedValue = this._escapeHtml(displayValue).replace(/\n/g, '<br/>')
+    fields.forEach(([label, valueHtml], idx) => {
+        // Field 3 (technologies) already has HTML formatting, others are escaped
+        const isHtmlField = idx === 2;
+        const displayValue = (!valueHtml || valueHtml === '-') ? '-' : valueHtml;
 
         html += `
-                <tr class="${idx % 2 === 0 ? 'even' : 'odd'}">
-                    <td style="width:45%;vertical-align:top;padding:5px 6px;">
-                        <strong>${idx + 1}.</strong>&nbsp;&nbsp;${this._escapeHtml(label)}
-                    </td>
-                    <td style="vertical-align:top;padding:5px 6px;">${escapedValue}</td>
-                </tr>`
-    })
+                <tr>
+                    <td style="width:24px;text-align:right;vertical-align:top;padding:5px 4px 5px 6px;font-size:8pt;">${idx + 1}.</td>
+                    <td style="width:42%;vertical-align:top;padding:5px 6px;font-size:8pt;"><strong>${this._escapeHtml(label)}</strong></td>
+                    <td style="vertical-align:top;padding:5px 6px;font-size:8pt;">${isHtmlField ? displayValue : displayValue}</td>
+                </tr>`;
+    });
 
     html += `
             </tbody>
-        </table>`
+        </table>`;
 
     // Results section
-    html += _renderResultsSection.call(this, resultReport)
+    html += _renderResultsSection.call(this, resultReport);
 
     html += `
-    </div>`
+    </div>`;
 
-    return html
-}
-
-function section_id(n) {
-    return `2.2.${n}.`
+    return html;
 }
 
 // ─── Results section ────────────────────────────────────────────────────────
 
 function _renderResultsSection(resultReport) {
-    if (!resultReport) return ''
+    if (!resultReport) return '';
 
-    const tables = resultReport.tables
-    const hasContent = (Array.isArray(tables) && tables.length > 0) || resultReport.resultText
+    const tables = resultReport.tables;
+    const hasContent = (Array.isArray(tables) && tables.length > 0) || resultReport.resultText;
 
-    if (!hasContent) return ''
+    if (!hasContent) return '';
 
     let html = `
-        <div style="margin-top:12px;">
-            <p style="margin:0 0 8px 0;font-size:11px;font-weight:bold;">
+        <div style="margin-top:16px;">
+            <p style="margin:0 0 12px 0;font-size:11px;font-weight:bold;">
                 B. Results with Table and good quality photographs in jpg.
-            </p>`
+            </p>`;
 
     if (Array.isArray(tables) && tables.length > 0) {
-        const sorted = [...tables].sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
+        const sorted = [...tables].sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
         sorted.forEach((table, tIdx) => {
-            html += _renderResultTable.call(this, table, tIdx + 1)
-        })
+            html += _renderResultTable.call(this, table, tIdx + 1);
+        });
     }
 
+    // Result text — italic "Result:" prefix matching original
     if (resultReport.resultText) {
         html += `
-            <p style="margin:8px 0 0 0;font-size:10px;">
-                <strong>Result:</strong> ${this._escapeHtml(resultReport.resultText)}
-            </p>`
+            <p style="margin:12px 0 0 0;font-size:9pt;">
+                <em><strong>Result:</strong></em> ${this._escapeHtml(resultReport.resultText)}
+            </p>`;
     }
 
     html += `
-        </div>`
+        </div>`;
 
-    return html
+    return html;
 }
 
 function _renderResultTable(table, tableNumber) {
-    const columns = Array.isArray(table.columns) ? [...table.columns] : []
-    const rows = Array.isArray(table.rows) ? [...table.rows] : []
+    const columns = Array.isArray(table.columns) ? [...table.columns] : [];
+    const rows = Array.isArray(table.rows) ? [...table.rows] : [];
 
-    if (columns.length === 0 && rows.length === 0) return ''
+    if (columns.length === 0 && rows.length === 0) return '';
 
-    columns.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
-    rows.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
+    columns.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+    rows.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
 
-    // Separate "Proposed" and "Actual" columns from the rest
+    // Separate Proposed/Actual columns — they go right after Technology Options
     const proposedCol = columns.find(c =>
-        (c.columnLabel || '').toLowerCase() === 'proposed' ||
-        (c.columnKey || '').toLowerCase() === 'proposed'
-    )
+        /^proposed$/i.test((c.columnLabel || '').trim()) ||
+        /^proposed$/i.test((c.columnKey || '').trim())
+    );
     const actualCol = columns.find(c =>
-        (c.columnLabel || '').toLowerCase() === 'actual' ||
-        (c.columnKey || '').toLowerCase() === 'actual'
-    )
-    const dataColumns = columns.filter(c => c !== proposedCol && c !== actualCol)
+        /^actual$/i.test((c.columnLabel || '').trim()) ||
+        /^actual$/i.test((c.columnKey || '').trim())
+    );
+    const dataColumns = columns.filter(c => c !== proposedCol && c !== actualCol);
 
-    const tableTitle = table.tableTitle || ''
+    const tableTitle = table.tableTitle || '';
 
+    // Table title — bold, larger font, matching original
     let html = `
-            <p style="margin:12px 0 4px 0;font-size:10px;font-weight:bold;">
+            <p style="margin:16px 0 8px 0;font-size:10pt;font-weight:bold;">
                 Table ${tableNumber} : ${this._escapeHtml(tableTitle)}
             </p>
             <table class="data-table" style="width:100%;margin-bottom:12px;font-size:8pt;">
                 <thead>
                     <tr>
-                        <th>Tehcnology Options</th>`
+                        <th>Tehcnology Options</th>`;
 
-    // "Proposed" and "Actual" columns come right after Technology Options
+    // Proposed and Actual columns right after Technology Options
     if (proposedCol) {
-        html += `<th>${this._escapeHtml(proposedCol.columnLabel || 'Proposed')}</th>`
+        html += `<th>${this._escapeHtml(proposedCol.columnLabel || 'Proposed')}</th>`;
     }
     if (actualCol) {
-        html += `<th>${this._escapeHtml(actualCol.columnLabel || 'Actual')}</th>`
+        html += `<th>${this._escapeHtml(actualCol.columnLabel || 'Actual')}</th>`;
     }
-
     for (const col of dataColumns) {
-        html += `<th>${this._escapeHtml(col.columnLabel || col.columnKey || '-')}</th>`
+        html += `<th>${this._escapeHtml(col.columnLabel || col.columnKey || '-')}</th>`;
     }
 
     html += `
                     </tr>
                 </thead>
-                <tbody>`
+                <tbody>`;
 
-    // Build ordered column list for cell rendering
-    const orderedColumns = []
-    if (proposedCol) orderedColumns.push(proposedCol)
-    if (actualCol) orderedColumns.push(actualCol)
-    orderedColumns.push(...dataColumns)
+    const orderedColumns = [];
+    if (proposedCol) orderedColumns.push(proposedCol);
+    if (actualCol) orderedColumns.push(actualCol);
+    orderedColumns.push(...dataColumns);
 
     rows.forEach((row, rIdx) => {
-        const rowLabel = row.rowLabel || row.optionKey || '-'
+        const rowLabel = row.rowLabel || row.optionKey || '-';
 
-        const cellMap = new Map()
+        const cellMap = new Map();
         if (Array.isArray(row.cells)) {
             for (const cell of row.cells) {
                 if (cell.oftResultTableColumnId !== undefined) {
-                    cellMap.set(cell.oftResultTableColumnId, cell.value)
+                    cellMap.set(cell.oftResultTableColumnId, cell.value);
                 }
             }
         }
 
         html += `
-                    <tr class="${rIdx % 2 === 0 ? 'even' : 'odd'}">
-                        <td>${this._escapeHtml(rowLabel)}</td>`
+                    <tr>
+                        <td>${this._escapeHtml(rowLabel)}</td>`;
 
         for (const col of orderedColumns) {
-            const cellValue = cellMap.get(col.oftResultTableColumnId)
-            const display = (cellValue != null && cellValue !== '') ? String(cellValue) : '-'
-            html += `<td>${this._escapeHtml(display)}</td>`
+            const cellValue = cellMap.get(col.oftResultTableColumnId);
+            const display = (cellValue != null && cellValue !== '') ? String(cellValue) : '-';
+            html += `<td>${this._escapeHtml(display)}</td>`;
         }
 
-        html += `</tr>`
-    })
+        html += `</tr>`;
+    });
 
     html += `
                 </tbody>
-            </table>`
+            </table>`;
 
-    return html
+    return html;
 }
 
 module.exports = {
     renderOftDetailCardsSection,
-}
+};

--- a/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
@@ -232,7 +232,7 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
         // Sub Total row
         html += `
             <tr style="font-weight:bold;">
-                <td>Sub Total</td>`;
+                <td>Sub Total (${sector.key})</td>`;
 
         if (isMultiState) {
             for (const st of stateKeys) {
@@ -262,7 +262,7 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
     // Grand Total row
     html += `
             <tr style="font-weight:bold;">
-                <td>Grand Total</td>`;
+                <td>Grand Total (F)</td>`;
 
     if (isMultiState) {
         for (const st of stateKeys) {

--- a/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
@@ -1,82 +1,41 @@
 /**
  * OFT Summary Template (Section 2.1)
  *
- * Renders the OFT Summary table grouped by five sectors (A-E),
- * matching the original ATARI website layout exactly.
+ * Renders the OFT Summary table grouped by sectors (OftSubject) and
+ * their thematic areas (OftThematicArea), ALL from the database.
+ * Shows every thematic area even when it has 0 data.
  *
- * Single-KVK:  3 value columns (technologies, locations, trials)
- * Multi-state:  per-state columns + total columns
+ * Data shape expected:
+ *   { records: [...OFT rows], subjects: [...OftSubject with thematicAreas] }
+ *
+ * Single-KVK:  3 value columns, heading "2.1. OFT Summary"
+ * Multi-state:  per-state columns + total, full heading hierarchy
  *
  * Bound to reportTemplateService (`this`).
  */
 
-// ── Sector definitions (order matters) ──────────────────────────────
-const SECTORS = [
-    {
-        key: 'A',
-        label: 'A) Technologies Assessed under Various Crops by KVKs (Crop Production)',
-        match: (name) => /crop\s*production/i.test(name),
-    },
-    {
-        key: 'B',
-        label: 'B) Technologies Assessed under Livestock and Fisheries by KVKs',
-        match: (name) =>
-            /livestock|animal\s*husbandry|fisheries|poultry|veterinary/i.test(name),
-    },
-    {
-        key: 'C',
-        label: 'C) Technologies Assessed under various Enterprises by KVKs',
-        match: (name) => /enterprise/i.test(name) && !/women/i.test(name),
-    },
-    {
-        key: 'D',
-        label: 'D) Technologies Assessed under various Enterprises for Women Empowerment',
-        match: (name) => /women/i.test(name),
-    },
-    {
-        key: 'E',
-        label: 'E) Technologies Assessed under various Crops (Horticulture crops.)',
-        match: (name) => /horticulture/i.test(name),
-    },
+// ── Sector label mapping by subject name keyword ────────────────────
+// Maps OftSubject names to sector labels + keys used in the original report.
+// If a subject doesn't match any keyword, it gets its own section.
+
+const SECTOR_MAP = [
+    { key: 'A', keyword: /crop\s*production/i, prefix: 'A) Technologies Assessed under Various Crops by KVKs (Crop Production)' },
+    { key: 'B', keyword: /livestock|animal|fisheries|poultry|veterinary/i, prefix: 'B) Technologies Assessed under Livestock and Fisheries by KVKs' },
+    { key: 'C', keyword: /enterprise/i, extraReject: /women/i, prefix: 'C) Technologies Assessed under various Enterprises by KVKs' },
+    { key: 'D', keyword: /women/i, prefix: 'D) Technologies Assessed under various Enterprises for Women Empowerment' },
+    { key: 'E', keyword: /horticulture/i, prefix: 'E) Technologies Assessed under various Crops (Horticulture crops.)' },
 ];
 
-function classifySector(subjectName) {
+function classifySubject(subjectName) {
     const name = (subjectName || '').trim();
-    for (const sector of SECTORS) {
-        if (sector.match(name)) return sector.key;
+    for (const s of SECTOR_MAP) {
+        if (s.extraReject && s.extraReject.test(name)) continue;
+        if (s.keyword.test(name)) return s;
     }
-    return 'C';
+    return null;
 }
 
-function buildAggregation(records, isMultiState) {
-    const agg = {};
-    for (const sector of SECTORS) {
-        agg[sector.key] = new Map();
-    }
-
-    for (const r of records) {
-        const subjectName = r.oftSubject?.subjectName || '';
-        const thematicArea = r.oftThematicArea?.thematicAreaName || 'Other';
-        const sectorKey = classifySector(subjectName);
-        const stateKey = isMultiState ? (r.kvk?.state?.stateName || 'Unknown') : '__all__';
-
-        if (!agg[sectorKey].has(thematicArea)) {
-            agg[sectorKey].set(thematicArea, new Map());
-        }
-
-        const stateMap = agg[sectorKey].get(thematicArea);
-        if (!stateMap.has(stateKey)) {
-            stateMap.set(stateKey, { techs: 0, locations: 0, trials: 0 });
-        }
-
-        const bucket = stateMap.get(stateKey);
-        bucket.techs += 1;
-        bucket.locations += Number(r.numberOfLocation) || 0;
-        bucket.trials += Number(r.numberOfTrialReplication) || 0;
-    }
-
-    return agg;
-}
+// ── Helpers ─────────────────────────────────────────────────────────
 
 function getUniqueStates(records) {
     const set = new Set();
@@ -87,27 +46,87 @@ function getUniqueStates(records) {
     return Array.from(set).sort();
 }
 
+function getBucket(stateMap, stateKey) {
+    return stateMap?.get(stateKey) || { techs: 0, locations: 0, trials: 0 };
+}
+
 function sumBuckets(stateMap, stateKeys) {
     const total = { techs: 0, locations: 0, trials: 0 };
     for (const key of stateKeys) {
-        const b = stateMap.get(key);
-        if (b) {
-            total.techs += b.techs;
-            total.locations += b.locations;
-            total.trials += b.trials;
-        }
+        const b = getBucket(stateMap, key);
+        total.techs += b.techs;
+        total.locations += b.locations;
+        total.trials += b.trials;
     }
     return total;
+}
+
+/**
+ * Build: subjectId -> thematicAreaName -> stateKey -> {techs, locations, trials}
+ */
+function buildAggregation(records, isMultiState) {
+    const agg = new Map(); // subjectId -> Map<thematicAreaName, Map<stateKey, bucket>>
+
+    for (const r of records) {
+        const subjectId = r.oftSubjectId || 0;
+        const thematicArea = r.oftThematicArea?.thematicAreaName || 'Other';
+        const stateKey = isMultiState ? (r.kvk?.state?.stateName || 'Unknown') : '__all__';
+
+        if (!agg.has(subjectId)) agg.set(subjectId, new Map());
+        const thematicMap = agg.get(subjectId);
+
+        if (!thematicMap.has(thematicArea)) thematicMap.set(thematicArea, new Map());
+        const stateMap = thematicMap.get(thematicArea);
+
+        if (!stateMap.has(stateKey)) stateMap.set(stateKey, { techs: 0, locations: 0, trials: 0 });
+        const bucket = stateMap.get(stateKey);
+        bucket.techs += 1;
+        bucket.locations += Number(r.numberOfLocation) || 0;
+        bucket.trials += Number(r.numberOfTrialReplication) || 0;
+    }
+
+    return agg;
+}
+
+function renderValueCells(isMultiState, stateKeys, stateMap) {
+    let html = '';
+    if (isMultiState) {
+        for (const st of stateKeys) {
+            const b = getBucket(stateMap, st);
+            html += `<td style="text-align:center;">${b.techs}</td>
+                <td style="text-align:center;">${b.locations}</td>
+                <td style="text-align:center;">${b.trials}</td>`;
+        }
+        const total = sumBuckets(stateMap, stateKeys);
+        html += `<td style="text-align:center;">${total.techs}</td>
+                <td style="text-align:center;">${total.locations}</td>
+                <td style="text-align:center;">${total.trials}</td>`;
+    } else {
+        const total = sumBuckets(stateMap, stateKeys);
+        html += `<td style="text-align:center;">${total.techs}</td>
+                <td style="text-align:center;">${total.locations}</td>
+                <td style="text-align:center;">${total.trials}</td>`;
+    }
+    return html;
 }
 
 // ── Main render function ────────────────────────────────────────────
 
 function renderOftSummarySection(section, data, sectionId, isFirstSection) {
-    if (!data || (Array.isArray(data) && data.length === 0)) {
+    // data can be { records, subjects } from data service, or plain array from combined template
+    let records, subjects;
+    if (data && !Array.isArray(data) && data.records) {
+        records = data.records;
+        subjects = data.subjects || [];
+    } else {
+        records = Array.isArray(data) ? data : (data ? [data] : []);
+        subjects = [];
+    }
+
+    if (records.length === 0 && subjects.length === 0) {
         return this._generateEmptySection(section, null, sectionId, isFirstSection);
     }
 
-    const records = Array.isArray(data) ? data : [data];
     const pageClass = isFirstSection
         ? 'section-page section-page-first'
         : 'section-page section-page-continued';
@@ -117,47 +136,78 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
     const stateKeys = isMultiState ? states : ['__all__'];
 
     const agg = buildAggregation(records, isMultiState);
-
-    // Total column count for colspan on sector header rows
     const colCount = isMultiState ? 1 + (states.length * 3) + 3 : 4;
 
+    // ── Build ordered sector list from DB subjects ──────────────
+    const sectorList = [];
+    const usedSubjectIds = new Set();
+
+    // First pass: map DB subjects to known sectors
+    for (const subject of subjects) {
+        const mapped = classifySubject(subject.subjectName);
+        const sectorKey = mapped ? mapped.key : subject.subjectName.charAt(0).toUpperCase();
+        const sectorLabel = mapped ? mapped.prefix : `${sectorKey}) ${subject.subjectName}`;
+
+        sectorList.push({
+            key: sectorKey,
+            label: sectorLabel,
+            subjectId: subject.oftSubjectId,
+            thematicAreas: (subject.thematicAreas || []).map(ta => ta.thematicAreaName),
+        });
+        usedSubjectIds.add(subject.oftSubjectId);
+    }
+
+    // If no subjects from DB, fall back to data-driven sectors
+    if (sectorList.length === 0) {
+        // Group by subject from the records themselves
+        const seenSubjects = new Map();
+        for (const r of records) {
+            const sid = r.oftSubjectId || 0;
+            if (!seenSubjects.has(sid)) {
+                const name = r.oftSubject?.subjectName || 'Unknown';
+                const mapped = classifySubject(name);
+                seenSubjects.set(sid, {
+                    key: mapped ? mapped.key : '?',
+                    label: mapped ? mapped.prefix : name,
+                    subjectId: sid,
+                    thematicAreas: [],
+                });
+            }
+        }
+        sectorList.push(...seenSubjects.values());
+    }
+
+    // ── Headings ────────────────────────────────────────────────
     let html = `
 <div id="${sectionId}" class="${pageClass}">`;
 
     if (isMultiState) {
-        // Superadmin: full heading hierarchy matching original
         html += `
     <h1 class="section-title" style="border-bottom:none;margin-bottom:6px;font-size:12px;">2. ACHIEVEMENTS ON TECHNOLOGIES ASSESSED AND REFINED (OFT)</h1>
     <p style="font-size:11px;font-weight:bold;margin-bottom:12px;">2.1. Technology Assessed by KVK (Discipline wise)</p>`;
     } else {
-        // KVK side: simple heading
         html += `
     <h1 class="section-title" style="margin-bottom:10px;">2.1. OFT Summary</h1>`;
     }
 
+    // ── Table header ────────────────────────────────────────────
     html += `
     <table class="data-table">
         <thead>`;
 
     if (isMultiState) {
-        // Row 0: "State wise details..." caption row spanning full width
         html += `
             <tr>
                 <th colspan="${colCount}" style="text-align:left;font-weight:bold;font-size:9pt;padding:8px;">
                     2.1. State wise details of On Farm Trials (OFTs) conducted by KVKs
                 </th>
-            </tr>`;
-        // Row 1: state name spans + Total span
-        html += `
+            </tr>
             <tr>
                 <th rowspan="2" style="vertical-align:bottom;">Sector wise Thematic Area</th>`;
         for (const st of states) {
             html += `<th colspan="3" style="text-align:center;">${this._escapeHtml(st)}</th>`;
         }
-        html += `<th colspan="3" style="text-align:center;">Total</th>`;
-        html += `</tr>`;
-        // Row 2: metric labels repeated
-        html += `
+        html += `<th colspan="3" style="text-align:center;">Total</th></tr>
             <tr>`;
         for (let i = 0; i <= states.length; i++) {
             html += `
@@ -180,17 +230,15 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
         </thead>
         <tbody>`;
 
-    // ── Body: iterate sectors ───────────────────────────────────
+    // ── Body ────────────────────────────────────────────────────
     const grandTotal = { techs: 0, locations: 0, trials: 0 };
     const grandTotalByState = {};
-    for (const st of stateKeys) {
-        grandTotalByState[st] = { techs: 0, locations: 0, trials: 0 };
-    }
+    for (const st of stateKeys) grandTotalByState[st] = { techs: 0, locations: 0, trials: 0 };
 
-    for (const sector of SECTORS) {
-        const thematicMap = agg[sector.key];
+    for (const sector of sectorList) {
+        const thematicMap = agg.get(sector.subjectId) || new Map();
 
-        // Sector header row — spans full width, bold, light background
+        // Sector header row
         html += `
             <tr style="background:#f0f0f0;">
                 <td colspan="${colCount}" style="font-weight:bold;padding:6px 8px;">
@@ -200,51 +248,64 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
 
         const sectorTotal = { techs: 0, locations: 0, trials: 0 };
         const sectorTotalByState = {};
-        for (const st of stateKeys) {
-            sectorTotalByState[st] = { techs: 0, locations: 0, trials: 0 };
-        }
+        for (const st of stateKeys) sectorTotalByState[st] = { techs: 0, locations: 0, trials: 0 };
 
-        const sortedThematicAreas = Array.from(thematicMap.keys()).sort();
+        // Render ALL thematic areas from DB (with 0 defaults)
+        const renderedAreas = new Set();
 
-        for (const thematicArea of sortedThematicAreas) {
-            const stateMap = thematicMap.get(thematicArea);
+        for (const areaName of sector.thematicAreas) {
+            renderedAreas.add(areaName);
+            const stateMap = thematicMap.get(areaName) || new Map();
             const rowTotal = sumBuckets(stateMap, stateKeys);
 
             html += `
             <tr>
-                <td>${this._escapeHtml(thematicArea)}</td>`;
+                <td>${this._escapeHtml(areaName)}</td>`;
+            html += renderValueCells(isMultiState, stateKeys, stateMap);
+            html += `</tr>`;
 
             if (isMultiState) {
                 for (const st of stateKeys) {
-                    const b = stateMap.get(st) || { techs: 0, locations: 0, trials: 0 };
-                    html += `<td style="text-align:center;">${b.techs}</td>
-                <td style="text-align:center;">${b.locations}</td>
-                <td style="text-align:center;">${b.trials}</td>`;
+                    const b = getBucket(stateMap, st);
                     sectorTotalByState[st].techs += b.techs;
                     sectorTotalByState[st].locations += b.locations;
                     sectorTotalByState[st].trials += b.trials;
                 }
-                html += `<td style="text-align:center;">${rowTotal.techs}</td>
-                <td style="text-align:center;">${rowTotal.locations}</td>
-                <td style="text-align:center;">${rowTotal.trials}</td>`;
-            } else {
-                html += `<td style="text-align:center;">${rowTotal.techs}</td>
-                <td style="text-align:center;">${rowTotal.locations}</td>
-                <td style="text-align:center;">${rowTotal.trials}</td>`;
             }
-
             sectorTotal.techs += rowTotal.techs;
             sectorTotal.locations += rowTotal.locations;
             sectorTotal.trials += rowTotal.trials;
-
-            html += `</tr>`;
         }
 
-        // Sub Total row
+        // Any extra areas from data not in the DB master list
+        for (const [areaName, stateMap] of thematicMap) {
+            if (renderedAreas.has(areaName)) continue;
+            const rowTotal = sumBuckets(stateMap, stateKeys);
+
+            html += `
+            <tr>
+                <td>${this._escapeHtml(areaName)}</td>`;
+            html += renderValueCells(isMultiState, stateKeys, stateMap);
+            html += `</tr>`;
+
+            if (isMultiState) {
+                for (const st of stateKeys) {
+                    const b = getBucket(stateMap, st);
+                    sectorTotalByState[st].techs += b.techs;
+                    sectorTotalByState[st].locations += b.locations;
+                    sectorTotalByState[st].trials += b.trials;
+                }
+            }
+            sectorTotal.techs += rowTotal.techs;
+            sectorTotal.locations += rowTotal.locations;
+            sectorTotal.trials += rowTotal.trials;
+        }
+
+        // Sub Total
+        const subLabel = isMultiState ? `Sub Total (${sector.key})` : 'Sub Total';
         html += `
             <tr style="font-weight:bold;">
-                <td>${isMultiState ? `Sub Total (${sector.key})` : 'Sub Total'}</td>`;
-
+                <td>${subLabel}</td>`;
         if (isMultiState) {
             for (const st of stateKeys) {
                 html += `<td style="text-align:center;">${sectorTotalByState[st].techs}</td>
@@ -262,7 +323,6 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
                 <td style="text-align:center;">${sectorTotal.locations}</td>
                 <td style="text-align:center;">${sectorTotal.trials}</td>`;
         }
-
         html += `</tr>`;
 
         grandTotal.techs += sectorTotal.techs;
@@ -270,11 +330,11 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
         grandTotal.trials += sectorTotal.trials;
     }
 
-    // Grand Total row
+    // Grand Total
+    const grandLabel = isMultiState ? 'Grand Total (F)' : 'Grand Total';
     html += `
             <tr style="font-weight:bold;">
-                <td>${isMultiState ? 'Grand Total (F)' : 'Grand Total'}</td>`;
-
+                <td>${grandLabel}</td>`;
     if (isMultiState) {
         for (const st of stateKeys) {
             html += `<td style="text-align:center;">${grandTotalByState[st].techs}</td>
@@ -289,10 +349,7 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
                 <td style="text-align:center;">${grandTotal.locations}</td>
                 <td style="text-align:center;">${grandTotal.trials}</td>`;
     }
-
-    html += `</tr>`;
-
-    html += `
+    html += `</tr>
         </tbody>
     </table>
 </div>`;

--- a/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
@@ -1,16 +1,13 @@
 /**
  * OFT Summary Template (Section 2.1)
  *
- * Renders the "On Farm Testing Summary" table grouped by five sectors (A-E),
- * with thematic-area rows, sector sub-totals, and a grand total.
+ * Renders the OFT Summary table grouped by five sectors (A-E),
+ * matching the original ATARI website layout exactly.
  *
- * Automatically detects single-KVK vs multi-state (superadmin) mode:
- *   - Single-state  -> 3 value columns (technologies, locations, trials)
- *   - Multi-state   -> per-state columns + total columns
+ * Single-KVK:  3 value columns (technologies, locations, trials)
+ * Multi-state:  per-state columns + total columns
  *
- * Bound to reportTemplateService (`this`), so helpers like
- * `this._escapeHtml()`, `this._generateEmptySection()`, and
- * `this._toDisplayValue()` are available.
+ * Bound to reportTemplateService (`this`).
  */
 
 // ── Sector definitions (order matters) ──────────────────────────────
@@ -43,12 +40,6 @@ const SECTORS = [
     },
 ];
 
-// ── Helpers ──────────────────────────────────────────────────────────
-
-/**
- * Classify a subjectName into one of the five sectors.
- * Falls back to sector C (Enterprises) when nothing matches.
- */
 function classifySector(subjectName) {
     const name = (subjectName || '').trim();
     for (const sector of SECTORS) {
@@ -57,14 +48,7 @@ function classifySector(subjectName) {
     return 'C';
 }
 
-/**
- * Build a lookup structure:
- *   sectorKey -> thematicAreaName -> stateKey -> { techs, locations, trials }
- *
- * `stateKey` is either a stateName or '__all__' for single-state mode.
- */
 function buildAggregation(records, isMultiState) {
-    // sectorKey -> Map<thematicAreaName, Map<stateKey, {techs, locations, trials}>>
     const agg = {};
     for (const sector of SECTORS) {
         agg[sector.key] = new Map();
@@ -94,9 +78,6 @@ function buildAggregation(records, isMultiState) {
     return agg;
 }
 
-/**
- * Collect sorted unique state names from the dataset.
- */
 function getUniqueStates(records) {
     const set = new Set();
     for (const r of records) {
@@ -106,9 +87,6 @@ function getUniqueStates(records) {
     return Array.from(set).sort();
 }
 
-/**
- * Sum a Map<stateKey, bucket> across all states for a given list of stateKeys.
- */
 function sumBuckets(stateMap, stateKeys) {
     const total = { techs: 0, locations: 0, trials: 0 };
     for (const key of stateKeys) {
@@ -134,54 +112,56 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
         ? 'section-page section-page-first'
         : 'section-page section-page-continued';
 
-    // Detect multi-state mode
     const states = getUniqueStates(records);
     const isMultiState = states.length > 1;
     const stateKeys = isMultiState ? states : ['__all__'];
 
     const agg = buildAggregation(records, isMultiState);
 
-    // ── Header row ──────────────────────────────────────────────
-    const valueColCount = isMultiState ? states.length * 3 + 3 : 3;
-
-    // Title changes based on scope
-    const sectionTitle = isMultiState
-        ? 'State wise details of On Farm Trials (OFTs) conducted by KVKs'
-        : 'OFT Summary';
+    // Total column count for colspan on sector header rows
+    const colCount = isMultiState ? 1 + (states.length * 3) + 3 : 4;
 
     let html = `
 <div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title">${section.id} ${this._escapeHtml(sectionTitle)}</h1>
+    <h1 class="section-title" style="border-bottom:none;margin-bottom:4px;">2. ACHIEVEMENTS ON TECHNOLOGIES ASSESSED AND REFINED (OFT)</h1>
+    <p style="font-size:10px;font-weight:bold;margin-bottom:10px;">2.1. Technology Assessed by KVK (Discipline wise)</p>`;
+
+    if (isMultiState) {
+        html += `
+    <p style="font-size:9px;font-weight:bold;margin-bottom:8px;">2.1. State wise details of On Farm Trials (OFTs) conducted by KVKs</p>`;
+    }
+
+    html += `
     <table class="data-table">
         <thead>`;
 
     if (isMultiState) {
-        // Two-row header: top row with state group spans, bottom row with metric labels
+        // Row 1: state name spans + Total span
         html += `
             <tr>
-                <th class="s-no" rowspan="2">S.No.</th>
-                <th rowspan="2">Sector wise Thematic Area</th>`;
+                <th rowspan="2" style="vertical-align:bottom;">Sector wise Thematic Area</th>`;
         for (const st of states) {
             html += `<th colspan="3" style="text-align:center;">${this._escapeHtml(st)}</th>`;
         }
         html += `<th colspan="3" style="text-align:center;">Total</th>`;
-        html += `</tr>
+        html += `</tr>`;
+        // Row 2: metric labels repeated
+        html += `
             <tr>`;
         for (let i = 0; i <= states.length; i++) {
             html += `
-                <th>No. of technologies assessed</th>
-                <th>No. of Locations</th>
-                <th>No. of Trial/Replications</th>`;
+                <th style="text-align:center;">No. of technologies assessed</th>
+                <th style="text-align:center;">No. of Locations</th>
+                <th style="text-align:center;">No. of Trial/Replications</th>`;
         }
         html += `</tr>`;
     } else {
         html += `
             <tr>
-                <th class="s-no">S.No.</th>
                 <th>Sector wise Thematic Area</th>
-                <th>No. of technologies assessed</th>
-                <th>No. of Locations</th>
-                <th>No. of Trial/Replications</th>
+                <th style="text-align:center;">No. of technologies assessed</th>
+                <th style="text-align:center;">No. of Locations</th>
+                <th style="text-align:center;">No. of Trial/Replications</th>
             </tr>`;
     }
 
@@ -190,7 +170,6 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
         <tbody>`;
 
     // ── Body: iterate sectors ───────────────────────────────────
-    let serialNo = 0;
     const grandTotal = { techs: 0, locations: 0, trials: 0 };
     const grandTotalByState = {};
     for (const st of stateKeys) {
@@ -198,69 +177,49 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
     }
 
     for (const sector of SECTORS) {
-        const thematicMap = agg[sector.key]; // Map<thematicArea, Map<stateKey, bucket>>
+        const thematicMap = agg[sector.key];
 
-        // Sector header row
+        // Sector header row — spans full width, bold, light background
         html += `
-            <tr style="background:#f0f0f0; font-weight:bold;">
-                <td colspan="${valueColCount + 2}" style="text-align:left; padding:6px 8px;">
+            <tr style="background:#f0f0f0;">
+                <td colspan="${colCount}" style="font-weight:bold;padding:6px 8px;">
                     ${this._escapeHtml(sector.label)}
                 </td>
             </tr>`;
 
-        // Sub-total accumulators for this sector
         const sectorTotal = { techs: 0, locations: 0, trials: 0 };
         const sectorTotalByState = {};
         for (const st of stateKeys) {
             sectorTotalByState[st] = { techs: 0, locations: 0, trials: 0 };
         }
 
-        if (thematicMap.size === 0) {
-            // No data for this sector
-            html += `
-            <tr>
-                <td colspan="${valueColCount + 2}" style="text-align:center; color:#888;">No data available</td>
-            </tr>`;
-        }
-
-        // Sort thematic areas alphabetically
         const sortedThematicAreas = Array.from(thematicMap.keys()).sort();
 
         for (const thematicArea of sortedThematicAreas) {
-            serialNo += 1;
             const stateMap = thematicMap.get(thematicArea);
             const rowTotal = sumBuckets(stateMap, stateKeys);
 
             html += `
-            <tr class="${serialNo % 2 === 0 ? 'even' : 'odd'}">
-                <td class="s-no">${serialNo}.</td>
+            <tr>
                 <td>${this._escapeHtml(thematicArea)}</td>`;
 
             if (isMultiState) {
                 for (const st of stateKeys) {
                     const b = stateMap.get(st) || { techs: 0, locations: 0, trials: 0 };
-                    html += `
-                <td style="text-align:center;">${b.techs}</td>
+                    html += `<td style="text-align:center;">${b.techs}</td>
                 <td style="text-align:center;">${b.locations}</td>
                 <td style="text-align:center;">${b.trials}</td>`;
                     sectorTotalByState[st].techs += b.techs;
                     sectorTotalByState[st].locations += b.locations;
                     sectorTotalByState[st].trials += b.trials;
                 }
-                // Total column
-                html += `
-                <td style="text-align:center;">${rowTotal.techs}</td>
+                html += `<td style="text-align:center;">${rowTotal.techs}</td>
                 <td style="text-align:center;">${rowTotal.locations}</td>
                 <td style="text-align:center;">${rowTotal.trials}</td>`;
             } else {
-                html += `
-                <td style="text-align:center;">${rowTotal.techs}</td>
+                html += `<td style="text-align:center;">${rowTotal.techs}</td>
                 <td style="text-align:center;">${rowTotal.locations}</td>
                 <td style="text-align:center;">${rowTotal.trials}</td>`;
-                const b = stateMap.get('__all__') || { techs: 0, locations: 0, trials: 0 };
-                sectorTotalByState['__all__'].techs += b.techs;
-                sectorTotalByState['__all__'].locations += b.locations;
-                sectorTotalByState['__all__'].trials += b.trials;
             }
 
             sectorTotal.techs += rowTotal.techs;
@@ -272,32 +231,25 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
 
         // Sub Total row
         html += `
-            <tr style="font-weight:bold; background:#fafafa;">
-                <td></td>
-                <td style="text-align:right;">Sub Total</td>`;
+            <tr style="font-weight:bold;">
+                <td>Sub Total</td>`;
 
         if (isMultiState) {
             for (const st of stateKeys) {
-                html += `
-                <td style="text-align:center;">${sectorTotalByState[st].techs}</td>
+                html += `<td style="text-align:center;">${sectorTotalByState[st].techs}</td>
                 <td style="text-align:center;">${sectorTotalByState[st].locations}</td>
                 <td style="text-align:center;">${sectorTotalByState[st].trials}</td>`;
                 grandTotalByState[st].techs += sectorTotalByState[st].techs;
                 grandTotalByState[st].locations += sectorTotalByState[st].locations;
                 grandTotalByState[st].trials += sectorTotalByState[st].trials;
             }
-            html += `
-                <td style="text-align:center;">${sectorTotal.techs}</td>
+            html += `<td style="text-align:center;">${sectorTotal.techs}</td>
                 <td style="text-align:center;">${sectorTotal.locations}</td>
                 <td style="text-align:center;">${sectorTotal.trials}</td>`;
         } else {
-            html += `
-                <td style="text-align:center;">${sectorTotal.techs}</td>
+            html += `<td style="text-align:center;">${sectorTotal.techs}</td>
                 <td style="text-align:center;">${sectorTotal.locations}</td>
                 <td style="text-align:center;">${sectorTotal.trials}</td>`;
-            grandTotalByState['__all__'].techs += sectorTotalByState['__all__'].techs;
-            grandTotalByState['__all__'].locations += sectorTotalByState['__all__'].locations;
-            grandTotalByState['__all__'].trials += sectorTotalByState['__all__'].trials;
         }
 
         html += `</tr>`;
@@ -307,26 +259,22 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
         grandTotal.trials += sectorTotal.trials;
     }
 
-    // ── Grand Total row ─────────────────────────────────────────
+    // Grand Total row
     html += `
-            <tr style="font-weight:bold; background:#e8e8e8; border-top:2px solid #333;">
-                <td></td>
-                <td style="text-align:right;">Grand Total</td>`;
+            <tr style="font-weight:bold;">
+                <td>Grand Total</td>`;
 
     if (isMultiState) {
         for (const st of stateKeys) {
-            html += `
-                <td style="text-align:center;">${grandTotalByState[st].techs}</td>
+            html += `<td style="text-align:center;">${grandTotalByState[st].techs}</td>
                 <td style="text-align:center;">${grandTotalByState[st].locations}</td>
                 <td style="text-align:center;">${grandTotalByState[st].trials}</td>`;
         }
-        html += `
-                <td style="text-align:center;">${grandTotal.techs}</td>
+        html += `<td style="text-align:center;">${grandTotal.techs}</td>
                 <td style="text-align:center;">${grandTotal.locations}</td>
                 <td style="text-align:center;">${grandTotal.trials}</td>`;
     } else {
-        html += `
-                <td style="text-align:center;">${grandTotal.techs}</td>
+        html += `<td style="text-align:center;">${grandTotal.techs}</td>
                 <td style="text-align:center;">${grandTotal.locations}</td>
                 <td style="text-align:center;">${grandTotal.trials}</td>`;
     }

--- a/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
@@ -1,0 +1,339 @@
+/**
+ * OFT Summary Template (Section 2.1)
+ *
+ * Renders the "On Farm Testing Summary" table grouped by five sectors (A-E),
+ * with thematic-area rows, sector sub-totals, and a grand total.
+ *
+ * Automatically detects single-KVK vs multi-state (superadmin) mode:
+ *   - Single-state  -> 3 value columns (technologies, locations, trials)
+ *   - Multi-state   -> per-state columns + total columns
+ *
+ * Bound to reportTemplateService (`this`), so helpers like
+ * `this._escapeHtml()`, `this._generateEmptySection()`, and
+ * `this._toDisplayValue()` are available.
+ */
+
+// ── Sector definitions (order matters) ──────────────────────────────
+const SECTORS = [
+    {
+        key: 'A',
+        label: 'A) Technologies Assessed under Various Crops by KVKs (Crop Production)',
+        match: (name) => /crop\s*production/i.test(name),
+    },
+    {
+        key: 'B',
+        label: 'B) Technologies Assessed under Livestock and Fisheries by KVKs',
+        match: (name) =>
+            /livestock|animal\s*husbandry|fisheries|poultry|veterinary/i.test(name),
+    },
+    {
+        key: 'C',
+        label: 'C) Technologies Assessed under various Enterprises by KVKs',
+        match: (name) => /enterprise/i.test(name) && !/women/i.test(name),
+    },
+    {
+        key: 'D',
+        label: 'D) Technologies Assessed under various Enterprises for Women Empowerment',
+        match: (name) => /women/i.test(name),
+    },
+    {
+        key: 'E',
+        label: 'E) Technologies Assessed under various Crops (Horticulture crops.)',
+        match: (name) => /horticulture/i.test(name),
+    },
+];
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Classify a subjectName into one of the five sectors.
+ * Falls back to sector C (Enterprises) when nothing matches.
+ */
+function classifySector(subjectName) {
+    const name = (subjectName || '').trim();
+    for (const sector of SECTORS) {
+        if (sector.match(name)) return sector.key;
+    }
+    return 'C';
+}
+
+/**
+ * Build a lookup structure:
+ *   sectorKey -> thematicAreaName -> stateKey -> { techs, locations, trials }
+ *
+ * `stateKey` is either a stateName or '__all__' for single-state mode.
+ */
+function buildAggregation(records, isMultiState) {
+    // sectorKey -> Map<thematicAreaName, Map<stateKey, {techs, locations, trials}>>
+    const agg = {};
+    for (const sector of SECTORS) {
+        agg[sector.key] = new Map();
+    }
+
+    for (const r of records) {
+        const subjectName = r.oftSubject?.subjectName || '';
+        const thematicArea = r.oftThematicArea?.thematicAreaName || 'Other';
+        const sectorKey = classifySector(subjectName);
+        const stateKey = isMultiState ? (r.kvk?.state?.stateName || 'Unknown') : '__all__';
+
+        if (!agg[sectorKey].has(thematicArea)) {
+            agg[sectorKey].set(thematicArea, new Map());
+        }
+
+        const stateMap = agg[sectorKey].get(thematicArea);
+        if (!stateMap.has(stateKey)) {
+            stateMap.set(stateKey, { techs: 0, locations: 0, trials: 0 });
+        }
+
+        const bucket = stateMap.get(stateKey);
+        bucket.techs += 1;
+        bucket.locations += Number(r.numberOfLocation) || 0;
+        bucket.trials += Number(r.numberOfTrialReplication) || 0;
+    }
+
+    return agg;
+}
+
+/**
+ * Collect sorted unique state names from the dataset.
+ */
+function getUniqueStates(records) {
+    const set = new Set();
+    for (const r of records) {
+        const name = r.kvk?.state?.stateName;
+        if (name) set.add(name);
+    }
+    return Array.from(set).sort();
+}
+
+/**
+ * Sum a Map<stateKey, bucket> across all states for a given list of stateKeys.
+ */
+function sumBuckets(stateMap, stateKeys) {
+    const total = { techs: 0, locations: 0, trials: 0 };
+    for (const key of stateKeys) {
+        const b = stateMap.get(key);
+        if (b) {
+            total.techs += b.techs;
+            total.locations += b.locations;
+            total.trials += b.trials;
+        }
+    }
+    return total;
+}
+
+// ── Main render function ────────────────────────────────────────────
+
+function renderOftSummarySection(section, data, sectionId, isFirstSection) {
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+        return this._generateEmptySection(section, null, sectionId, isFirstSection);
+    }
+
+    const records = Array.isArray(data) ? data : [data];
+    const pageClass = isFirstSection
+        ? 'section-page section-page-first'
+        : 'section-page section-page-continued';
+
+    // Detect multi-state mode
+    const states = getUniqueStates(records);
+    const isMultiState = states.length > 1;
+    const stateKeys = isMultiState ? states : ['__all__'];
+
+    const agg = buildAggregation(records, isMultiState);
+
+    // ── Header row ──────────────────────────────────────────────
+    const valueColCount = isMultiState ? states.length * 3 + 3 : 3;
+
+    let html = `
+<div id="${sectionId}" class="${pageClass}">
+    <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>
+    <table class="data-table">
+        <thead>`;
+
+    if (isMultiState) {
+        // Two-row header: top row with state group spans, bottom row with metric labels
+        html += `
+            <tr>
+                <th class="s-no" rowspan="2">S.No.</th>
+                <th rowspan="2">Sector wise Thematic Area</th>`;
+        for (const st of states) {
+            html += `<th colspan="3" style="text-align:center;">${this._escapeHtml(st)}</th>`;
+        }
+        html += `<th colspan="3" style="text-align:center;">Total</th>`;
+        html += `</tr>
+            <tr>`;
+        for (let i = 0; i <= states.length; i++) {
+            html += `
+                <th>No. of technologies assessed</th>
+                <th>No. of Locations</th>
+                <th>No. of Trial/Replications</th>`;
+        }
+        html += `</tr>`;
+    } else {
+        html += `
+            <tr>
+                <th class="s-no">S.No.</th>
+                <th>Sector wise Thematic Area</th>
+                <th>No. of technologies assessed</th>
+                <th>No. of Locations</th>
+                <th>No. of Trial/Replications</th>
+            </tr>`;
+    }
+
+    html += `
+        </thead>
+        <tbody>`;
+
+    // ── Body: iterate sectors ───────────────────────────────────
+    let serialNo = 0;
+    const grandTotal = { techs: 0, locations: 0, trials: 0 };
+    const grandTotalByState = {};
+    for (const st of stateKeys) {
+        grandTotalByState[st] = { techs: 0, locations: 0, trials: 0 };
+    }
+
+    for (const sector of SECTORS) {
+        const thematicMap = agg[sector.key]; // Map<thematicArea, Map<stateKey, bucket>>
+
+        // Sector header row
+        html += `
+            <tr style="background:#f0f0f0; font-weight:bold;">
+                <td colspan="${valueColCount + 2}" style="text-align:left; padding:6px 8px;">
+                    ${this._escapeHtml(sector.label)}
+                </td>
+            </tr>`;
+
+        // Sub-total accumulators for this sector
+        const sectorTotal = { techs: 0, locations: 0, trials: 0 };
+        const sectorTotalByState = {};
+        for (const st of stateKeys) {
+            sectorTotalByState[st] = { techs: 0, locations: 0, trials: 0 };
+        }
+
+        if (thematicMap.size === 0) {
+            // No data for this sector
+            html += `
+            <tr>
+                <td colspan="${valueColCount + 2}" style="text-align:center; color:#888;">No data available</td>
+            </tr>`;
+        }
+
+        // Sort thematic areas alphabetically
+        const sortedThematicAreas = Array.from(thematicMap.keys()).sort();
+
+        for (const thematicArea of sortedThematicAreas) {
+            serialNo += 1;
+            const stateMap = thematicMap.get(thematicArea);
+            const rowTotal = sumBuckets(stateMap, stateKeys);
+
+            html += `
+            <tr class="${serialNo % 2 === 0 ? 'even' : 'odd'}">
+                <td class="s-no">${serialNo}.</td>
+                <td>${this._escapeHtml(thematicArea)}</td>`;
+
+            if (isMultiState) {
+                for (const st of stateKeys) {
+                    const b = stateMap.get(st) || { techs: 0, locations: 0, trials: 0 };
+                    html += `
+                <td style="text-align:center;">${b.techs}</td>
+                <td style="text-align:center;">${b.locations}</td>
+                <td style="text-align:center;">${b.trials}</td>`;
+                    sectorTotalByState[st].techs += b.techs;
+                    sectorTotalByState[st].locations += b.locations;
+                    sectorTotalByState[st].trials += b.trials;
+                }
+                // Total column
+                html += `
+                <td style="text-align:center;">${rowTotal.techs}</td>
+                <td style="text-align:center;">${rowTotal.locations}</td>
+                <td style="text-align:center;">${rowTotal.trials}</td>`;
+            } else {
+                html += `
+                <td style="text-align:center;">${rowTotal.techs}</td>
+                <td style="text-align:center;">${rowTotal.locations}</td>
+                <td style="text-align:center;">${rowTotal.trials}</td>`;
+                const b = stateMap.get('__all__') || { techs: 0, locations: 0, trials: 0 };
+                sectorTotalByState['__all__'].techs += b.techs;
+                sectorTotalByState['__all__'].locations += b.locations;
+                sectorTotalByState['__all__'].trials += b.trials;
+            }
+
+            sectorTotal.techs += rowTotal.techs;
+            sectorTotal.locations += rowTotal.locations;
+            sectorTotal.trials += rowTotal.trials;
+
+            html += `</tr>`;
+        }
+
+        // Sub Total row
+        html += `
+            <tr style="font-weight:bold; background:#fafafa;">
+                <td></td>
+                <td style="text-align:right;">Sub Total</td>`;
+
+        if (isMultiState) {
+            for (const st of stateKeys) {
+                html += `
+                <td style="text-align:center;">${sectorTotalByState[st].techs}</td>
+                <td style="text-align:center;">${sectorTotalByState[st].locations}</td>
+                <td style="text-align:center;">${sectorTotalByState[st].trials}</td>`;
+                grandTotalByState[st].techs += sectorTotalByState[st].techs;
+                grandTotalByState[st].locations += sectorTotalByState[st].locations;
+                grandTotalByState[st].trials += sectorTotalByState[st].trials;
+            }
+            html += `
+                <td style="text-align:center;">${sectorTotal.techs}</td>
+                <td style="text-align:center;">${sectorTotal.locations}</td>
+                <td style="text-align:center;">${sectorTotal.trials}</td>`;
+        } else {
+            html += `
+                <td style="text-align:center;">${sectorTotal.techs}</td>
+                <td style="text-align:center;">${sectorTotal.locations}</td>
+                <td style="text-align:center;">${sectorTotal.trials}</td>`;
+            grandTotalByState['__all__'].techs += sectorTotalByState['__all__'].techs;
+            grandTotalByState['__all__'].locations += sectorTotalByState['__all__'].locations;
+            grandTotalByState['__all__'].trials += sectorTotalByState['__all__'].trials;
+        }
+
+        html += `</tr>`;
+
+        grandTotal.techs += sectorTotal.techs;
+        grandTotal.locations += sectorTotal.locations;
+        grandTotal.trials += sectorTotal.trials;
+    }
+
+    // ── Grand Total row ─────────────────────────────────────────
+    html += `
+            <tr style="font-weight:bold; background:#e8e8e8; border-top:2px solid #333;">
+                <td></td>
+                <td style="text-align:right;">Grand Total</td>`;
+
+    if (isMultiState) {
+        for (const st of stateKeys) {
+            html += `
+                <td style="text-align:center;">${grandTotalByState[st].techs}</td>
+                <td style="text-align:center;">${grandTotalByState[st].locations}</td>
+                <td style="text-align:center;">${grandTotalByState[st].trials}</td>`;
+        }
+        html += `
+                <td style="text-align:center;">${grandTotal.techs}</td>
+                <td style="text-align:center;">${grandTotal.locations}</td>
+                <td style="text-align:center;">${grandTotal.trials}</td>`;
+    } else {
+        html += `
+                <td style="text-align:center;">${grandTotal.techs}</td>
+                <td style="text-align:center;">${grandTotal.locations}</td>
+                <td style="text-align:center;">${grandTotal.trials}</td>`;
+    }
+
+    html += `</tr>`;
+
+    html += `
+        </tbody>
+    </table>
+</div>`;
+
+    return html;
+}
+
+module.exports = { renderOftSummarySection };

--- a/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
@@ -144,9 +144,14 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
     // ── Header row ──────────────────────────────────────────────
     const valueColCount = isMultiState ? states.length * 3 + 3 : 3;
 
+    // Title changes based on scope
+    const sectionTitle = isMultiState
+        ? 'State wise details of On Farm Trials (OFTs) conducted by KVKs'
+        : 'OFT Summary';
+
     let html = `
 <div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>
+    <h1 class="section-title">${section.id} ${this._escapeHtml(sectionTitle)}</h1>
     <table class="data-table">
         <thead>`;
 

--- a/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
@@ -122,13 +122,17 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
     const colCount = isMultiState ? 1 + (states.length * 3) + 3 : 4;
 
     let html = `
-<div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title" style="border-bottom:none;margin-bottom:4px;">2. ACHIEVEMENTS ON TECHNOLOGIES ASSESSED AND REFINED (OFT)</h1>
-    <p style="font-size:10px;font-weight:bold;margin-bottom:10px;">2.1. Technology Assessed by KVK (Discipline wise)</p>`;
+<div id="${sectionId}" class="${pageClass}">`;
 
     if (isMultiState) {
+        // Superadmin: full heading hierarchy matching original
         html += `
-    <p style="font-size:9px;font-weight:bold;margin-bottom:8px;">2.1. State wise details of On Farm Trials (OFTs) conducted by KVKs</p>`;
+    <h1 class="section-title" style="border-bottom:none;margin-bottom:6px;font-size:12px;">2. ACHIEVEMENTS ON TECHNOLOGIES ASSESSED AND REFINED (OFT)</h1>
+    <p style="font-size:11px;font-weight:bold;margin-bottom:12px;">2.1. Technology Assessed by KVK (Discipline wise)</p>`;
+    } else {
+        // KVK side: simple heading
+        html += `
+    <h1 class="section-title" style="margin-bottom:10px;">2.1. OFT Summary</h1>`;
     }
 
     html += `
@@ -136,6 +140,13 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
         <thead>`;
 
     if (isMultiState) {
+        // Row 0: "State wise details..." caption row spanning full width
+        html += `
+            <tr>
+                <th colspan="${colCount}" style="text-align:left;font-weight:bold;font-size:9pt;padding:8px;">
+                    2.1. State wise details of On Farm Trials (OFTs) conducted by KVKs
+                </th>
+            </tr>`;
         // Row 1: state name spans + Total span
         html += `
             <tr>
@@ -232,7 +243,7 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
         // Sub Total row
         html += `
             <tr style="font-weight:bold;">
-                <td>Sub Total (${sector.key})</td>`;
+                <td>${isMultiState ? `Sub Total (${sector.key})` : 'Sub Total'}</td>`;
 
         if (isMultiState) {
             for (const st of stateKeys) {
@@ -262,7 +273,7 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
     // Grand Total row
     html += `
             <tr style="font-weight:bold;">
-                <td>Grand Total (F)</td>`;
+                <td>${isMultiState ? 'Grand Total (F)' : 'Grand Total'}</td>`;
 
     if (isMultiState) {
         for (const st of stateKeys) {

--- a/backend/services/reports/reportAggregationService.js
+++ b/backend/services/reports/reportAggregationService.js
@@ -296,6 +296,28 @@ class ReportAggregationService {
             };
         }
 
+        // For custom format sections (OFT, etc.), combine all array data
+        if (sectionConfig.format === 'custom') {
+            const allRows = [];
+            validData.forEach(sd => {
+                if (Array.isArray(sd.data)) {
+                    allRows.push(...sd.data);
+                } else if (sd.data) {
+                    allRows.push(sd.data);
+                }
+            });
+
+            return {
+                sectionId,
+                data: allRows,
+                metadata: {
+                    recordCount: allRows.length,
+                    lastUpdated: new Date(),
+                    filters: {},
+                },
+            };
+        }
+
         // Default: return first valid data
         return validData[0];
     }

--- a/backend/services/reports/reportDataService.js
+++ b/backend/services/reports/reportDataService.js
@@ -71,9 +71,14 @@ class ReportDataService {
             case 'kvkFarmImplements':
                 rawData = await reportRepository.getKvkFarmImplements(kvkId, sectionFilters);
                 break;
-            case 'oftSummary':
-                rawData = await oftReportRepository.getOftSummaryData(kvkId, sectionFilters);
+            case 'oftSummary': {
+                const [summaryRecords, subjects] = await Promise.all([
+                    oftReportRepository.getOftSummaryData(kvkId, sectionFilters),
+                    oftReportRepository.getOftSubjectsWithThematicAreas(),
+                ]);
+                rawData = { records: summaryRecords, subjects };
                 break;
+            }
             case 'oftDetailCards':
                 rawData = await oftReportRepository.getOftDetailCards(kvkId, sectionFilters);
                 break;

--- a/backend/services/reports/reportDataService.js
+++ b/backend/services/reports/reportDataService.js
@@ -1,4 +1,5 @@
 const reportRepository = require('../../repositories/reports/reportRepository.js');
+const oftReportRepository = require('../../repositories/reports/oftReport/index.js');
 const { getSectionConfig } = require('../../config/reportConfig.js');
 const cacheService = require('../cache/redisCacheService.js');
 const CacheKeyBuilder = require('../../utils/cacheKeyBuilder.js');
@@ -70,12 +71,21 @@ class ReportDataService {
             case 'kvkFarmImplements':
                 rawData = await reportRepository.getKvkFarmImplements(kvkId, sectionFilters);
                 break;
+            case 'oftSummary':
+                rawData = await oftReportRepository.getOftSummaryData(kvkId, sectionFilters);
+                break;
+            case 'oftDetailCards':
+                rawData = await oftReportRepository.getOftDetailCards(kvkId, sectionFilters);
+                break;
             default:
                 throw new Error(`Unknown data source: ${dataSource}`);
         }
 
+        // OFT sections pass raw data to templates (complex nested structures)
+        const skipTransform = dataSource === 'oftSummary' || dataSource === 'oftDetailCards';
+
         // Transform data according to section configuration
-        const transformedData = this._transformSectionData(rawData, sectionConfig);
+        const transformedData = skipTransform ? rawData : this._transformSectionData(rawData, sectionConfig);
         
         // Build standardized structure
         const result = {

--- a/backend/services/reports/reportTemplateService.js
+++ b/backend/services/reports/reportTemplateService.js
@@ -8,6 +8,7 @@ const { renderEquipmentRecordsSection } = require('./formsTemplate/aboutkvkTempl
 const { renderAboutKvkSection } = require('./formsTemplate/aboutkvkTemplates/aboutKvkTemplate.js');
 const { renderOftSummarySection } = require('./formsTemplate/oftTemplates/oftSummaryTemplate.js');
 const { renderOftDetailCardsSection } = require('./formsTemplate/oftTemplates/oftDetailCardsTemplate.js');
+const { renderOftCombinedSection } = require('./formsTemplate/oftTemplates/oftCombinedTemplate.js');
 
 /**
  * Report Template Service
@@ -27,6 +28,7 @@ class ReportTemplateService {
             'about-kvk-equipment-details': renderEquipmentRecordsSection.bind(this),
             'oft-summary': renderOftSummarySection.bind(this),
             'oft-detail-cards': renderOftDetailCardsSection.bind(this),
+            'oft-combined': renderOftCombinedSection.bind(this),
         };
     }
 

--- a/backend/services/reports/reportTemplateService.js
+++ b/backend/services/reports/reportTemplateService.js
@@ -71,12 +71,12 @@ class ReportTemplateService {
      * Generate standalone HTML document for a custom template.
      * Reuses the same custom-template handlers used by all-reports flow.
      */
-    generateStandaloneCustomTemplateHTML(templateKey, data, options = {}) {
+    async generateStandaloneCustomTemplateHTML(templateKey, data, options = {}) {
         const { sectionId = '1.1', title = 'Custom Report' } = options;
         const pseudoSection = { id: sectionId, title };
         const sectionConfig = { customTemplate: templateKey };
         const sectionAnchorId = `section-${sectionId.replace(/\./g, '-')}`;
-        const renderedSection = this._generateCustomSection(
+        const renderedSection = await this._generateCustomSection(
             pseudoSection,
             data,
             sectionConfig,
@@ -232,6 +232,7 @@ class ReportTemplateService {
             );
         }
 
+        // Handler may return a string or a Promise (async handlers like oft-combined)
         return customTemplateHandler(section, data, sectionId, isFirstSection);
     }
 

--- a/backend/services/reports/reportTemplateService.js
+++ b/backend/services/reports/reportTemplateService.js
@@ -6,6 +6,8 @@ const { renderVehiclesSection } = require('./formsTemplate/aboutkvkTemplates/veh
 const { renderVehicleDetailsSection } = require('./formsTemplate/aboutkvkTemplates/vehicleDetailsTemplate.js');
 const { renderEquipmentRecordsSection } = require('./formsTemplate/aboutkvkTemplates/equipmentRecordsTemplate.js');
 const { renderAboutKvkSection } = require('./formsTemplate/aboutkvkTemplates/aboutKvkTemplate.js');
+const { renderOftSummarySection } = require('./formsTemplate/oftTemplates/oftSummaryTemplate.js');
+const { renderOftDetailCardsSection } = require('./formsTemplate/oftTemplates/oftDetailCardsTemplate.js');
 
 /**
  * Report Template Service
@@ -23,6 +25,8 @@ class ReportTemplateService {
             'about-kvk-equipment-records': renderEquipmentRecordsSection.bind(this),
             'about-kvk-equipment-record': renderEquipmentRecordsSection.bind(this),
             'about-kvk-equipment-details': renderEquipmentRecordsSection.bind(this),
+            'oft-summary': renderOftSummarySection.bind(this),
+            'oft-detail-cards': renderOftDetailCardsSection.bind(this),
         };
     }
 

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -730,6 +730,8 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                 ? 'about-kvk-vehicle-details'
                 : entityType === ENTITY_TYPES.KVK_EQUIPMENT_DETAILS
                 ? 'about-kvk-equipment-records'
+                : entityType === ENTITY_TYPES.ACHIEVEMENT_OFT
+                ? 'oft-detail-cards'
                 : undefined;
         await handleExportData(format, {
             title,

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -731,7 +731,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                 : entityType === ENTITY_TYPES.KVK_EQUIPMENT_DETAILS
                 ? 'about-kvk-equipment-records'
                 : entityType === ENTITY_TYPES.ACHIEVEMENT_OFT
-                ? 'oft-detail-cards'
+                ? 'oft-combined'
                 : undefined;
         await handleExportData(format, {
             title,


### PR DESCRIPTION
## Summary
- Add **Section 2.1 (OFT Summary)**: pivot table with sectors A-E, thematic area rows, subtotals, grand total. Auto-detects single-KVK vs multi-state (superadmin) and renders state-wise columns accordingly.
- Add **Section 2.2 (OFT Detail Cards)**: 16-field card layout per OFT trial with dynamic result tables. Groups by KVK for superadmin scope.
- Add `oftEndDate` field to Prisma schema (was missing from original model).
- New repository, templates, data service wiring, and aggregation support for OFT formats.

### Files changed
- `backend/prisma/kvk/achievements/oft_schema.prisma` — added `oftEndDate`
- `backend/config/reportConfig.js` — sections 2.1 & 2.2
- `backend/repositories/reports/oftReport/` — new OFT repository
- `backend/services/reports/formsTemplate/oftTemplates/` — summary matrix & detail cards renderers
- `backend/services/reports/reportDataService.js` — OFT data source routing
- `backend/services/reports/reportTemplateService.js` — registered OFT template handlers
- `backend/services/reports/reportAggregationService.js` — custom format aggregation for multi-KVK

## Test plan
- [ ] Run `npx prisma generate` — should succeed with new `oftEndDate` field
- [ ] Verify OFT summary renders correctly for single KVK (3-column format)
- [ ] Verify OFT summary renders correctly for multi-KVK/superadmin (state-wise columns)
- [ ] Verify OFT detail cards render all 16 fields per trial
- [ ] Verify dynamic result tables render with correct column-cell mapping
- [ ] Verify PDF/Excel/Word export for both sections
- [ ] Run `npx prisma migrate dev` to apply schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)