### PR TITLE
feat(permissions): per-user, per-module permission editor for *_user roles

### DIFF
--- a/backend/controllers/userPermissionController.js
+++ b/backend/controllers/userPermissionController.js
@@ -1,0 +1,54 @@
+const userPermissionService = require('../services/userPermissionService.js');
+
+const userPermissionController = {
+  /**
+   * GET /api/admin/users/:id/permissions
+   * Return the per-user permission matrix (role ceiling + user grants).
+   */
+  getUserPermissions: async (req, res) => {
+    try {
+      const id = Number(req.params.id);
+      if (!Number.isInteger(id) || id <= 0) {
+        return res.status(400).json({ error: 'Invalid user ID' });
+      }
+
+      const data = await userPermissionService.getUserPermissionsMatrix(id, req.user.userId);
+      res.status(200).json(data);
+    } catch (error) {
+      res.status(400).json({ error: error.message });
+    }
+  },
+
+  /**
+   * PUT /api/admin/users/:id/permissions
+   * Replace the user's per-module permission grants.
+   */
+  updateUserPermissions: async (req, res) => {
+    try {
+      const id = Number(req.params.id);
+      if (!Number.isInteger(id) || id <= 0) {
+        return res.status(400).json({ error: 'Invalid user ID' });
+      }
+
+      const { permissionIds } = req.body;
+      if (!Array.isArray(permissionIds)) {
+        return res.status(400).json({ error: 'permissionIds must be an array' });
+      }
+
+      const result = await userPermissionService.updateUserPermissions(
+        id,
+        permissionIds,
+        req.user.userId
+      );
+
+      res.status(200).json({
+        message: 'User permissions updated successfully',
+        count: result.count,
+      });
+    } catch (error) {
+      res.status(400).json({ error: error.message });
+    }
+  },
+};
+
+module.exports = userPermissionController;

--- a/backend/controllers/userPermissionController.js
+++ b/backend/controllers/userPermissionController.js
@@ -15,7 +15,7 @@ const userPermissionController = {
       const data = await userPermissionService.getUserPermissionsMatrix(id, req.user.userId);
       res.status(200).json(data);
     } catch (error) {
-      res.status(400).json({ error: error.message });
+      res.status(error.statusCode || 400).json({ error: error.message });
     }
   },
 
@@ -30,7 +30,7 @@ const userPermissionController = {
         return res.status(400).json({ error: 'Invalid user ID' });
       }
 
-      const { permissionIds } = req.body;
+      const { permissionIds, allowEmpty } = req.body;
       if (!Array.isArray(permissionIds)) {
         return res.status(400).json({ error: 'permissionIds must be an array' });
       }
@@ -38,7 +38,8 @@ const userPermissionController = {
       const result = await userPermissionService.updateUserPermissions(
         id,
         permissionIds,
-        req.user.userId
+        req.user.userId,
+        { allowEmpty: allowEmpty === true }
       );
 
       res.status(200).json({
@@ -46,7 +47,7 @@ const userPermissionController = {
         count: result.count,
       });
     } catch (error) {
-      res.status(400).json({ error: error.message });
+      res.status(error.statusCode || 400).json({ error: error.message });
     }
   },
 };

--- a/backend/repositories/userPermissionRepository.js
+++ b/backend/repositories/userPermissionRepository.js
@@ -104,6 +104,64 @@ const userPermissionRepository = {
     }
     return map;
   },
+
+  /**
+   * Get a user's raw permission rows enriched with module info.
+   * Used by the permission resolver to decide whether the user has real
+   * per-module grants or only the legacy USER_SCOPE ceiling.
+   *
+   * @param {number} userId - User ID
+   * @returns {Promise<Array<{ permissionId: number, action: string, moduleCode: string }>>}
+   */
+  getUserPermissionsWithModule: async (userId) => {
+    const rows = await prisma.userPermission.findMany({
+      where: { userId },
+      select: {
+        permissionId: true,
+        permission: {
+          select: {
+            action: true,
+            module: { select: { moduleCode: true } },
+          },
+        },
+      },
+    });
+
+    return rows
+      .map((r) => ({
+        permissionId: r.permissionId,
+        action: r.permission?.action,
+        moduleCode: r.permission?.module?.moduleCode,
+      }))
+      .filter((r) => r.action && r.moduleCode);
+  },
+
+  /**
+   * Replace a user's per-module permission grants atomically.
+   * Also clears any legacy USER_SCOPE rows so the resolver switches from
+   * fallback (ceiling) semantics to strict per-module intersection.
+   *
+   * @param {number} userId - User ID
+   * @param {number[]} permissionIds - Real per-module permission IDs to assign
+   * @returns {Promise<{ count: number }>} Number of rows inserted
+   */
+  setUserModulePermissions: async (userId, permissionIds) => {
+    return prisma.$transaction(async (tx) => {
+      await tx.userPermission.deleteMany({ where: { userId } });
+      if (!permissionIds?.length) {
+        return { count: 0 };
+      }
+      const data = permissionIds.map((permissionId) => ({
+        userId,
+        permissionId,
+      }));
+      const result = await tx.userPermission.createMany({
+        data,
+        skipDuplicates: true,
+      });
+      return { count: result.count };
+    });
+  },
 };
 
 module.exports = userPermissionRepository;

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 
 const userManagementController = require('../controllers/userManagementController.js');
 const rolePermissionController = require('../controllers/rolePermissionController.js');
+const userPermissionController = require('../controllers/userPermissionController.js');
 const logHistoryController = require('../controllers/logHistoryController.js');
 const notificationController = require('../controllers/notificationController.js');
 const moduleImageController = require('../controllers/moduleImageController.js');
@@ -46,6 +47,22 @@ router.put('/users/:id', strictRateLimiter, requirePermission(USER_MANAGEMENT_MO
 
 // Delete user (soft delete) – requires DELETE
 router.delete('/users/:id', strictRateLimiter, requirePermission(USER_MANAGEMENT_MODULE, 'DELETE'), userManagementController.deleteUser);
+
+// Per-user permission matrix – VIEW to read, EDIT to write.
+// Guarded by user_management_users module; the service layer additionally
+// enforces role hierarchy and that the target is a *_user role.
+router.get(
+  '/users/:id/permissions',
+  apiRateLimiter,
+  requirePermission(USER_MANAGEMENT_MODULE, 'VIEW'),
+  userPermissionController.getUserPermissions,
+);
+router.put(
+  '/users/:id/permissions',
+  strictRateLimiter,
+  requirePermission(USER_MANAGEMENT_MODULE, 'EDIT'),
+  userPermissionController.updateUserPermissions,
+);
 
 // Login activity logs – requires VIEW
 router.get('/log-history', apiRateLimiter, requirePermission(LOG_HISTORY_MODULE, 'VIEW'), logHistoryController.getLogHistory);

--- a/backend/services/auth/permissionResolverService.js
+++ b/backend/services/auth/permissionResolverService.js
@@ -5,6 +5,7 @@ const cacheService = require('../cache/redisCacheService.js');
 
 const CACHE_VERSION = 'v1';
 const DEFAULT_CACHE_TTL_SECONDS = 3600;
+const USER_SCOPE_MODULE_CODE = 'USER_SCOPE';
 
 const USER_PROFILE_FIELDS = {
   userId: true,
@@ -54,6 +55,29 @@ function intersectWithUserActions(rolePermissionsByModule, userActions) {
 
   for (const [moduleCode, actions] of Object.entries(rolePermissionsByModule)) {
     const filtered = actions.filter((action) => userActionSet.has(action));
+    if (filtered.length > 0) {
+      result[moduleCode] = filtered;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Strict per-module intersection between the role's permissions and the
+ * user's per-module grants. A user cannot exceed the role ceiling; a user
+ * missing a specific (module, action) pair simply does not get that cell.
+ *
+ * @param {Record<string, string[]>} rolePermissionsByModule
+ * @param {Array<{ moduleCode: string, action: string }>} userModuleGrants
+ * @returns {Record<string, string[]>}
+ */
+function intersectWithUserModuleGrants(rolePermissionsByModule, userModuleGrants) {
+  const userKeys = new Set(userModuleGrants.map((g) => `${g.moduleCode}:${g.action}`));
+  const result = {};
+
+  for (const [moduleCode, actions] of Object.entries(rolePermissionsByModule)) {
+    const filtered = actions.filter((action) => userKeys.has(`${moduleCode}:${action}`));
     if (filtered.length > 0) {
       result[moduleCode] = filtered;
     }
@@ -152,12 +176,30 @@ const permissionResolverService = {
     }
 
     const rolePermissionsByModule = await permissionResolverService.getRolePermissions(roleId, options);
-    const userActions = await userPermissionRepository.getUserPermissionActions(userId);
+    const userPermissionRows = await userPermissionRepository.getUserPermissionsWithModule(userId);
 
-    const effectivePermissions =
-      userActions.length > 0
-        ? intersectWithUserActions(rolePermissionsByModule, userActions)
-        : {};
+    // Split the user's raw rows into legacy ceiling (USER_SCOPE, flat action
+    // list) vs real per-module grants. If any per-module grant exists we
+    // switch to strict per-module intersection; otherwise we fall back to the
+    // legacy ceiling so pre-existing users keep their current effective access.
+    const userScopeActions = [];
+    const userModuleGrants = [];
+    for (const row of userPermissionRows) {
+      if (row.moduleCode === USER_SCOPE_MODULE_CODE) {
+        userScopeActions.push(row.action);
+      } else {
+        userModuleGrants.push({ moduleCode: row.moduleCode, action: row.action });
+      }
+    }
+
+    let effectivePermissions;
+    if (userModuleGrants.length > 0) {
+      effectivePermissions = intersectWithUserModuleGrants(rolePermissionsByModule, userModuleGrants);
+    } else if (userScopeActions.length > 0) {
+      effectivePermissions = intersectWithUserActions(rolePermissionsByModule, userScopeActions);
+    } else {
+      effectivePermissions = {};
+    }
 
     await cacheService.set(key, effectivePermissions, getCacheTtlSeconds());
     return clonePermissionsMap(effectivePermissions);

--- a/backend/services/userPermissionService.js
+++ b/backend/services/userPermissionService.js
@@ -7,6 +7,12 @@ const permissionResolverService = require('./auth/permissionResolverService.js')
 
 const USER_SCOPE_MODULE_CODE = 'USER_SCOPE';
 
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
 /**
  * Build the per-user permission matrix: every module with every action,
  * annotated with whether the user has it granted, and whether the user's
@@ -20,20 +26,20 @@ const USER_SCOPE_MODULE_CODE = 'USER_SCOPE';
 async function getUserPermissionsMatrix(userId, callerUserId) {
   const targetUser = await userRepository.findById(userId);
   if (!targetUser) {
-    throw new Error('User not found');
+    throw httpError(404, 'User not found');
   }
 
   const targetRoleName = targetUser.role?.roleName || '';
   if (!targetRoleName.endsWith('_user')) {
-    throw new Error('Per-user permissions are only configurable for *_user roles');
+    throw httpError(400, 'Per-user permissions are only configurable for *_user roles');
   }
 
   const caller = await userRepository.findById(callerUserId);
-  if (!caller) throw new Error('Caller not found');
+  if (!caller) throw httpError(403, 'Caller not found');
   const callerRoleName = caller.role?.roleName || '';
 
   if (callerRoleName !== 'super_admin' && !outranks(callerRoleName, targetUser.role)) {
-    throw new Error('You do not have permission to view this user\'s permissions');
+    throw httpError(403, 'You do not have permission to view this user\'s permissions');
   }
 
   const [roleModules, userRows] = await Promise.all([
@@ -102,38 +108,48 @@ async function getUserPermissionsMatrix(userId, callerUserId) {
  * @param {number[]} permissionIds - Desired set
  * @param {number} callerUserId - Caller user ID
  */
-async function updateUserPermissions(userId, permissionIds, callerUserId) {
+async function updateUserPermissions(userId, permissionIds, callerUserId, options = {}) {
   if (!Array.isArray(permissionIds)) {
-    throw new Error('permissionIds must be an array');
+    throw httpError(400, 'permissionIds must be an array');
   }
+
+  // Validate every entry is a positive integer BEFORE dedup, so duplicates
+  // don't masquerade as "invalid positive integers".
+  for (const id of permissionIds) {
+    const n = Number(id);
+    if (!Number.isInteger(n) || n <= 0) {
+      throw httpError(400, 'permissionIds must contain positive integers');
+    }
+  }
+  const uniqueIds = Array.from(new Set(permissionIds.map((id) => Number(id))));
 
   const targetUser = await userRepository.findById(userId);
   if (!targetUser) {
-    throw new Error('User not found');
+    throw httpError(404, 'User not found');
   }
 
   const targetRoleName = targetUser.role?.roleName || '';
   if (!targetRoleName.endsWith('_user')) {
-    throw new Error('Per-user permissions are only configurable for *_user roles');
+    throw httpError(400, 'Per-user permissions are only configurable for *_user roles');
   }
 
   const caller = await userRepository.findById(callerUserId);
-  if (!caller) throw new Error('Caller not found');
+  if (!caller) throw httpError(403, 'Caller not found');
   const callerRoleName = caller.role?.roleName || '';
 
   if (callerRoleName !== 'super_admin' && !outranks(callerRoleName, targetUser.role)) {
-    throw new Error('You do not have permission to edit this user\'s permissions');
+    throw httpError(403, 'You do not have permission to edit this user\'s permissions');
   }
 
-  // De-duplicate incoming IDs.
-  const uniqueIds = Array.from(new Set(permissionIds.map((id) => Number(id)))).filter(
-    (id) => Number.isInteger(id) && id > 0
-  );
-
-  if (uniqueIds.length !== permissionIds.length) {
-    // Non-integer / non-positive values were dropped; not fatal but worth rejecting.
-    // Keep strict to avoid silently saving a half-valid payload.
-    throw new Error('permissionIds must contain positive integers');
+  // Safety net: saving an empty set wipes both per-module rows AND legacy
+  // USER_SCOPE ceiling rows, leaving the user with zero effective access.
+  // Require explicit confirmation so an accidental "save with nothing checked"
+  // can't silently strip a user.
+  if (uniqueIds.length === 0 && !options.allowEmpty) {
+    throw httpError(
+      400,
+      'Saving zero permissions will strip all access from this user. Pass allowEmpty: true to confirm.'
+    );
   }
 
   if (uniqueIds.length > 0) {
@@ -149,13 +165,13 @@ async function updateUserPermissions(userId, permissionIds, callerUserId) {
     if (rows.length !== uniqueIds.length) {
       const known = new Set(rows.map((r) => r.permissionId));
       const invalid = uniqueIds.filter((id) => !known.has(id));
-      throw new Error(`Invalid permission IDs: ${invalid.join(', ')}`);
+      throw httpError(400, `Invalid permission IDs: ${invalid.join(', ')}`);
     }
 
     // Disallow USER_SCOPE rows — those belong to the legacy ceiling path.
     const userScopeHit = rows.find((r) => r.module?.moduleCode === USER_SCOPE_MODULE_CODE);
     if (userScopeHit) {
-      throw new Error('USER_SCOPE permissions cannot be set via the per-user editor');
+      throw httpError(400, 'USER_SCOPE permissions cannot be set via the per-user editor');
     }
 
     // Enforce role ceiling.
@@ -164,7 +180,8 @@ async function updateUserPermissions(userId, permissionIds, callerUserId) {
     );
     const outside = uniqueIds.filter((id) => !roleCeiling.has(id));
     if (outside.length > 0) {
-      throw new Error(
+      throw httpError(
+        400,
         `Permission(s) ${outside.join(', ')} are outside the user's role ceiling`
       );
     }

--- a/backend/services/userPermissionService.js
+++ b/backend/services/userPermissionService.js
@@ -1,0 +1,188 @@
+const prisma = require('../config/prisma.js');
+const userRepository = require('../repositories/userRepository.js');
+const userPermissionRepository = require('../repositories/userPermissionRepository.js');
+const rolePermissionRepository = require('../repositories/rolePermissionRepository.js');
+const { outranks } = require('../constants/roleHierarchy.js');
+const permissionResolverService = require('./auth/permissionResolverService.js');
+
+const USER_SCOPE_MODULE_CODE = 'USER_SCOPE';
+
+/**
+ * Build the per-user permission matrix: every module with every action,
+ * annotated with whether the user has it granted, and whether the user's
+ * role even allows it (the ceiling). The UI uses `roleGrants` to disable
+ * cells outside the ceiling.
+ *
+ * @param {number} userId - Target user ID
+ * @param {number} callerUserId - ID of the caller (for hierarchy check)
+ * @returns {Promise<object>}
+ */
+async function getUserPermissionsMatrix(userId, callerUserId) {
+  const targetUser = await userRepository.findById(userId);
+  if (!targetUser) {
+    throw new Error('User not found');
+  }
+
+  const targetRoleName = targetUser.role?.roleName || '';
+  if (!targetRoleName.endsWith('_user')) {
+    throw new Error('Per-user permissions are only configurable for *_user roles');
+  }
+
+  const caller = await userRepository.findById(callerUserId);
+  if (!caller) throw new Error('Caller not found');
+  const callerRoleName = caller.role?.roleName || '';
+
+  if (callerRoleName !== 'super_admin' && !outranks(callerRoleName, targetUser.role)) {
+    throw new Error('You do not have permission to view this user\'s permissions');
+  }
+
+  const [roleModules, userRows] = await Promise.all([
+    rolePermissionRepository.getRolePermissionsStructured(targetUser.roleId),
+    userPermissionRepository.getUserPermissionsWithModule(userId),
+  ]);
+
+  const userGrantKeys = new Set();
+  const userScopeActions = new Set();
+  for (const row of userRows) {
+    if (row.moduleCode === USER_SCOPE_MODULE_CODE) {
+      userScopeActions.add(row.action);
+    } else {
+      userGrantKeys.add(`${row.moduleCode}:${row.action}`);
+    }
+  }
+
+  const hasPerModuleGrants = userGrantKeys.size > 0;
+
+  const modules = roleModules
+    .filter((m) => m.moduleCode !== USER_SCOPE_MODULE_CODE)
+    .map((m) => ({
+      moduleId: m.moduleId,
+      menuName: m.menuName,
+      subMenuName: m.subMenuName,
+      moduleCode: m.moduleCode,
+      permissions: m.permissions.map((p) => {
+        const roleGrants = p.hasPermission;
+        let userHas;
+        if (hasPerModuleGrants) {
+          userHas = roleGrants && userGrantKeys.has(`${m.moduleCode}:${p.action}`);
+        } else {
+          userHas = roleGrants && userScopeActions.has(p.action);
+        }
+        return {
+          permissionId: p.permissionId,
+          action: p.action,
+          roleGrants,
+          hasPermission: userHas,
+        };
+      }),
+    }));
+
+  return {
+    userId: targetUser.userId,
+    name: targetUser.name,
+    email: targetUser.email,
+    roleId: targetUser.roleId,
+    roleName: targetRoleName,
+    modules,
+  };
+}
+
+/**
+ * Replace a user's per-module permissions. Silently clears any legacy
+ * USER_SCOPE ceiling rows so the resolver switches to strict per-module
+ * intersection for this user.
+ *
+ * Guardrails:
+ *   - target user exists and has a *_user role
+ *   - caller strictly outranks target (super_admin bypasses)
+ *   - every permissionId is a real permission
+ *   - every permissionId sits inside the target role's ceiling
+ *
+ * @param {number} userId - Target user ID
+ * @param {number[]} permissionIds - Desired set
+ * @param {number} callerUserId - Caller user ID
+ */
+async function updateUserPermissions(userId, permissionIds, callerUserId) {
+  if (!Array.isArray(permissionIds)) {
+    throw new Error('permissionIds must be an array');
+  }
+
+  const targetUser = await userRepository.findById(userId);
+  if (!targetUser) {
+    throw new Error('User not found');
+  }
+
+  const targetRoleName = targetUser.role?.roleName || '';
+  if (!targetRoleName.endsWith('_user')) {
+    throw new Error('Per-user permissions are only configurable for *_user roles');
+  }
+
+  const caller = await userRepository.findById(callerUserId);
+  if (!caller) throw new Error('Caller not found');
+  const callerRoleName = caller.role?.roleName || '';
+
+  if (callerRoleName !== 'super_admin' && !outranks(callerRoleName, targetUser.role)) {
+    throw new Error('You do not have permission to edit this user\'s permissions');
+  }
+
+  // De-duplicate incoming IDs.
+  const uniqueIds = Array.from(new Set(permissionIds.map((id) => Number(id)))).filter(
+    (id) => Number.isInteger(id) && id > 0
+  );
+
+  if (uniqueIds.length !== permissionIds.length) {
+    // Non-integer / non-positive values were dropped; not fatal but worth rejecting.
+    // Keep strict to avoid silently saving a half-valid payload.
+    throw new Error('permissionIds must contain positive integers');
+  }
+
+  if (uniqueIds.length > 0) {
+    // Load every requested permission with its module, in one query.
+    const rows = await prisma.permission.findMany({
+      where: { permissionId: { in: uniqueIds } },
+      select: {
+        permissionId: true,
+        module: { select: { moduleCode: true } },
+      },
+    });
+
+    if (rows.length !== uniqueIds.length) {
+      const known = new Set(rows.map((r) => r.permissionId));
+      const invalid = uniqueIds.filter((id) => !known.has(id));
+      throw new Error(`Invalid permission IDs: ${invalid.join(', ')}`);
+    }
+
+    // Disallow USER_SCOPE rows — those belong to the legacy ceiling path.
+    const userScopeHit = rows.find((r) => r.module?.moduleCode === USER_SCOPE_MODULE_CODE);
+    if (userScopeHit) {
+      throw new Error('USER_SCOPE permissions cannot be set via the per-user editor');
+    }
+
+    // Enforce role ceiling.
+    const roleCeiling = new Set(
+      await rolePermissionRepository.getRolePermissionIds(targetUser.roleId)
+    );
+    const outside = uniqueIds.filter((id) => !roleCeiling.has(id));
+    if (outside.length > 0) {
+      throw new Error(
+        `Permission(s) ${outside.join(', ')} are outside the user's role ceiling`
+      );
+    }
+  }
+
+  const result = await userPermissionRepository.setUserModulePermissions(userId, uniqueIds);
+
+  // Best-effort cache invalidation.
+  try {
+    await permissionResolverService.invalidateUserPermissions(userId);
+  } catch (error) {
+    console.error('Permission cache invalidation failed after user permission update:', error.message);
+  }
+
+  return result;
+}
+
+module.exports = {
+  getUserPermissionsMatrix,
+  updateUserPermissions,
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { DataManagementView } from './pages/dashboard/shared/DataManagementView'
 import { RoleManagement } from './pages/admin/RoleManagement'
 import { RolePermissionEditor } from './pages/admin/RolePermissionEditor'
 import { UserManagement } from './pages/admin/UserManagement'
+import { UserPermissionEditor } from './pages/admin/UserPermissionEditor'
 import { ModuleImages } from './pages/features/ModuleImages'
 import { Targets } from './pages/features/Targets'
 import { LogHistory } from './pages/admin/LogHistory'
@@ -127,6 +128,14 @@ function AppRoutes() {
                         element={
                             <ProtectedRoute requiredModuleCode="user_management_users">
                                 <UserManagement />
+                            </ProtectedRoute>
+                        }
+                    />
+                    <Route
+                        path="/view-users/:userId/permissions"
+                        element={
+                            <ProtectedRoute requiredModuleCode="user_management_users">
+                                <UserPermissionEditor />
                             </ProtectedRoute>
                         }
                     />

--- a/frontend/src/config/route/adminManagement.ts
+++ b/frontend/src/config/route/adminManagement.ts
@@ -31,6 +31,14 @@ export const adminManagementRoutes: RouteConfig[] = [
         moduleCode: 'role_management_roles',
     },
     {
+        path: '/view-users/:userId/permissions',
+        title: 'User Permissions',
+        description: 'Edit per-user module permissions',
+        category: 'Admin',
+        parent: '/view-users',
+        moduleCode: 'user_management_users',
+    },
+    {
         path: '/view-log-history',
         title: 'Log History',
         description: 'View system activity logs',

--- a/frontend/src/hooks/useUserManagement.ts
+++ b/frontend/src/hooks/useUserManagement.ts
@@ -118,3 +118,33 @@ export function useUpdateRolePermissions() {
         },
     });
 }
+
+/**
+ * Hook to fetch a user's permission matrix.
+ */
+export function useUserPermissions(userId: number | null) {
+    return useQuery({
+        queryKey: ['userPermissions', userId],
+        queryFn: () => userApi.getUserPermissions(userId!),
+        enabled: userId != null,
+        staleTime: 2 * 60 * 1000,
+    });
+}
+
+/**
+ * Hook to replace a user's per-module permission grants.
+ */
+export function useUpdateUserPermissions() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ userId, permissionIds }: { userId: number; permissionIds: number[] }) =>
+            userApi.updateUserPermissions(userId, permissionIds),
+        onSuccess: (_, variables) => {
+            queryClient.invalidateQueries({ queryKey: ['userPermissions', variables.userId] });
+            queryClient.invalidateQueries({ queryKey: ['users'] });
+            // Refresh current user's permissions in case the admin just edited themselves.
+            queryClient.invalidateQueries({ queryKey: ['currentUser'] });
+        },
+    });
+}

--- a/frontend/src/hooks/useUserManagement.ts
+++ b/frontend/src/hooks/useUserManagement.ts
@@ -138,8 +138,15 @@ export function useUpdateUserPermissions() {
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: ({ userId, permissionIds }: { userId: number; permissionIds: number[] }) =>
-            userApi.updateUserPermissions(userId, permissionIds),
+        mutationFn: ({
+            userId,
+            permissionIds,
+            allowEmpty,
+        }: {
+            userId: number
+            permissionIds: number[]
+            allowEmpty?: boolean
+        }) => userApi.updateUserPermissions(userId, permissionIds, { allowEmpty }),
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({ queryKey: ['userPermissions', variables.userId] });
             queryClient.invalidateQueries({ queryKey: ['users'] });

--- a/frontend/src/pages/admin/UserManagement.tsx
+++ b/frontend/src/pages/admin/UserManagement.tsx
@@ -6,7 +6,8 @@ import { useUsers, useDeleteUser } from '../../hooks/useUserManagement'
 import { CreateUserModal } from '@/components/admin/CreateUserModal'
 import { EditUserModal } from '@/components/admin/EditUserModal'
 import type { EditUser } from '@/components/admin/EditUserModal'
-import { Search, Plus, Edit, Trash2, AlertCircle, ChevronLeft } from 'lucide-react'
+import { Search, Plus, Edit, Trash2, AlertCircle, ChevronLeft, UserCog } from 'lucide-react'
+import { outranks } from '../../constants/roleHierarchy'
 import { Breadcrumbs } from '../../components/common/Breadcrumbs'
 import { Card, CardContent } from '../../components/ui/Card'
 import { getBreadcrumbsForPath, getRouteConfig } from '../../config/route'
@@ -36,7 +37,7 @@ interface User {
 export const UserManagement: React.FC = () => {
     const navigate = useNavigate()
     const location = useLocation()
-    const { hasPermission, canActOnRole } = useAuth()
+    const { user: currentUser, hasPermission, canActOnRole } = useAuth()
     const [searchTerm, setSearchTerm] = useState('')
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
     const [isEditModalOpen, setIsEditModalOpen] = useState(false)
@@ -71,7 +72,15 @@ export const UserManagement: React.FC = () => {
     const canCreateUsers = hasPermission('ADD', 'user_management_users')
     const canEditUser = hasPermission('EDIT', 'user_management_users')
     const canDeleteUser = hasPermission('DELETE', 'user_management_users')
-    const showActionsColumn = (canEditUser || canDeleteUser) && users.some(u => canActOnRole(u.roleName))
+    // Per-user permission editor is only offered for *_user target roles and
+    // when the caller strictly outranks them (matches backend hierarchy gate).
+    const canManagePermsFor = (u: User) =>
+        canEditUser &&
+        u.roleName?.endsWith('_user') &&
+        (currentUser?.role === 'super_admin' || outranks(currentUser?.role || '', u.roleName))
+    const showActionsColumn =
+        (canEditUser || canDeleteUser) &&
+        users.some(u => canActOnRole(u.roleName) || canManagePermsFor(u))
 
     // Handle delete user
     const handleDelete = async (userId: number) => {
@@ -273,6 +282,20 @@ export const UserManagement: React.FC = () => {
                                                 {showActionsColumn && (
                                                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                                                         <div className="flex items-center justify-end gap-2">
+                                                            {canManagePermsFor(user) && (
+                                                                <button
+                                                                    onClick={() =>
+                                                                        navigate(
+                                                                            `/view-users/${user.userId}/permissions`
+                                                                        )
+                                                                    }
+                                                                    className="p-1.5 text-[#487749] hover:bg-[#F5F5F5] rounded-xl border border-[#E0E0E0] transition-all duration-200"
+                                                                    aria-label="Manage permissions"
+                                                                    title="Manage permissions"
+                                                                >
+                                                                    <UserCog className="w-4 h-4" />
+                                                                </button>
+                                                            )}
                                                             {canEditUser && canActOnRole(user.roleName) && (
                                                                 <button
                                                                     onClick={() => {

--- a/frontend/src/pages/admin/UserPermissionEditor.tsx
+++ b/frontend/src/pages/admin/UserPermissionEditor.tsx
@@ -112,10 +112,16 @@ export const UserPermissionEditor: React.FC = () => {
     }, [data?.modules])
 
     const menuEntries = useMemo(() => {
-        return MENU_DISPLAY_ORDER.map((menuName) => [
-            menuName,
-            orderedModules.filter((m) => m.menuName === menuName),
-        ]).filter(([, mods]) => mods.length > 0) as [string, UserModuleWithPermissions[]][]
+        // Group by actual menus present in the payload so an unknown menu
+        // (e.g. one added to the backend but not yet listed in
+        // MENU_DISPLAY_ORDER) is appended at the end instead of dropped.
+        const groups = new Map<string, UserModuleWithPermissions[]>()
+        for (const mod of orderedModules) {
+            const arr = groups.get(mod.menuName) ?? []
+            arr.push(mod)
+            groups.set(mod.menuName, arr)
+        }
+        return Array.from(groups.entries()) as [string, UserModuleWithPermissions[]][]
     }, [orderedModules])
 
     // Only the role-granted permission IDs are toggleable. Header/group
@@ -185,15 +191,26 @@ export const UserPermissionEditor: React.FC = () => {
     const handleSave = async () => {
         if (!userId || !data) return
         setSuccessMessage(null)
+
+        const isEmpty = selectedPermissions.size === 0
+        if (isEmpty) {
+            const ok = window.confirm(
+                `${data.name} will have no access after this save. Continue?`
+            )
+            if (!ok) return
+        }
+
         try {
             await updateMutation.mutateAsync({
                 userId: Number(userId),
                 permissionIds: Array.from(selectedPermissions),
+                allowEmpty: isEmpty,
             })
             setSuccessMessage('User permissions updated successfully')
             setTimeout(() => setSuccessMessage(null), 3000)
         } catch {
-            // mutation error state drives the banner
+            // Mutation failure surfaces through updateMutation.error →
+            // the top-level error banner; nothing to handle here.
         }
     }
 

--- a/frontend/src/pages/admin/UserPermissionEditor.tsx
+++ b/frontend/src/pages/admin/UserPermissionEditor.tsx
@@ -1,0 +1,440 @@
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
+import { useAuth } from '../../contexts/AuthContext'
+import { outranks } from '../../constants/roleHierarchy'
+import { UserModuleWithPermissions, getRoleLabel } from '../../services/userApi'
+import { useUserPermissions, useUpdateUserPermissions } from '../../hooks/useUserManagement'
+import { AlertCircle, CheckCircle2, ChevronLeft } from 'lucide-react'
+import { Breadcrumbs } from '../../components/common/Breadcrumbs'
+import { Card, CardContent } from '../../components/ui/Card'
+import { getBreadcrumbsForPath, getRouteConfig } from '../../config/route'
+
+const MENU_DISPLAY_ORDER = [
+    'All Masters',
+    'Role Management',
+    'User Management',
+    'About KVKs',
+    'Achievements',
+    'Performance Indicators',
+    'Miscellaneous Information',
+    'Digital Information',
+    'Swachh Bharat Abhiyaan',
+    'Meetings',
+    'Module Images',
+    'Targets',
+    'Log History',
+    'Notifications',
+    'Reports',
+]
+
+const IndeterminateCheckbox: React.FC<
+    React.InputHTMLAttributes<HTMLInputElement> & { indeterminate?: boolean }
+> = ({ indeterminate, ...props }) => {
+    const ref = useRef<HTMLInputElement>(null)
+    useEffect(() => {
+        if (ref.current) ref.current.indeterminate = !!indeterminate
+    }, [indeterminate])
+    return <input ref={ref} type="checkbox" {...props} />
+}
+
+const CHECKBOX_CLASS =
+    'w-4 h-4 text-[#487749] border-[#E0E0E0] rounded focus:ring-[#487749]/20 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed'
+
+export const UserPermissionEditor: React.FC = () => {
+    const { userId } = useParams<{ userId: string }>()
+    const navigate = useNavigate()
+    const location = useLocation()
+    const { user: currentUser } = useAuth()
+    const [successMessage, setSuccessMessage] = useState<string | null>(null)
+    const [selectedPermissions, setSelectedPermissions] = useState<Set<number>>(new Set())
+
+    const routeConfig = getRouteConfig(location.pathname)
+    const breadcrumbs = getBreadcrumbsForPath(location.pathname)
+
+    const {
+        data,
+        isLoading,
+        error: queryError,
+    } = useUserPermissions(userId ? Number(userId) : null)
+
+    const updateMutation = useUpdateUserPermissions()
+    const isSaving = updateMutation.isPending
+    const error = queryError
+        ? queryError instanceof Error
+            ? queryError.message
+            : 'Failed to load permissions'
+        : updateMutation.error
+        ? updateMutation.error instanceof Error
+            ? updateMutation.error.message
+            : 'Failed to save permissions'
+        : null
+
+    // Seed selected set from current user grants
+    useEffect(() => {
+        if (data) {
+            const selected = new Set<number>()
+            data.modules.forEach((module) => {
+                module.permissions.forEach((p) => {
+                    if (p.hasPermission) selected.add(p.permissionId)
+                })
+            })
+            setSelectedPermissions(selected)
+        }
+    }, [data])
+
+    // Caller must strictly outrank the target user's role to edit (super_admin bypass).
+    const canEdit =
+        currentUser?.role === 'super_admin' ||
+        (data?.roleName ? outranks(currentUser?.role || '', data.roleName) : false)
+
+    const togglePermission = (permissionId: number, roleGrants: boolean) => {
+        if (!canEdit || !roleGrants) return
+        setSelectedPermissions((prev) => {
+            const next = new Set(prev)
+            if (next.has(permissionId)) next.delete(permissionId)
+            else next.add(permissionId)
+            return next
+        })
+    }
+
+    const orderedModules = useMemo(() => {
+        if (!data?.modules) return []
+        const orderIndex = (name: string) => {
+            const i = MENU_DISPLAY_ORDER.indexOf(name)
+            return i === -1 ? MENU_DISPLAY_ORDER.length : i
+        }
+        return [...data.modules].sort((a, b) => {
+            const i = orderIndex(a.menuName)
+            const j = orderIndex(b.menuName)
+            if (i !== j) return i - j
+            return a.subMenuName.localeCompare(b.subMenuName)
+        })
+    }, [data?.modules])
+
+    const menuEntries = useMemo(() => {
+        return MENU_DISPLAY_ORDER.map((menuName) => [
+            menuName,
+            orderedModules.filter((m) => m.menuName === menuName),
+        ]).filter(([, mods]) => mods.length > 0) as [string, UserModuleWithPermissions[]][]
+    }, [orderedModules])
+
+    // Only the role-granted permission IDs are toggleable. Header/group
+    // "select all" checkboxes ignore anything outside the role ceiling.
+    const { viewIds, addIds, editIds, deleteIds } = useMemo(() => {
+        const viewIds: number[] = []
+        const addIds: number[] = []
+        const editIds: number[] = []
+        const deleteIds: number[] = []
+        orderedModules.forEach((mod) => {
+            mod.permissions.forEach((p) => {
+                if (!p.roleGrants) return
+                if (p.action === 'VIEW') viewIds.push(p.permissionId)
+                else if (p.action === 'ADD') addIds.push(p.permissionId)
+                else if (p.action === 'EDIT') editIds.push(p.permissionId)
+                else if (p.action === 'DELETE') deleteIds.push(p.permissionId)
+            })
+        })
+        return { viewIds, addIds, editIds, deleteIds }
+    }, [orderedModules])
+
+    const groupPermIds = useMemo(() => {
+        const map: Record<
+            string,
+            { viewIds: number[]; addIds: number[]; editIds: number[]; deleteIds: number[] }
+        > = {}
+        for (const [menuName, modules] of menuEntries) {
+            const g = {
+                viewIds: [] as number[],
+                addIds: [] as number[],
+                editIds: [] as number[],
+                deleteIds: [] as number[],
+            }
+            for (const mod of modules) {
+                for (const p of mod.permissions) {
+                    if (!p.roleGrants) continue
+                    if (p.action === 'VIEW') g.viewIds.push(p.permissionId)
+                    else if (p.action === 'ADD') g.addIds.push(p.permissionId)
+                    else if (p.action === 'EDIT') g.editIds.push(p.permissionId)
+                    else if (p.action === 'DELETE') g.deleteIds.push(p.permissionId)
+                }
+            }
+            map[menuName] = g
+        }
+        return map
+    }, [menuEntries])
+
+    const allSelected = useCallback(
+        (ids: number[]) => ids.length > 0 && ids.every((id) => selectedPermissions.has(id)),
+        [selectedPermissions]
+    )
+    const someSelected = useCallback(
+        (ids: number[]) => ids.length > 0 && ids.some((id) => selectedPermissions.has(id)),
+        [selectedPermissions]
+    )
+
+    const toggleAllForAction = (ids: number[]) => {
+        if (!canEdit) return
+        setSelectedPermissions((prev) => {
+            const next = new Set(prev)
+            const select = !allSelected(ids)
+            ids.forEach((id) => (select ? next.add(id) : next.delete(id)))
+            return next
+        })
+    }
+
+    const handleSave = async () => {
+        if (!userId || !data) return
+        setSuccessMessage(null)
+        try {
+            await updateMutation.mutateAsync({
+                userId: Number(userId),
+                permissionIds: Array.from(selectedPermissions),
+            })
+            setSuccessMessage('User permissions updated successfully')
+            setTimeout(() => setSuccessMessage(null), 3000)
+        } catch {
+            // mutation error state drives the banner
+        }
+    }
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center min-h-[400px]">
+                <div className="text-center">
+                    <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-[#487749]" />
+                    <p className="mt-4 text-[#757575]">Loading permissions...</p>
+                </div>
+            </div>
+        )
+    }
+
+    if (!data) {
+        return (
+            <div className="flex items-center justify-center min-h-[400px]">
+                <div className="text-center text-[#757575]">User not found</div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="bg-white rounded-2xl p-1">
+            <div className="mb-6 flex items-center gap-4 px-6 pt-4">
+                <button
+                    onClick={() => {
+                        if (routeConfig?.parent) {
+                            navigate(routeConfig.parent)
+                        } else {
+                            navigate('/view-users')
+                        }
+                    }}
+                    className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-[#487749] border border-[#E0E0E0] rounded-xl hover:bg-[#F5F5F5] transition-colors"
+                >
+                    <ChevronLeft className="w-4 h-4" />
+                    Back
+                </button>
+                {breadcrumbs.length > 0 && (
+                    <Breadcrumbs
+                        items={breadcrumbs.map((b, i) => ({ ...b, level: i }))}
+                        showHome={false}
+                    />
+                )}
+            </div>
+
+            <Card className="bg-[#FAF9F6]">
+                <CardContent className="p-6">
+                    <div className="mb-6 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+                        <div>
+                            <h2 className="text-xl font-semibold text-[#487749]">
+                                User Permissions: {data.name}
+                            </h2>
+                            <p className="text-sm text-[#757575] mt-1">
+                                {data.email} — {getRoleLabel(data.roleName)}
+                            </p>
+                            <p className="text-xs text-[#9E9E9E] mt-1">
+                                Unavailable cells are outside this role's ceiling.
+                            </p>
+                        </div>
+                        {canEdit ? (
+                            <button
+                                onClick={handleSave}
+                                disabled={isSaving}
+                                className="flex items-center gap-2 px-6 py-2.5 bg-[#487749] text-white rounded-xl text-sm font-medium hover:bg-[#3d6540] disabled:opacity-50 transition-all duration-200 shadow-sm"
+                            >
+                                {isSaving ? 'Saving...' : 'Save Changes'}
+                            </button>
+                        ) : (
+                            <span className="px-4 py-2 text-sm font-medium text-[#757575] bg-[#F5F5F5] rounded-xl border border-[#E0E0E0]">
+                                View Only
+                            </span>
+                        )}
+                    </div>
+
+                    {error && (
+                        <div className="mb-4 flex items-center gap-2 p-4 bg-red-50 border border-red-200 rounded-xl text-red-600 text-sm">
+                            <AlertCircle className="w-4 h-4 shrink-0" />
+                            <span>{error}</span>
+                        </div>
+                    )}
+                    {successMessage && (
+                        <div className="mb-4 flex items-center gap-2 p-4 bg-green-50 border border-green-200 rounded-xl text-green-600 text-sm">
+                            <CheckCircle2 className="w-4 h-4 shrink-0" />
+                            <span>{successMessage}</span>
+                        </div>
+                    )}
+
+                    <div className="bg-white rounded-xl border border-[#E0E0E0] overflow-hidden mt-4">
+                        <div className="overflow-x-auto">
+                            <table className="w-full border-collapse">
+                                <thead>
+                                    <tr className="bg-[#F5F5F5] border-b border-[#E0E0E0]">
+                                        <th className="px-6 py-4 text-left text-xs font-semibold text-[#212121] uppercase tracking-wider border-r border-[#E0E0E0]">
+                                            Menu
+                                        </th>
+                                        <th className="px-6 py-4 text-left text-xs font-semibold text-[#212121] uppercase tracking-wider border-r border-[#E0E0E0]">
+                                            Sub Menu
+                                        </th>
+                                        {(['VIEW', 'ADD', 'EDIT', 'DELETE'] as const).map((action) => {
+                                            const ids =
+                                                action === 'VIEW'
+                                                    ? viewIds
+                                                    : action === 'ADD'
+                                                    ? addIds
+                                                    : action === 'EDIT'
+                                                    ? editIds
+                                                    : deleteIds
+                                            return (
+                                                <th
+                                                    key={action}
+                                                    className={`px-4 py-4 text-center text-xs font-semibold text-[#212121] uppercase tracking-wider ${
+                                                        action === 'DELETE'
+                                                            ? ''
+                                                            : 'border-r border-[#E0E0E0]'
+                                                    }`}
+                                                >
+                                                    <div className="flex flex-col items-center gap-1.5">
+                                                        <span>
+                                                            {action.charAt(0) +
+                                                                action.slice(1).toLowerCase()}
+                                                        </span>
+                                                        <IndeterminateCheckbox
+                                                            checked={allSelected(ids)}
+                                                            indeterminate={
+                                                                !allSelected(ids) && someSelected(ids)
+                                                            }
+                                                            onChange={() => toggleAllForAction(ids)}
+                                                            disabled={!canEdit || ids.length === 0}
+                                                            className={CHECKBOX_CLASS}
+                                                        />
+                                                    </div>
+                                                </th>
+                                            )
+                                        })}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {menuEntries.map(([menuName, modules]) => {
+                                        const gp = groupPermIds[menuName]
+                                        return (
+                                            <React.Fragment key={menuName}>
+                                                <tr className="bg-[#EFF5EF] border-b border-[#E0E0E0]">
+                                                    <td className="px-6 py-3 text-sm font-semibold text-[#487749] border-r border-[#E0E0E0]">
+                                                        {menuName}
+                                                    </td>
+                                                    <td className="px-6 py-3 text-xs text-[#757575] italic border-r border-[#E0E0E0]">
+                                                        Select all
+                                                    </td>
+                                                    {(
+                                                        [
+                                                            ['VIEW', gp.viewIds],
+                                                            ['ADD', gp.addIds],
+                                                            ['EDIT', gp.editIds],
+                                                            ['DELETE', gp.deleteIds],
+                                                        ] as const
+                                                    ).map(([action, ids], idx) => (
+                                                        <td
+                                                            key={action}
+                                                            className={`px-4 py-3 text-center ${
+                                                                idx === 3 ? '' : 'border-r border-[#E0E0E0]'
+                                                            }`}
+                                                        >
+                                                            {ids.length > 0 && (
+                                                                <IndeterminateCheckbox
+                                                                    checked={allSelected(ids)}
+                                                                    indeterminate={
+                                                                        !allSelected(ids) &&
+                                                                        someSelected(ids)
+                                                                    }
+                                                                    onChange={() =>
+                                                                        toggleAllForAction(ids)
+                                                                    }
+                                                                    disabled={!canEdit}
+                                                                    className={CHECKBOX_CLASS}
+                                                                />
+                                                            )}
+                                                        </td>
+                                                    ))}
+                                                </tr>
+                                                {modules.map((module) => {
+                                                    const cells = (
+                                                        ['VIEW', 'ADD', 'EDIT', 'DELETE'] as const
+                                                    ).map((action) =>
+                                                        module.permissions.find((p) => p.action === action)
+                                                    )
+                                                    return (
+                                                        <tr
+                                                            key={module.moduleId}
+                                                            className="border-b border-[#E0E0E0] hover:bg-[#F5F5F5] transition-colors"
+                                                        >
+                                                            <td className="border-r border-[#E0E0E0]" />
+                                                            <td className="px-6 py-4 text-sm text-[#212121] border-r border-[#E0E0E0]">
+                                                                {module.subMenuName}
+                                                            </td>
+                                                            {cells.map((p, idx) => (
+                                                                <td
+                                                                    key={idx}
+                                                                    className={`px-4 py-4 text-center ${
+                                                                        idx === 3
+                                                                            ? ''
+                                                                            : 'border-r border-[#E0E0E0]'
+                                                                    }`}
+                                                                >
+                                                                    {p && (
+                                                                        <input
+                                                                            type="checkbox"
+                                                                            checked={selectedPermissions.has(
+                                                                                p.permissionId
+                                                                            )}
+                                                                            onChange={() =>
+                                                                                togglePermission(
+                                                                                    p.permissionId,
+                                                                                    p.roleGrants
+                                                                                )
+                                                                            }
+                                                                            disabled={
+                                                                                !canEdit || !p.roleGrants
+                                                                            }
+                                                                            title={
+                                                                                !p.roleGrants
+                                                                                    ? 'Not available in this role'
+                                                                                    : undefined
+                                                                            }
+                                                                            className={CHECKBOX_CLASS}
+                                                                        />
+                                                                    )}
+                                                                </td>
+                                                            ))}
+                                                        </tr>
+                                                    )
+                                                })}
+                                            </React.Fragment>
+                                        )
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    )
+}

--- a/frontend/src/services/userApi.ts
+++ b/frontend/src/services/userApi.ts
@@ -96,6 +96,33 @@ export interface RolePermissionsResponse {
   modules: ModuleWithPermissions[];
 }
 
+/** Per-user permission cell: carries both the user's grant and the role ceiling. */
+export interface UserModulePermission {
+  permissionId: number;
+  action: 'VIEW' | 'ADD' | 'EDIT' | 'DELETE';
+  /** Whether the user currently has this permission. */
+  hasPermission: boolean;
+  /** Whether the user's role grants this permission (the ceiling). */
+  roleGrants: boolean;
+}
+
+export interface UserModuleWithPermissions {
+  moduleId: number;
+  menuName: string;
+  subMenuName: string;
+  moduleCode: string;
+  permissions: UserModulePermission[];
+}
+
+export interface UserPermissionsResponse {
+  userId: number;
+  name: string;
+  email: string;
+  roleId: number;
+  roleName: string;
+  modules: UserModuleWithPermissions[];
+}
+
 export const userApi = {
   /**
    * Create a new role (super_admin only)
@@ -254,6 +281,35 @@ export const userApi = {
     } catch (error) {
       if (error instanceof ApiError) {
         throw new Error(error.data?.error || 'Failed to delete user');
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * Get the per-user permission matrix (role ceiling + user grants).
+   * Only valid for *_user roles.
+   */
+  getUserPermissions: async (userId: number): Promise<UserPermissionsResponse> => {
+    try {
+      return await apiClient.get<UserPermissionsResponse>(`/admin/users/${userId}/permissions`);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw new Error(error.data?.error || 'Failed to fetch user permissions');
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * Replace a user's per-module permission grants.
+   */
+  updateUserPermissions: async (userId: number, permissionIds: number[]): Promise<void> => {
+    try {
+      await apiClient.put(`/admin/users/${userId}/permissions`, { permissionIds });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw new Error(error.data?.error || 'Failed to update user permissions');
       }
       throw error;
     }

--- a/frontend/src/services/userApi.ts
+++ b/frontend/src/services/userApi.ts
@@ -303,10 +303,19 @@ export const userApi = {
 
   /**
    * Replace a user's per-module permission grants.
+   * Pass `allowEmpty: true` when intentionally stripping all access — the
+   * backend otherwise rejects an empty set to guard against accidental wipes.
    */
-  updateUserPermissions: async (userId: number, permissionIds: number[]): Promise<void> => {
+  updateUserPermissions: async (
+    userId: number,
+    permissionIds: number[],
+    options: { allowEmpty?: boolean } = {}
+  ): Promise<void> => {
     try {
-      await apiClient.put(`/admin/users/${userId}/permissions`, { permissionIds });
+      await apiClient.put(`/admin/users/${userId}/permissions`, {
+        permissionIds,
+        allowEmpty: options.allowEmpty === true,
+      });
     } catch (error) {
       if (error instanceof ApiError) {
         throw new Error(error.data?.error || 'Failed to update user permissions');


### PR DESCRIPTION
## Summary

- New layer of authorization on top of role permissions: admins can open any `*_user` account from User Management and toggle module access cell-by-cell, scoped to the role's ceiling.
- Backend resolver now does strict per-module intersection when per-module grants exist, with the legacy `USER_SCOPE` ceiling kept as a fallback so existing users keep identical effective access on deploy.
- New backend endpoints `GET / PUT /api/admin/users/:id/permissions`, guarded by `user_management_users` VIEW/EDIT plus a service-layer hierarchy + `*_user` gate.
- New frontend page `UserPermissionEditor` (matrix UI cloned from the role editor) reachable via a `UserCog` button on every `*_user` row in User Management. Out-of-ceiling cells are disabled with a "Not available in this role" tooltip.

## Non-breaking

Existing users with only `USER_SCOPE` rows continue to resolve identically. A user switches to per-module semantics only the first time an admin saves them in the new editor — no migration required.

## Test plan

- [ ] Backend boots cleanly (`npm start` from `/backend`)
- [ ] Frontend builds (`bun run build`) and `tsc --noEmit` introduces no new errors in touched files
- [ ] Log in as super_admin → User Management → row of a `*_user` shows the new UserCog icon (order: UserCog → Edit → Delete)
- [ ] UserCog opens `/view-users/:userId/permissions`; matrix loads; cells the role doesn't grant are disabled with the tooltip
- [ ] Toggle a few cells, Save → success banner; reload editor, selections persist
- [ ] Backend rejects writes from a caller that doesn't strictly outrank the target (403)
- [ ] Backend rejects per-user editor for non-`*_user` targets (e.g. `state_admin`) (400)
- [ ] Existing `*_user` accounts (legacy USER_SCOPE ceiling, no per-module rows) still log in with the same effective access until first save through the new editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)