### PR TITLE
refactor(masters): rename Organization -> Institute, University -> Host

### DIFF
--- a/frontend/src/components/admin/CreateUserModal.tsx
+++ b/frontend/src/components/admin/CreateUserModal.tsx
@@ -248,7 +248,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 newErrors.districtId = 'District is required'
             }
             if (orgRequired && !formData.orgId) {
-                newErrors.orgId = 'Organization is required'
+                newErrors.orgId = 'Institute is required'
             }
         } else {
             // Sub-admin: validate form-selected hierarchy fields below their level
@@ -540,7 +540,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 {/* Hierarchy info for sub-admins */}
                 {isSubAdmin && !showStateForSubAdmin && !showDistrictForSubAdmin && !showOrgForSubAdmin && selectedRole !== 'kvk_admin' && selectedRole !== 'kvk_user' && (
                     <p className="text-sm text-[#757575]">
-                        New user will inherit your <strong className="text-[#212121]">Zone, State, District &amp; Organization</strong>.
+                        New user will inherit your <strong className="text-[#212121]">Zone, State, District &amp; Institute</strong>.
                     </p>
                 )}
 
@@ -622,7 +622,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 {/* Sub-admin: Organization dropdown */}
                 {showOrgForSubAdmin && (
                     <DependentDropdown
-                        label="Organization"
+                        label="Institute"
                         required={orgRequired}
                         value={formData.orgId || ''}
                         onChange={(value) => {
@@ -670,7 +670,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 {/* Super Admin hierarchy dropdowns */}
                 {!isSubAdmin && showZoneField && (showStateField || showDistrictField || showOrgField) && (
                     <p className="text-xs text-[#757575]">
-                        Select <strong>Zone → State → District → Organization → KVK</strong> in order. Higher-level selections filter the options below.
+                        Select <strong>Zone → State → District → Institute → KVK</strong> in order. Higher-level selections filter the options below.
                     </p>
                 )}
 
@@ -775,7 +775,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
 
                 {!isSubAdmin && showOrgField && (
                     <DependentDropdown
-                        label="Organization"
+                        label="Institute"
                         required={orgRequired}
                         value={formData.orgId || ''}
                         onChange={(value) => {
@@ -823,7 +823,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 {/* University dropdown - only shown for KVK-level roles that need it */}
                 {(selectedRole === 'kvk_admin' || selectedRole === 'kvk_user') && !isKvkAdminCreating && ((!isSubAdmin && showOrgField) || showOrgForSubAdmin) && (
                     <DependentDropdown
-                        label="University"
+                        label="Host"
                         value={formData.universityId || ''}
                         onChange={(value) => {
                             const universityId = value ? Number(value) : ''

--- a/frontend/src/config/route/allMasters.ts
+++ b/frontend/src/config/route/allMasters.ts
@@ -37,7 +37,7 @@ export const allMastersRoutes: RouteConfig[] = [
     },
     {
         path: ENTITY_PATHS.ORGANIZATIONS,
-        title: 'Organization Master',
+        title: 'Institute Master',
         category: 'All Masters',
         subcategory: 'Basic Masters',
         parent: '/all-master',
@@ -48,7 +48,7 @@ export const allMastersRoutes: RouteConfig[] = [
     },
     {
         path: ENTITY_PATHS.UNIVERSITIES,
-        title: 'University Master',
+        title: 'Host Master',
         category: 'All Masters',
         subcategory: 'Basic Masters',
         parent: '/all-master',

--- a/frontend/src/pages/dashboard/SuperAdminDashboard.tsx
+++ b/frontend/src/pages/dashboard/SuperAdminDashboard.tsx
@@ -104,7 +104,7 @@ export const SuperAdminDashboard: React.FC = () => {
     const kpiCards = data
         ? [
               {
-                  label: 'Organization',
+                  label: 'Institute',
                   value: data.kpis.organizationCount,
                   to: ENTITY_PATHS.ORGANIZATIONS,
                   icon: <FileText className="w-6 h-6" />,

--- a/frontend/src/pages/dashboard/masters/BasicMastersTab.tsx
+++ b/frontend/src/pages/dashboard/masters/BasicMastersTab.tsx
@@ -10,8 +10,8 @@ const sections: FeatureSection[] = [
             { label: 'Zones Master', path: '/all-master/zones' },
             { label: 'States Master', path: '/all-master/states' },
             { label: 'Districts Master', path: '/all-master/districts' },
-            { label: 'Organization Master', path: '/all-master/organizations' },
-            { label: 'University Master', path: '/all-master/universities' },
+            { label: 'Institute Master', path: '/all-master/organizations' },
+            { label: 'Host Master', path: '/all-master/universities' },
             { label: 'KVKs', path: '/all-master/kvks' },
         ],
     },
@@ -21,7 +21,7 @@ export const BasicMastersTab: React.FC = () => {
     return (
         <FeatureTabLayout
             title="Basic Masters"
-            description="Manage zones, states, organizations, and districts"
+            description="Manage zones, states, institutes, hosts, and districts"
             sections={sections}
         />
     )

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -233,6 +233,8 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     const canUserCreate = () => {
         if (!user) return false
         if (moduleCode && !hasPermission('ADD', moduleCode)) return false
+        // Explicit opt-out via routeConfig wins for everyone, regardless of role.
+        if (routeConfig?.canCreate === 'none') return false
         // About KVK entities: check routeConfig.canCreate for KVKS, otherwise only KVK role can add details
         if (isAboutKvkEntity) {
             if (entityType === ENTITY_TYPES.KVKS) {

--- a/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
@@ -839,7 +839,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
 
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
                             <DependentDropdown
-                                label="Organization"
+                                label="Institute"
                                 required
                                 value={formData.orgId ?? ''}
                                 onChange={(value) => {
@@ -872,7 +872,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 cacheKey="about-kvk-organizations-by-zone-state-district"
                             />
                             <DependentDropdown
-                                label="University"
+                                label="Host"
                                 required
                                 value={formData.universityId ?? ''}
                                 onChange={(value) => setFormData((prev: any) => ({
@@ -925,8 +925,8 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                     onChange={() => {}}
                                     readOnly
                                     disabled
-                                    helperText={!selectedUniversityId ? 'Select University to populate host details' : undefined}
-                                    placeholder="Populated from university (host organisation)"
+                                    helperText={!selectedUniversityId ? 'Select Host to populate host details' : undefined}
+                                    placeholder="Populated from host (host organisation)"
                                 />
                             </div>
                             <FormInput
@@ -935,7 +935,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 onChange={() => {}}
                                 readOnly
                                 disabled
-                                helperText={!selectedUniversityId ? 'Select University to populate host details' : undefined}
+                                helperText={!selectedUniversityId ? 'Select Host to populate host details' : undefined}
                                 placeholder="+91"
                             />
                             <FormInput
@@ -944,7 +944,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 onChange={() => {}}
                                 readOnly
                                 disabled
-                                helperText={!selectedUniversityId ? 'Select University to populate host details' : undefined}
+                                helperText={!selectedUniversityId ? 'Select Host to populate host details' : undefined}
                                 placeholder="Enter landline"
                             />
                             <FormInput
@@ -953,7 +953,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 onChange={() => {}}
                                 readOnly
                                 disabled
-                                helperText={!selectedUniversityId ? 'Select University to populate host details' : undefined}
+                                helperText={!selectedUniversityId ? 'Select Host to populate host details' : undefined}
                                 placeholder="Enter fax"
                             />
                             <div className="md:col-span-3">
@@ -964,7 +964,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                     onChange={() => {}}
                                     readOnly
                                     disabled
-                                    helperText={!selectedUniversityId ? 'Select University to populate host details' : undefined}
+                                    helperText={!selectedUniversityId ? 'Select Host to populate host details' : undefined}
                                     placeholder="Enter email address"
                                 />
                             </div>

--- a/frontend/src/pages/dashboard/shared/forms/BasicMasterForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/BasicMasterForms.tsx
@@ -200,7 +200,7 @@ export const BasicMasterForms: React.FC<BasicMasterFormsProps> = ({
             {entityType === ENTITY_TYPES.ORGANIZATIONS && (
                 <div className="space-y-4">
                     <FormSelect
-                        label="Organization Name"
+                        label="Institute Name"
                         required
                         value={formData.orgName ?? ''}
                         onChange={(e) => setFormData((prev: any) => ({ ...prev, orgName: e.target.value }))}
@@ -278,13 +278,13 @@ export const BasicMasterForms: React.FC<BasicMasterFormsProps> = ({
             {entityType === ENTITY_TYPES.UNIVERSITIES && (
                 <div className="space-y-4">
                     <FormInput
-                        label="University Name"
+                        label="Host Name"
                         required
                         value={formData.universityName ?? ''}
                         onChange={useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
                             setFormData((prev: any) => ({ ...prev, universityName: e.target.value }))
                         }, [setFormData])}
-                        placeholder="Enter university name"
+                        placeholder="Enter host name"
                     />
                     <FormSelect
                         label="Zone"
@@ -348,7 +348,7 @@ export const BasicMasterForms: React.FC<BasicMasterFormsProps> = ({
                         loadingMessage="Loading districts..."
                     />
                     <DependentDropdown
-                        label="Organization"
+                        label="Institute"
                         required
                         value={formData.orgId ?? ''}
                         onChange={(value) => {
@@ -373,8 +373,8 @@ export const BasicMasterForms: React.FC<BasicMasterFormsProps> = ({
                             }))
                         }}
                         cacheKey="organizations-by-district"
-                        emptyMessage="No organizations available for this district"
-                        loadingMessage="Loading organizations..."
+                        emptyMessage="No institutes available for this district"
+                        loadingMessage="Loading institutes..."
                     />
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <FormInput

--- a/frontend/src/utils/exportService.ts
+++ b/frontend/src/utils/exportService.ts
@@ -116,11 +116,11 @@ function getHeaders(type: string, sampleItem: any): string[] {
                 'KVK Name',
                 'State',
                 'District',
-                'University',
+                'Host',
                 'Mobile',
                 'Email',
                 'Address',
-                'Organization',
+                'Institute',
                 'Sanction Year',
             ]
         case 'bank':


### PR DESCRIPTION
Closes #102

## Summary
- UI-only rename across the dashboard: Basic Masters tab, All Masters route titles (allMasters.ts), CreateUserModal labels/hints/validation copy, super-admin dashboard KPI card, AboutKvk + BasicMaster form labels + helper/placeholder copy, export service KVK column headers.
- Prisma models (`OrgMaster`, `UniversityMaster`) and DB columns are untouched. Entity type keys in `entityConstants.ts` and `FIELD_NAMES` identifiers preserved.

Stacked on top of #111 (issue #105).

## Test plan
- [ ] Super Admin → Basic Masters tab shows "Institute Master" and "Host Master".
- [ ] Create-KVK form shows "Institute" and "Host" dropdown labels + populated helper text uses "Select Host".
- [ ] Create-user modal uses the new labels + hint copy.
- [ ] Existing master data + submissions round-trip (no schema change).