### PR TITLE
fix(about-kvk): hide Add New on routes with canCreate 'none'

### DIFF
--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -233,6 +233,8 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     const canUserCreate = () => {
         if (!user) return false
         if (moduleCode && !hasPermission('ADD', moduleCode)) return false
+        // Explicit opt-out via routeConfig wins for everyone, regardless of role.
+        if (routeConfig?.canCreate === 'none') return false
         // About KVK entities: check routeConfig.canCreate for KVKS, otherwise only KVK role can add details
         if (isAboutKvkEntity) {
             if (entityType === ENTITY_TYPES.KVKS) {


### PR DESCRIPTION
Closes #105

## Summary
- `canUserCreate()` in `DataManagementView.tsx` previously fell through to a role-only check for About-KVK non-KVKS entities. Routes declaring `canCreate: 'none'` (e.g. Start Transfer / Staff Transferred) still showed the Add New button for kvk_admin/kvk_user.
- Honor `routeConfig.canCreate === 'none'` up front so the explicit opt-out wins regardless of role.

## Test plan
- [ ] Start Transfer listing: Add New no longer renders for kvk_admin / kvk_user.
- [ ] Other About-KVK routes (Infrastructure, Employees, etc.) still show Add New for kvk_admin / kvk_user.
- [ ] Super-admin create paths (KVKs) unaffected.