### PR TITLE
fix(permissions): dedicated all_masters_kvks + trim *_user role ceilings

### DIFF
--- a/backend/scripts/permissions.js
+++ b/backend/scripts/permissions.js
@@ -14,6 +14,7 @@ const MODULES = [
   { menuName: 'All Masters', subMenuName: 'Organization Master', moduleCode: 'all_masters_organization_master' },
   { menuName: 'All Masters', subMenuName: 'Districts Master', moduleCode: 'all_masters_districts_master' },
   { menuName: 'All Masters', subMenuName: 'University Master', moduleCode: 'all_masters_university_master' },
+  { menuName: 'All Masters', subMenuName: 'KVK Master', moduleCode: 'all_masters_kvks' },
   { menuName: 'All Masters', subMenuName: 'OFT Master', moduleCode: 'all_masters_oft_master' },
   { menuName: 'All Masters', subMenuName: 'FLD Master', moduleCode: 'all_masters_fld_master' },
   { menuName: 'All Masters', subMenuName: 'CFLD Master', moduleCode: 'all_masters_cfld_master' },
@@ -123,7 +124,7 @@ const BASE_USER_MODULES = [
   'misc_ppv_fra_training', 'misc_rawe_fet', 'misc_vip_visitors',
   'digital_mobile_app', 'digital_web_portal', 'digital_kisan_sarthi', 'digital_kisan_advisory',
   'digital_messages_other_channels', 'swachh_observation_sewa', 'swachh_pakhwada',
-  'swachh_budget_expenditure', 'meetings_sac', 'meetings_other_atari', 'all_masters_nicra_master', 'all_masters_natural_farming_master', 'module_images', 'notifications',
+  'swachh_budget_expenditure', 'meetings_sac', 'meetings_other_atari', 'all_masters_nicra_master', 'all_masters_natural_farming_master', 'module_images', 'notifications', 'form_summary_status',
 ];
 
 const USER_ACTIONS = PERMISSION_ACTIONS;
@@ -132,32 +133,32 @@ const ROLE_PERMISSIONS = {
   super_admin: { permissions: 'ALL' },
   zone_admin: {
     permissions: {
-      modules: ['all_masters_zone_master', 'all_masters_states_master', 'all_masters_districts_master', 'all_masters_organization_master', 'all_masters_nicra_master', 'all_masters_impact_area_master', 'all_masters_enterprise_type_master', 'all_masters_account_type_master', 'all_masters_programme_type_master', 'all_masters_ppv_fra_training_type_master', 'all_masters_dignitary_type_master', 'user_management_users', 'role_management_roles', 'about_kvks_view_kvks', 'about_kvks_bank_account_details', 'about_kvks_employee_details', 'about_kvks_staff_details', 'about_kvks_infrastructure_details', 'about_kvks_vehicle_details', 'about_kvks_equipment_details', 'about_kvks_farm_implement_details', 'achievements_technical_achievement_summary', 'achievements_oft', 'achievements_fld', 'achievements_trainings', 'achievements_extension_activities', 'achievements_other_extension_activities', 'performance_indicators_impact', 'performance_indicators_district_village', 'performance_indicators_infrastructure', 'performance_indicators_financial', 'performance_indicators_linkages', 'module_images', 'reports', 'log_history', 'notifications', 'form_summary_status'],
+      modules: ['all_masters_zone_master', 'all_masters_states_master', 'all_masters_districts_master', 'all_masters_organization_master', 'all_masters_university_master', 'all_masters_kvks', 'all_masters_nicra_master', 'all_masters_impact_area_master', 'all_masters_enterprise_type_master', 'all_masters_account_type_master', 'all_masters_programme_type_master', 'all_masters_ppv_fra_training_type_master', 'all_masters_dignitary_type_master', 'user_management_users', 'role_management_roles', 'about_kvks_view_kvks', 'about_kvks_bank_account_details', 'about_kvks_employee_details', 'about_kvks_staff_details', 'about_kvks_infrastructure_details', 'about_kvks_vehicle_details', 'about_kvks_equipment_details', 'about_kvks_farm_implement_details', 'achievements_technical_achievement_summary', 'achievements_oft', 'achievements_fld', 'achievements_trainings', 'achievements_extension_activities', 'achievements_other_extension_activities', 'performance_indicators_impact', 'performance_indicators_district_village', 'performance_indicators_infrastructure', 'performance_indicators_financial', 'performance_indicators_linkages', 'module_images', 'reports', 'log_history', 'notifications', 'form_summary_status'],
       actions: ['VIEW', 'ADD', 'EDIT', 'DELETE'],
     },
   },
   state_admin: {
     permissions: {
-      modules: ['all_masters_states_master', 'all_masters_districts_master', 'all_masters_organization_master', 'all_masters_nicra_master', 'all_masters_impact_area_master', 'all_masters_enterprise_type_master', 'all_masters_account_type_master', 'all_masters_programme_type_master', 'all_masters_ppv_fra_training_type_master', 'all_masters_dignitary_type_master', 'user_management_users', 'about_kvks_view_kvks', 'about_kvks_bank_account_details', 'about_kvks_employee_details', 'about_kvks_staff_details', 'achievements_technical_achievement_summary', 'achievements_oft', 'achievements_fld', 'achievements_trainings', 'performance_indicators_impact', 'module_images', 'reports', 'log_history', 'notifications', 'form_summary_status'],
+      modules: ['all_masters_states_master', 'all_masters_districts_master', 'all_masters_organization_master', 'all_masters_university_master', 'all_masters_kvks', 'all_masters_nicra_master', 'all_masters_impact_area_master', 'all_masters_enterprise_type_master', 'all_masters_account_type_master', 'all_masters_programme_type_master', 'all_masters_ppv_fra_training_type_master', 'all_masters_dignitary_type_master', 'user_management_users', 'about_kvks_view_kvks', 'about_kvks_bank_account_details', 'about_kvks_employee_details', 'about_kvks_staff_details', 'achievements_technical_achievement_summary', 'achievements_oft', 'achievements_fld', 'achievements_trainings', 'performance_indicators_impact', 'module_images', 'reports', 'log_history', 'notifications', 'form_summary_status'],
       actions: ['VIEW', 'ADD', 'EDIT', 'DELETE'],
     },
   },
   district_admin: {
     permissions: {
-      modules: ['all_masters_districts_master', 'user_management_users', 'about_kvks_view_kvks', 'about_kvks_employee_details', 'achievements_technical_achievement_summary', 'achievements_oft', 'achievements_fld', 'module_images', 'reports', 'log_history', 'notifications', 'form_summary_status'],
+      modules: ['all_masters_districts_master', 'all_masters_kvks', 'user_management_users', 'about_kvks_view_kvks', 'about_kvks_employee_details', 'achievements_technical_achievement_summary', 'achievements_oft', 'achievements_fld', 'module_images', 'reports', 'log_history', 'notifications', 'form_summary_status'],
       actions: ['VIEW', 'ADD', 'EDIT'],
     },
   },
   org_admin: {
     permissions: {
-      modules: ['all_masters_organization_master', 'user_management_users', 'about_kvks_view_kvks', 'about_kvks_employee_details', 'achievements_technical_achievement_summary', 'module_images', 'reports', 'log_history', 'notifications', 'form_summary_status'],
+      modules: ['all_masters_organization_master', 'all_masters_kvks', 'user_management_users', 'about_kvks_view_kvks', 'about_kvks_employee_details', 'achievements_technical_achievement_summary', 'module_images', 'reports', 'log_history', 'notifications', 'form_summary_status'],
       actions: ['VIEW', 'ADD', 'EDIT'],
     },
   },
   kvk_admin: {
     permissions: {
       modules: [
-        'all_masters_zone_master', 'all_masters_states_master', 'all_masters_organization_master', 'all_masters_districts_master', 'all_masters_university_master',
+        'all_masters_zone_master', 'all_masters_states_master', 'all_masters_organization_master', 'all_masters_districts_master', 'all_masters_university_master', 'all_masters_kvks',
         'all_masters_oft_master', 'all_masters_fld_master', 'all_masters_cfld_master', 'all_masters_training_master', 'all_masters_extension_activity_master',
         'all_masters_other_extension_activity_master', 'all_masters_events_master', 'all_masters_products_master', 'all_masters_climate_master', 'all_masters_arya_master',
         'all_masters_tsp_scsp_master', 'all_masters_natural_farming_master',
@@ -171,24 +172,35 @@ const ROLE_PERMISSIONS = {
       actions: ['VIEW', 'ADD', 'EDIT', 'DELETE'],
     },
   },
+  // _user roles: role permissions define the CEILING (maximum possible access).
+  // Actual access is the intersection of role permissions ∩ user-level permissions
+  // (either USER_SCOPE legacy rows or per-module rows set via the editor).
+  // All 4 actions are included so admins can grant any combination when creating
+  // users. Admin-tier masters are deliberately excluded — *_user roles see only
+  // the work-surface modules (About KVKs / Achievements / Performance / etc.)
+  // plus the user-tier masters (NICRA, natural farming).
   kvk_user: {
-    // _user roles: role permissions define the CEILING (maximum possible access).
-    // Actual access is the intersection of role permissions ∩ user-level permissions (granted during user creation).
-    // All 4 actions are included so admins can grant any combination when creating users.
     permissions: {
-      modules: [
-        'all_masters_zone_master', 'all_masters_states_master', 'all_masters_organization_master', 'all_masters_districts_master', 'all_masters_university_master',
-        'all_masters_oft_master', 'all_masters_fld_master', 'all_masters_cfld_master', 'all_masters_training_master', 'all_masters_extension_activity_master',
-        'all_masters_other_extension_activity_master', 'all_masters_events_master', 'all_masters_products_master', 'all_masters_climate_master', 'all_masters_arya_master',
-        'all_masters_tsp_scsp_master', 'all_masters_natural_farming_master',
-        'all_masters_publication_master', 'all_masters_season_master', 'all_masters_sanctioned_post_master', 'all_masters_staff_category_master',
-        'all_masters_pay_level_master', 'all_masters_discipline_master', 'all_masters_crop_type_master', 'all_masters_infrastructure_master',
-        'all_masters_soil_water_analysis_master', 'all_masters_nari_activity_master', 'all_masters_nari_garden_type_master', 'all_masters_nicra_master',
-        'all_masters_impact_area_master', 'all_masters_enterprise_type_master', 'all_masters_account_type_master', 'all_masters_programme_type_master',
-        'all_masters_ppv_fra_training_type_master', 'all_masters_dignitary_type_master', 'all_masters_financial_project_master', 'all_masters_funding_agency_master',
-        'about_kvks_view_kvks', 'about_kvks_bank_account_details', 'about_kvks_employee_details', 'about_kvks_staff_details', 'about_kvks_infrastructure_details', 'about_kvks_vehicle_details', 'about_kvks_equipment_details', 'about_kvks_farm_implement_details', 'achievements_technical_achievement_summary', 'achievements_oft', 'achievements_fld', 'achievements_fld_extension_training', 'achievements_fld_technical_feedback', 'achievements_trainings', 'achievements_extension_activities', 'achievements_other_extension_activities', 'achievements_technology_week_celebration', 'achievements_celebration_days', 'achievements_production_supply_tech_products', 'achievements_soil_water_testing', 'achievements_projects', 'achievements_publications', 'achievements_award_recognition', 'achievements_hrd', 'performance_indicators_impact', 'performance_indicators_district_village', 'performance_indicators_infrastructure', 'performance_indicators_financial', 'performance_indicators_linkages', 'misc_prevalent_diseases_crops', 'misc_prevalent_diseases_livestock', 'misc_nyk_training', 'misc_ppv_fra_training', 'misc_rawe_fet', 'misc_vip_visitors', 'digital_mobile_app', 'digital_web_portal', 'digital_kisan_sarthi', 'digital_kisan_advisory', 'digital_messages_other_channels', 'swachh_observation_sewa', 'swachh_pakhwada', 'swachh_budget_expenditure', 'meetings_sac', 'meetings_other_atari', 'module_images', 'notifications', 'form_summary_status'
-      ],
-      actions: ['VIEW', 'ADD', 'EDIT'],
+      modules: [...BASE_USER_MODULES],
+      actions: USER_ACTIONS,
+    },
+  },
+  state_user: {
+    permissions: {
+      modules: [...BASE_USER_MODULES, 'reports'],
+      actions: USER_ACTIONS,
+    },
+  },
+  district_user: {
+    permissions: {
+      modules: [...BASE_USER_MODULES, 'reports'],
+      actions: USER_ACTIONS,
+    },
+  },
+  org_user: {
+    permissions: {
+      modules: [...BASE_USER_MODULES, 'reports'],
+      actions: USER_ACTIONS,
     },
   },
 };

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -62,7 +62,7 @@ const superAdminMenuItems: MenuItem[] = [
                 label: 'Basic Masters',
                 path: '/all-master/basic',
                 icon: <Folder className="w-4 h-4" />,
-                moduleCodes: ['all_masters_zone_master', 'all_masters_states_master', 'all_masters_districts_master', 'all_masters_organization_master', 'all_masters_university_master', 'about_kvks_view_kvks'],
+                moduleCodes: ['all_masters_zone_master', 'all_masters_states_master', 'all_masters_districts_master', 'all_masters_organization_master', 'all_masters_university_master', 'all_masters_kvks'],
             },
             {
                 label: 'OFT & FLD Masters',

--- a/frontend/src/config/route/allMasters.ts
+++ b/frontend/src/config/route/allMasters.ts
@@ -66,7 +66,7 @@ export const allMastersRoutes: RouteConfig[] = [
         subcategoryPath: '/all-master/basic',
         siblings: MASTER_SIBLING_GROUPS.BASIC_MASTERS,
         fields: FIELD_GROUPS.VIEW_KVKS,
-        moduleCode: 'about_kvks_view_kvks',
+        moduleCode: 'all_masters_kvks',
         canCreate: ['super_admin'],
     },
     {


### PR DESCRIPTION
Two root causes were letting KVK users see All Masters in the sidebar even with no masters permission:

1. The KVKs master at /all-master/kvks borrowed its moduleCode from the About KVKs menu (about_kvks_view_kvks). That permission is part of almost every role's ceiling, so the Sidebar's Basic Masters row (which listed about_kvks_view_kvks in its moduleCodes array) matched .some() for everyone and the whole All Masters menu opened up.

2. The kvk_user role-permission seed had a hand-rolled list of 37+ admin-tier all_masters_* modules (zone, states, districts, org, university, oft, fld, cfld, ...). So even the dedicated master permission wouldn't have hidden Basic Masters — the user had VIEW on every basic master via the role × USER_SCOPE intersection.

Fix, in one coherent change:

- Introduce a first-class permission for the KVKs master: all_masters_kvks. Seeded in the MODULES list, granted to super_admin (automatic via 'ALL'), zone/state/district/org/kvk admins.
- Route config (allMasters.ts) now references all_masters_kvks on the KVK Master entry instead of borrowing about_kvks_view_kvks.
- Sidebar's Basic Masters moduleCodes array replaces about_kvks_view_kvks with all_masters_kvks — so the gate only considers master-tier permissions, consistent with how every other Basic Masters item works.
- kvk_user role-permissions are now [...BASE_USER_MODULES], matching the pattern main_permissions.js already used. This removes all admin-tier masters from the role's ceiling while keeping work-surface modules (About KVKs / Achievements / Performance / Misc / Digital / Swachh / Meetings / NICRA / Natural Farming + module_images / notifications / form_summary_status).
- BASE_USER_MODULES picks up form_summary_status so every *_user role keeps dashboard access.
- state_user / district_user / org_user are now seeded explicitly ([...BASE_USER_MODULES, 'reports']). Previously absent from ROLE_PERMISSIONS, leaving them with zero role-permissions after any seed run.

Net effect for a kvk_user with USER_SCOPE:VIEW:
  before → VIEW on every all_masters_* in the old ceiling; All Masters menu shows in the sidebar with all 5 basic tabs visible. after  → no all_masters_* permissions except NICRA / Natural Farming; All Masters menu hidden from the sidebar unless the role is explicitly granted a master permission via the editor.

Run order on deploy: run `npm run seed:permissions` before merging the frontend — the seed inserts the new module rows the frontend references.