### PR TITLE
feat(about-kvk): calendar year-of-sanction, reorder fields, drop Total Land

### DIFF
--- a/frontend/src/components/admin/CreateUserModal.tsx
+++ b/frontend/src/components/admin/CreateUserModal.tsx
@@ -248,7 +248,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 newErrors.districtId = 'District is required'
             }
             if (orgRequired && !formData.orgId) {
-                newErrors.orgId = 'Organization is required'
+                newErrors.orgId = 'Institute is required'
             }
         } else {
             // Sub-admin: validate form-selected hierarchy fields below their level
@@ -540,7 +540,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 {/* Hierarchy info for sub-admins */}
                 {isSubAdmin && !showStateForSubAdmin && !showDistrictForSubAdmin && !showOrgForSubAdmin && selectedRole !== 'kvk_admin' && selectedRole !== 'kvk_user' && (
                     <p className="text-sm text-[#757575]">
-                        New user will inherit your <strong className="text-[#212121]">Zone, State, District &amp; Organization</strong>.
+                        New user will inherit your <strong className="text-[#212121]">Zone, State, District &amp; Institute</strong>.
                     </p>
                 )}
 
@@ -622,7 +622,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 {/* Sub-admin: Organization dropdown */}
                 {showOrgForSubAdmin && (
                     <DependentDropdown
-                        label="Organization"
+                        label="Institute"
                         required={orgRequired}
                         value={formData.orgId || ''}
                         onChange={(value) => {
@@ -670,7 +670,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 {/* Super Admin hierarchy dropdowns */}
                 {!isSubAdmin && showZoneField && (showStateField || showDistrictField || showOrgField) && (
                     <p className="text-xs text-[#757575]">
-                        Select <strong>Zone → State → District → Organization → KVK</strong> in order. Higher-level selections filter the options below.
+                        Select <strong>Zone → State → District → Institute → KVK</strong> in order. Higher-level selections filter the options below.
                     </p>
                 )}
 
@@ -775,7 +775,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
 
                 {!isSubAdmin && showOrgField && (
                     <DependentDropdown
-                        label="Organization"
+                        label="Institute"
                         required={orgRequired}
                         value={formData.orgId || ''}
                         onChange={(value) => {
@@ -823,7 +823,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 {/* University dropdown - only shown for KVK-level roles that need it */}
                 {(selectedRole === 'kvk_admin' || selectedRole === 'kvk_user') && !isKvkAdminCreating && ((!isSubAdmin && showOrgField) || showOrgForSubAdmin) && (
                     <DependentDropdown
-                        label="University"
+                        label="Host"
                         value={formData.universityId || ''}
                         onChange={(value) => {
                             const universityId = value ? Number(value) : ''

--- a/frontend/src/config/route/allMasters.ts
+++ b/frontend/src/config/route/allMasters.ts
@@ -37,7 +37,7 @@ export const allMastersRoutes: RouteConfig[] = [
     },
     {
         path: ENTITY_PATHS.ORGANIZATIONS,
-        title: 'Organization Master',
+        title: 'Institute Master',
         category: 'All Masters',
         subcategory: 'Basic Masters',
         parent: '/all-master',
@@ -48,7 +48,7 @@ export const allMastersRoutes: RouteConfig[] = [
     },
     {
         path: ENTITY_PATHS.UNIVERSITIES,
-        title: 'University Master',
+        title: 'Host Master',
         category: 'All Masters',
         subcategory: 'Basic Masters',
         parent: '/all-master',

--- a/frontend/src/pages/dashboard/SuperAdminDashboard.tsx
+++ b/frontend/src/pages/dashboard/SuperAdminDashboard.tsx
@@ -104,7 +104,7 @@ export const SuperAdminDashboard: React.FC = () => {
     const kpiCards = data
         ? [
               {
-                  label: 'Organization',
+                  label: 'Institute',
                   value: data.kpis.organizationCount,
                   to: ENTITY_PATHS.ORGANIZATIONS,
                   icon: <FileText className="w-6 h-6" />,

--- a/frontend/src/pages/dashboard/masters/BasicMastersTab.tsx
+++ b/frontend/src/pages/dashboard/masters/BasicMastersTab.tsx
@@ -10,8 +10,8 @@ const sections: FeatureSection[] = [
             { label: 'Zones Master', path: '/all-master/zones' },
             { label: 'States Master', path: '/all-master/states' },
             { label: 'Districts Master', path: '/all-master/districts' },
-            { label: 'Organization Master', path: '/all-master/organizations' },
-            { label: 'University Master', path: '/all-master/universities' },
+            { label: 'Institute Master', path: '/all-master/organizations' },
+            { label: 'Host Master', path: '/all-master/universities' },
             { label: 'KVKs', path: '/all-master/kvks' },
         ],
     },
@@ -21,7 +21,7 @@ export const BasicMastersTab: React.FC = () => {
     return (
         <FeatureTabLayout
             title="Basic Masters"
-            description="Manage zones, states, organizations, and districts"
+            description="Manage zones, states, institutes, hosts, and districts"
             sections={sections}
         />
     )

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -233,6 +233,8 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     const canUserCreate = () => {
         if (!user) return false
         if (moduleCode && !hasPermission('ADD', moduleCode)) return false
+        // Explicit opt-out via routeConfig wins for everyone, regardless of role.
+        if (routeConfig?.canCreate === 'none') return false
         // About KVK entities: check routeConfig.canCreate for KVKS, otherwise only KVK role can add details
         if (isAboutKvkEntity) {
             if (entityType === ENTITY_TYPES.KVKS) {

--- a/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
@@ -5,7 +5,7 @@ import { FormInput, FormSelect, FormTextArea, FormSection } from './shared/FormC
 import { State, District, Organization, University } from '@/types/masterData'
 import { useMasterData } from '@/hooks/useMasterData'
 import { useAuth } from '@/contexts/AuthContext'
-import { Trash2, Plus, X } from 'lucide-react'
+import { X } from 'lucide-react'
 import {
     useSanctionedPosts,
     useInfraMasters,
@@ -22,7 +22,6 @@ import { DependentDropdown } from '@/components/common/DependentDropdown'
 import { masterDataApi } from '@/services/masterDataApi'
 import { useUniversityHostFields } from '@/hooks/useUniversityHostFields'
 import { cleanIndianMobileInput } from '@/utils/indianPhone'
-import { parseEstablishmentYearInput } from '@/utils/formNumericGuards'
 
 interface AboutKvkFormsProps {
     entityType: ExtendedEntityType | null
@@ -727,27 +726,20 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 />
                             </div>
                             <FormInput
-                                label="Mobile Number"
+                                label="Year of Sanction"
+                                type="date"
                                 required
-                                value={formData.mobile ?? ''}
-                                onChange={(e) =>
-                                    setFormData({ ...formData, mobile: cleanIndianMobileInput(e.target.value) })
-                                }
-                                placeholder="10-digit mobile"
-                                inputMode="numeric"
-                                autoComplete="tel"
-                            />
-                            <FormInput
-                                label="Landline"
-                                value={formData.landline ?? ''}
-                                onChange={(e) => setFormData({ ...formData, landline: e.target.value })}
-                                placeholder="Enter landline"
-                            />
-                            <FormInput
-                                label="Fax"
-                                value={formData.fax ?? ''}
-                                onChange={(e) => setFormData({ ...formData, fax: e.target.value })}
-                                placeholder="Enter fax"
+                                value={formData.yearOfSanctionDate ?? (formData.yearOfSanction ? `${formData.yearOfSanction}-01-01` : '')}
+                                onChange={(e) => {
+                                    const raw = e.target.value
+                                    const year = raw ? new Date(raw).getFullYear() : ''
+                                    setFormData({
+                                        ...formData,
+                                        yearOfSanctionDate: raw,
+                                        yearOfSanction: typeof year === 'number' && !Number.isNaN(year) ? year : '',
+                                    })
+                                }}
+                                placeholder="Select date"
                             />
                             <div className="md:col-span-1 lg:col-span-2">
                                 <FormInput
@@ -760,18 +752,27 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 />
                             </div>
                             <FormInput
-                                label="Year of Sanction"
+                                label="Mobile Number"
                                 required
-                                inputMode="numeric"
-                                autoComplete="off"
-                                value={formData.yearOfSanction ?? ''}
+                                value={formData.mobile ?? ''}
                                 onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        yearOfSanction: parseEstablishmentYearInput(e.target.value),
-                                    })
+                                    setFormData({ ...formData, mobile: cleanIndianMobileInput(e.target.value) })
                                 }
-                                placeholder="e.g. 2004"
+                                placeholder="10-digit mobile"
+                                inputMode="numeric"
+                                autoComplete="tel"
+                            />
+                            <FormInput
+                                label="Fax"
+                                value={formData.fax ?? ''}
+                                onChange={(e) => setFormData({ ...formData, fax: e.target.value })}
+                                placeholder="Enter fax"
+                            />
+                            <FormInput
+                                label="Landline"
+                                value={formData.landline ?? ''}
+                                onChange={(e) => setFormData({ ...formData, landline: e.target.value })}
+                                placeholder="Enter landline"
                             />
                         </div>
 
@@ -982,61 +983,6 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                         </div>
                     </FormSection>
 
-                    <FormSection title="Total Land with KVK">
-                        <div className="space-y-4">
-                            {(formData.landDetails || []).map((item: any, index: number) => (
-                                <div key={index} className="flex gap-4 items-center">
-                                    <div className="flex-1">
-                                        <FormInput
-                                            label={`Item ${index + 1}`}
-                                            value={item.item ?? ''}
-                                            onChange={(e) => {
-                                                const newList = [...formData.landDetails];
-                                                newList[index].item = e.target.value;
-                                                setFormData({ ...formData, landDetails: newList });
-                                            }}
-                                            placeholder="e.g. Main Farm"
-                                        />
-                                    </div>
-                                    <div className="w-32">
-                                        <FormInput
-                                            label="Area (Ha)"
-                                            type="number"
-                                            step="any"
-                                            value={item.areaHa ?? ''}
-                                            onChange={(e) => {
-                                                const newList = [...formData.landDetails];
-                                                newList[index].areaHa = e.target.value;
-                                                setFormData({ ...formData, landDetails: newList });
-                                            }}
-                                            placeholder="0.00"
-                                        />
-                                    </div>
-                                    <button
-                                        type="button"
-                                        onClick={() => {
-                                            const newList = formData.landDetails.filter((_: any, i: number) => i !== index);
-                                            setFormData({ ...formData, landDetails: newList });
-                                        }}
-                                        className="mt-6 p-2 text-red-500 hover:bg-red-50 rounded-lg transition-colors"
-                                    >
-                                        <Trash2 className="w-5 h-5" />
-                                    </button>
-                                </div>
-                            ))}
-                            <button
-                                type="button"
-                                onClick={() => {
-                                    const newList = [...(formData.landDetails || []), { item: '', areaHa: '' }];
-                                    setFormData({ ...formData, landDetails: newList });
-                                }}
-                                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-[#487749] border border-[#487749] rounded-xl hover:bg-[#487749] hover:text-white transition-all"
-                            >
-                                <Plus className="w-4 h-4" />
-                                Add More Item
-                            </button>
-                        </div>
-                    </FormSection>
                 </div>
             )}
         </div>

--- a/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
@@ -839,7 +839,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
 
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
                             <DependentDropdown
-                                label="Organization"
+                                label="Institute"
                                 required
                                 value={formData.orgId ?? ''}
                                 onChange={(value) => {
@@ -872,7 +872,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 cacheKey="about-kvk-organizations-by-zone-state-district"
                             />
                             <DependentDropdown
-                                label="University"
+                                label="Host"
                                 required
                                 value={formData.universityId ?? ''}
                                 onChange={(value) => setFormData((prev: any) => ({
@@ -925,8 +925,8 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                     onChange={() => {}}
                                     readOnly
                                     disabled
-                                    helperText={!selectedUniversityId ? 'Select University to populate host details' : undefined}
-                                    placeholder="Populated from university (host organisation)"
+                                    helperText={!selectedUniversityId ? 'Select Host to populate host details' : undefined}
+                                    placeholder="Populated from host (host organisation)"
                                 />
                             </div>
                             <FormInput
@@ -935,7 +935,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 onChange={() => {}}
                                 readOnly
                                 disabled
-                                helperText={!selectedUniversityId ? 'Select University to populate host details' : undefined}
+                                helperText={!selectedUniversityId ? 'Select Host to populate host details' : undefined}
                                 placeholder="+91"
                             />
                             <FormInput
@@ -944,7 +944,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 onChange={() => {}}
                                 readOnly
                                 disabled
-                                helperText={!selectedUniversityId ? 'Select University to populate host details' : undefined}
+                                helperText={!selectedUniversityId ? 'Select Host to populate host details' : undefined}
                                 placeholder="Enter landline"
                             />
                             <FormInput
@@ -953,7 +953,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 onChange={() => {}}
                                 readOnly
                                 disabled
-                                helperText={!selectedUniversityId ? 'Select University to populate host details' : undefined}
+                                helperText={!selectedUniversityId ? 'Select Host to populate host details' : undefined}
                                 placeholder="Enter fax"
                             />
                             <div className="md:col-span-3">
@@ -964,7 +964,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                     onChange={() => {}}
                                     readOnly
                                     disabled
-                                    helperText={!selectedUniversityId ? 'Select University to populate host details' : undefined}
+                                    helperText={!selectedUniversityId ? 'Select Host to populate host details' : undefined}
                                     placeholder="Enter email address"
                                 />
                             </div>

--- a/frontend/src/pages/dashboard/shared/forms/BasicMasterForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/BasicMasterForms.tsx
@@ -200,7 +200,7 @@ export const BasicMasterForms: React.FC<BasicMasterFormsProps> = ({
             {entityType === ENTITY_TYPES.ORGANIZATIONS && (
                 <div className="space-y-4">
                     <FormSelect
-                        label="Organization Name"
+                        label="Institute Name"
                         required
                         value={formData.orgName ?? ''}
                         onChange={(e) => setFormData((prev: any) => ({ ...prev, orgName: e.target.value }))}
@@ -278,13 +278,13 @@ export const BasicMasterForms: React.FC<BasicMasterFormsProps> = ({
             {entityType === ENTITY_TYPES.UNIVERSITIES && (
                 <div className="space-y-4">
                     <FormInput
-                        label="University Name"
+                        label="Host Name"
                         required
                         value={formData.universityName ?? ''}
                         onChange={useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
                             setFormData((prev: any) => ({ ...prev, universityName: e.target.value }))
                         }, [setFormData])}
-                        placeholder="Enter university name"
+                        placeholder="Enter host name"
                     />
                     <FormSelect
                         label="Zone"
@@ -348,7 +348,7 @@ export const BasicMasterForms: React.FC<BasicMasterFormsProps> = ({
                         loadingMessage="Loading districts..."
                     />
                     <DependentDropdown
-                        label="Organization"
+                        label="Institute"
                         required
                         value={formData.orgId ?? ''}
                         onChange={(value) => {
@@ -373,8 +373,8 @@ export const BasicMasterForms: React.FC<BasicMasterFormsProps> = ({
                             }))
                         }}
                         cacheKey="organizations-by-district"
-                        emptyMessage="No organizations available for this district"
-                        loadingMessage="Loading organizations..."
+                        emptyMessage="No institutes available for this district"
+                        loadingMessage="Loading institutes..."
                     />
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <FormInput

--- a/frontend/src/utils/exportService.ts
+++ b/frontend/src/utils/exportService.ts
@@ -116,11 +116,11 @@ function getHeaders(type: string, sampleItem: any): string[] {
                 'KVK Name',
                 'State',
                 'District',
-                'University',
+                'Host',
                 'Mobile',
                 'Email',
                 'Address',
-                'Organization',
+                'Institute',
                 'Sanction Year',
             ]
         case 'bank':


### PR DESCRIPTION
Closes #103

## Summary
- Year of Sanction is now `<input type=\"date\">`; on change we derive the int year (`new Date(val).getFullYear()`) into `yearOfSanction` and keep the raw picker value in `yearOfSanctionDate` for redisplay — the API contract stays int.
- Reordered the Create KVK form: Name → Year of Sanction → … → Mobile → Fax → Landline.
- Removed the entire "Total Land with KVK" repeater from this form. The `KvkLandDetail` Prisma model is untouched and will be edited from the new About KVK "Infrastructure & Land Details" group (follow-up #104).

Stacked on top of #112 (issue #102).

## Test plan
- [ ] Create a new KVK, pick any date; confirm the payload serializes `yearOfSanction` as an integer year (e.g. 2024-08-15 → 2024).
- [ ] Field order matches spec on the rendered form.
- [ ] No "Total Land" UI rendered.
- [ ] Existing KVKs load back with their year displayed correctly.