### PR TITLE
fix(technical-summary): route PDF/Excel/Word exports through backend

### DIFF
--- a/backend/controllers/exportController.js
+++ b/backend/controllers/exportController.js
@@ -64,6 +64,11 @@ const {
     generateWorldSoilDayPageExcelBuffer,
     generateWorldSoilDayPageWordBuffer,
 } = require('../utils/worldSoilDayPageExport.js');
+const {
+    generateTechnicalSummaryPdfBuffer,
+    generateTechnicalSummaryExcelBuffer,
+    generateTechnicalSummaryWordBuffer,
+} = require('../utils/technicalSummaryExport.js');
 const { buildPublicationDetailsTabularData } = require('../services/reports/formsTemplate/achievementTemplates/publicationDetailsDetailedTemplate.js');
 const { buildKvkAwardSummaryTabularData } = require('../services/reports/formsTemplate/achievementTemplates/kvkAwardSummaryTemplate.js');
 const { buildScientistAwardSummaryTabularData } = require('../services/reports/formsTemplate/achievementTemplates/scientistAwardSummaryTemplate.js');
@@ -204,11 +209,18 @@ const exportData = async (req, res) => {
 
         switch (format.toLowerCase()) {
             case 'pdf':
-                const html = templateKey
-                    ? await generateCustomTemplateHTML(templateKey, effectiveRawData, title, Boolean(isAggregatedReport))
-                    : generateHTML(title, headers, rows);
+                if (templateKey === 'technical-achievement-summary-report' && effectiveRawData) {
+                    // Standalone multi-section layout — doesn't fit the section-per-template
+                    // HTML path used by other reports, so its helper produces the PDF buffer
+                    // directly via Puppeteer.
+                    buffer = await generateTechnicalSummaryPdfBuffer(effectiveRawData);
+                } else {
+                    const html = templateKey
+                        ? await generateCustomTemplateHTML(templateKey, effectiveRawData, title, Boolean(isAggregatedReport))
+                        : generateHTML(title, headers, rows);
 
-                buffer = await exportHelper.generatePDF(html);
+                    buffer = await exportHelper.generatePDF(html);
+                }
                 contentType = 'application/pdf';
                 fileName += '.pdf';
                 break;
@@ -258,6 +270,8 @@ const exportData = async (req, res) => {
                         title,
                         resolveWorldSoilDayPagePayload(effectiveRawData, { isAggregatedReport: Boolean(isAggregatedReport) }),
                     );
+                } else if (templateKey === 'technical-achievement-summary-report' && effectiveRawData) {
+                    buffer = await generateTechnicalSummaryExcelBuffer(effectiveRawData);
                 } else {
                     buffer = await exportHelper.generateExcel(title, tabularData.headers, tabularData.rows);
                 }
@@ -310,6 +324,8 @@ const exportData = async (req, res) => {
                         title,
                         resolveWorldSoilDayPagePayload(effectiveRawData, { isAggregatedReport: Boolean(isAggregatedReport) }),
                     );
+                } else if (templateKey === 'technical-achievement-summary-report' && effectiveRawData) {
+                    buffer = await generateTechnicalSummaryWordBuffer(effectiveRawData);
                 } else {
                     buffer = await exportHelper.generateWord(title, tabularData.headers, tabularData.rows);
                 }

--- a/backend/utils/technicalSummaryExport.js
+++ b/backend/utils/technicalSummaryExport.js
@@ -1,0 +1,310 @@
+/**
+ * Technical Achievement Summary exports (PDF + Excel + Word).
+ *
+ * Shape of the payload (sent from the frontend's buildExportTables helper):
+ *   {
+ *     tables: [{ title: string, headers: string[], rows: (string|number)[][] }, ...],
+ *     reportingYear: number,
+ *     kvkLabel: string,
+ *   }
+ *
+ * PDF is rendered via Puppeteer (exportHelper.generatePDF) — Chromium handles
+ * modern CSS (including oklch) natively, unlike the client-side html2pdf.js
+ * which we previously used. Excel + Word match the prior xlsx / docx output
+ * layout so consumers don't see a format regression.
+ */
+
+const ExcelJS = require('exceljs');
+const {
+  Document,
+  Packer,
+  Paragraph,
+  Table,
+  TableRow,
+  TableCell,
+  WidthType,
+  AlignmentType,
+  HeadingLevel,
+  PageOrientation,
+} = require('docx');
+
+const { generatePDF } = require('./exportHelper');
+
+const REPORT_TITLE = 'Technical Achievement Summary';
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildTablesHtml(tables) {
+  return tables
+    .map((table) => {
+      const headers = table.headers || [];
+      const rows = Array.isArray(table.rows) ? table.rows : [];
+      const tbody = rows
+        .map(
+          (line) =>
+            `<tr>${line
+              .map((value) => `<td>${escapeHtml(String(value ?? ''))}</td>`)
+              .join('')}</tr>`,
+        )
+        .join('');
+      return `
+        <table class="tas-table">
+          <thead>
+            <tr><th class="table-title" colspan="${headers.length}">${escapeHtml(table.title)}</th></tr>
+            <tr>${headers.map((header) => `<th>${escapeHtml(String(header))}</th>`).join('')}</tr>
+          </thead>
+          <tbody>${tbody}</tbody>
+        </table>
+      `;
+    })
+    .join('');
+}
+
+/**
+ * Produce the full HTML document fed to Puppeteer. CSS mirrors the layout the
+ * page previously injected into its own DOM for html2pdf — so the resulting
+ * PDF looks (pixel-close) identical.
+ */
+function buildPdfHtml({ tables, reportingYear, kvkLabel }) {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>${escapeHtml(REPORT_TITLE)}</title>
+    <style>
+      @page { size: A4 landscape; margin: 10mm; }
+      html, body { margin: 0; padding: 0; color: #111; background: #fff; }
+      .tas-report { font-family: Arial, sans-serif; padding: 18px; color: #111; }
+      .tas-title { font-size: 20px; font-weight: 700; margin-bottom: 4px; }
+      .tas-meta { font-size: 12px; margin-bottom: 2px; }
+      .tas-table { width: 100%; border-collapse: collapse; margin-top: 12px; page-break-inside: auto; }
+      .tas-table tr { page-break-inside: avoid; }
+      .tas-table th, .tas-table td {
+        border: 1px solid #000;
+        font-size: 9px;
+        padding: 3px 4px;
+        text-align: center;
+      }
+      .tas-table .table-title { background: #f2f2f2; font-size: 11px; font-weight: 700; }
+    </style>
+  </head>
+  <body>
+    <div class="tas-report">
+      <div class="tas-title">${escapeHtml(REPORT_TITLE)}</div>
+      <div class="tas-meta">Reporting Year: ${escapeHtml(String(reportingYear))}</div>
+      <div class="tas-meta">KVK: ${escapeHtml(kvkLabel)}</div>
+      ${buildTablesHtml(tables)}
+    </div>
+  </body>
+</html>`;
+}
+
+async function generateTechnicalSummaryPdfBuffer(payload) {
+  const html = buildPdfHtml(payload);
+  return generatePDF(html);
+}
+
+/**
+ * Multi-section single-sheet Excel. Each table gets a merged title row, a
+ * header row, then its data rows, followed by a spacer row. Column widths
+ * are sized to the widest table so every section aligns visually.
+ */
+async function generateTechnicalSummaryExcelBuffer({ tables, reportingYear, kvkLabel }) {
+  const workbook = new ExcelJS.Workbook();
+  const sheet = workbook.addWorksheet('Technical Summary');
+
+  const maxColumns = Math.max(
+    1,
+    ...tables.map((t) => (t.headers || []).length),
+  );
+
+  let rowIdx = 1;
+  const writeMergedRow = (value, { bold = false, fontSize = 11, fill = null, align = 'center' } = {}) => {
+    sheet.mergeCells(rowIdx, 1, rowIdx, maxColumns);
+    const cell = sheet.getCell(rowIdx, 1);
+    cell.value = value;
+    cell.font = { name: 'Arial', size: fontSize, bold };
+    cell.alignment = { horizontal: align, vertical: 'middle', wrapText: true };
+    if (fill) {
+      cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: fill } };
+    }
+    rowIdx += 1;
+  };
+
+  writeMergedRow(REPORT_TITLE, { bold: true, fontSize: 16, align: 'center' });
+  writeMergedRow(`Reporting Year: ${reportingYear}`, { fontSize: 11, align: 'left' });
+  writeMergedRow(`KVK: ${kvkLabel}`, { fontSize: 11, align: 'left' });
+  rowIdx += 1;
+
+  const applyBorders = (row, width) => {
+    for (let c = 1; c <= width; c += 1) {
+      row.getCell(c).border = {
+        top: { style: 'thin' },
+        left: { style: 'thin' },
+        bottom: { style: 'thin' },
+        right: { style: 'thin' },
+      };
+    }
+  };
+
+  for (const table of tables) {
+    const headers = table.headers || [];
+    const dataRows = Array.isArray(table.rows) ? table.rows : [];
+    const width = Math.max(1, headers.length);
+
+    // Section title (merged across table width)
+    sheet.mergeCells(rowIdx, 1, rowIdx, width);
+    const titleCell = sheet.getCell(rowIdx, 1);
+    titleCell.value = table.title;
+    titleCell.font = { name: 'Arial', size: 11, bold: true };
+    titleCell.alignment = { horizontal: 'center', vertical: 'middle', wrapText: true };
+    titleCell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF2F2F2' } };
+    applyBorders(sheet.getRow(rowIdx), width);
+    rowIdx += 1;
+
+    // Header row
+    const headerRow = sheet.getRow(rowIdx);
+    headers.forEach((h, i) => {
+      headerRow.getCell(i + 1).value = h;
+    });
+    headerRow.eachCell({ includeEmpty: false }, (cell) => {
+      cell.font = { name: 'Arial', size: 10, bold: true };
+      cell.alignment = { horizontal: 'center', vertical: 'middle', wrapText: true };
+    });
+    applyBorders(headerRow, width);
+    rowIdx += 1;
+
+    // Data rows
+    for (const line of dataRows) {
+      const dataRow = sheet.getRow(rowIdx);
+      for (let c = 0; c < width; c += 1) {
+        dataRow.getCell(c + 1).value = line[c] ?? '';
+      }
+      dataRow.eachCell({ includeEmpty: false }, (cell) => {
+        cell.font = { name: 'Arial', size: 10 };
+        cell.alignment = { horizontal: 'center', vertical: 'middle', wrapText: true };
+      });
+      applyBorders(dataRow, width);
+      rowIdx += 1;
+    }
+
+    rowIdx += 1; // spacer between sections
+  }
+
+  for (let c = 1; c <= maxColumns; c += 1) {
+    sheet.getColumn(c).width = 14;
+  }
+
+  return workbook.xlsx.writeBuffer();
+}
+
+function wordParagraph(text, { bold = false, heading = null, size = 22, align = AlignmentType.LEFT } = {}) {
+  return new Paragraph({
+    alignment: align,
+    heading: heading || undefined,
+    children: [
+      {
+        text,
+        bold,
+        size,
+      },
+    ].map((run) => new (require('docx').TextRun)(run)),
+  });
+}
+
+function wordCell(text, { bold = false, shaded = false } = {}) {
+  return new TableCell({
+    shading: shaded ? { fill: 'F2F2F2' } : undefined,
+    children: [
+      new Paragraph({
+        alignment: AlignmentType.CENTER,
+        children: [new (require('docx').TextRun)({ text: String(text ?? ''), bold, size: 18 })],
+      }),
+    ],
+  });
+}
+
+async function generateTechnicalSummaryWordBuffer({ tables, reportingYear, kvkLabel }) {
+  const children = [];
+
+  children.push(
+    new Paragraph({
+      heading: HeadingLevel.HEADING_1,
+      alignment: AlignmentType.CENTER,
+      children: [new (require('docx').TextRun)({ text: REPORT_TITLE, bold: true, size: 32 })],
+    }),
+  );
+  children.push(wordParagraph(`Reporting Year: ${reportingYear}`));
+  children.push(wordParagraph(`KVK: ${kvkLabel}`));
+  children.push(new Paragraph({ text: '' }));
+
+  for (const table of tables) {
+    const headers = table.headers || [];
+    const dataRows = Array.isArray(table.rows) ? table.rows : [];
+    const width = Math.max(1, headers.length);
+
+    const rows = [
+      // Section title spans all columns via a single merged-looking row.
+      new TableRow({
+        children: [
+          new TableCell({
+            columnSpan: width,
+            shading: { fill: 'F2F2F2' },
+            children: [
+              new Paragraph({
+                alignment: AlignmentType.CENTER,
+                children: [
+                  new (require('docx').TextRun)({ text: String(table.title), bold: true, size: 22 }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+      new TableRow({
+        tableHeader: true,
+        children: headers.map((h) => wordCell(h, { bold: true, shaded: true })),
+      }),
+      ...dataRows.map(
+        (line) =>
+          new TableRow({
+            children: Array.from({ length: width }, (_, i) => wordCell(line[i] ?? '')),
+          }),
+      ),
+    ];
+
+    children.push(
+      new Table({
+        width: { size: 100, type: WidthType.PERCENTAGE },
+        rows,
+      }),
+    );
+    children.push(new Paragraph({ text: '' }));
+  }
+
+  const doc = new Document({
+    sections: [
+      {
+        properties: {
+          page: { size: { orientation: PageOrientation.LANDSCAPE } },
+        },
+        children,
+      },
+    ],
+  });
+
+  return Packer.toBuffer(doc);
+}
+
+module.exports = {
+  generateTechnicalSummaryPdfBuffer,
+  generateTechnicalSummaryExcelBuffer,
+  generateTechnicalSummaryWordBuffer,
+};

--- a/backend/utils/technicalSummaryExport.js
+++ b/backend/utils/technicalSummaryExport.js
@@ -205,27 +205,19 @@ async function generateTechnicalSummaryExcelBuffer({ tables, reportingYear, kvkL
   return workbook.xlsx.writeBuffer();
 }
 
-function wordParagraph(text, { bold = false, heading = null, size = 22, align = AlignmentType.LEFT } = {}) {
-  return new Paragraph({
-    alignment: align,
-    heading: heading || undefined,
-    children: [
-      {
-        text,
-        bold,
-        size,
-      },
-    ].map((run) => new (require('docx').TextRun)(run)),
+// Data cell — minimal styling, matches the density fldPageExport etc. use.
+function wordCell(text) {
+  return new TableCell({
+    children: [new Paragraph({ text: String(text ?? '') })],
   });
 }
 
-function wordCell(text, { bold = false, shaded = false } = {}) {
+function wordHeaderCell(text) {
   return new TableCell({
-    shading: shaded ? { fill: 'F2F2F2' } : undefined,
+    shading: { fill: 'F2F2F2' },
     children: [
       new Paragraph({
-        alignment: AlignmentType.CENTER,
-        children: [new (require('docx').TextRun)({ text: String(text ?? ''), bold, size: 18 })],
+        children: [new (require('docx').TextRun)({ text: String(text ?? ''), bold: true })],
       }),
     ],
   });
@@ -236,13 +228,13 @@ async function generateTechnicalSummaryWordBuffer({ tables, reportingYear, kvkLa
 
   children.push(
     new Paragraph({
+      text: REPORT_TITLE,
       heading: HeadingLevel.HEADING_1,
       alignment: AlignmentType.CENTER,
-      children: [new (require('docx').TextRun)({ text: REPORT_TITLE, bold: true, size: 32 })],
     }),
   );
-  children.push(wordParagraph(`Reporting Year: ${reportingYear}`));
-  children.push(wordParagraph(`KVK: ${kvkLabel}`));
+  children.push(new Paragraph({ text: `Reporting Year: ${reportingYear}` }));
+  children.push(new Paragraph({ text: `KVK: ${kvkLabel}` }));
   children.push(new Paragraph({ text: '' }));
 
   for (const table of tables) {
@@ -250,27 +242,21 @@ async function generateTechnicalSummaryWordBuffer({ tables, reportingYear, kvkLa
     const dataRows = Array.isArray(table.rows) ? table.rows : [];
     const width = Math.max(1, headers.length);
 
-    const rows = [
-      // Section title spans all columns via a single merged-looking row.
-      new TableRow({
-        children: [
-          new TableCell({
-            columnSpan: width,
-            shading: { fill: 'F2F2F2' },
-            children: [
-              new Paragraph({
-                alignment: AlignmentType.CENTER,
-                children: [
-                  new (require('docx').TextRun)({ text: String(table.title), bold: true, size: 22 }),
-                ],
-              }),
-            ],
-          }),
-        ],
+    // Section title lives OUTSIDE the table as a HEADING_2 paragraph.
+    // Putting it inside as a single-cell merged row was causing docx to
+    // mis-size the column grid — the data rows got squeezed into a narrow
+    // strip, each header letter wrapping to its own line.
+    children.push(
+      new Paragraph({
+        text: table.title,
+        heading: HeadingLevel.HEADING_2,
       }),
+    );
+
+    const rows = [
       new TableRow({
         tableHeader: true,
-        children: headers.map((h) => wordCell(h, { bold: true, shaded: true })),
+        children: headers.map((h) => wordHeaderCell(h)),
       }),
       ...dataRows.map(
         (line) =>

--- a/backend/utils/technicalSummaryExport.js
+++ b/backend/utils/technicalSummaryExport.js
@@ -205,15 +205,18 @@ async function generateTechnicalSummaryExcelBuffer({ tables, reportingYear, kvkL
   return workbook.xlsx.writeBuffer();
 }
 
-// Data cell — minimal styling, matches the density fldPageExport etc. use.
-function wordCell(text) {
+// Data cell — minimal styling with an explicit width so the table doesn't
+// auto-collapse to 100-twip columns. `width` is in twips.
+function wordCell(text, width) {
   return new TableCell({
+    width: { size: width, type: WidthType.DXA },
     children: [new Paragraph({ text: String(text ?? '') })],
   });
 }
 
-function wordHeaderCell(text) {
+function wordHeaderCell(text, width) {
   return new TableCell({
+    width: { size: width, type: WidthType.DXA },
     shading: { fill: 'F2F2F2' },
     children: [
       new Paragraph({
@@ -237,15 +240,18 @@ async function generateTechnicalSummaryWordBuffer({ tables, reportingYear, kvkLa
   children.push(new Paragraph({ text: `KVK: ${kvkLabel}` }));
   children.push(new Paragraph({ text: '' }));
 
+  // Landscape A4 usable width (twips) after ~1-inch margins both sides.
+  // Used to give docx an explicit columnWidths array — otherwise it
+  // defaults to 100 twips per column (~1.8mm) and Word renders every
+  // column as a single character wide.
+  const LANDSCAPE_USABLE_TWIPS = 13950;
+
   for (const table of tables) {
     const headers = table.headers || [];
     const dataRows = Array.isArray(table.rows) ? table.rows : [];
     const width = Math.max(1, headers.length);
 
     // Section title lives OUTSIDE the table as a HEADING_2 paragraph.
-    // Putting it inside as a single-cell merged row was causing docx to
-    // mis-size the column grid — the data rows got squeezed into a narrow
-    // strip, each header letter wrapping to its own line.
     children.push(
       new Paragraph({
         text: table.title,
@@ -253,22 +259,26 @@ async function generateTechnicalSummaryWordBuffer({ tables, reportingYear, kvkLa
       }),
     );
 
+    const colTwips = Math.floor(LANDSCAPE_USABLE_TWIPS / width);
+    const columnWidths = Array.from({ length: width }, () => colTwips);
+
     const rows = [
       new TableRow({
         tableHeader: true,
-        children: headers.map((h) => wordHeaderCell(h)),
+        children: headers.map((h) => wordHeaderCell(h, colTwips)),
       }),
       ...dataRows.map(
         (line) =>
           new TableRow({
-            children: Array.from({ length: width }, (_, i) => wordCell(line[i] ?? '')),
+            children: Array.from({ length: width }, (_, i) => wordCell(line[i] ?? '', colTwips)),
           }),
       ),
     ];
 
     children.push(
       new Table({
-        width: { size: 100, type: WidthType.PERCENTAGE },
+        columnWidths,
+        width: { size: LANDSCAPE_USABLE_TWIPS, type: WidthType.DXA },
         rows,
       }),
     );

--- a/frontend/src/pages/dashboard/forms/TechnicalAchievementSummary.tsx
+++ b/frontend/src/pages/dashboard/forms/TechnicalAchievementSummary.tsx
@@ -1,12 +1,24 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { ChevronLeft } from 'lucide-react'
+import { ChevronLeft, Download } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { Card, CardContent } from '@/components/ui/Card'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTechnicalSummary, useTechnicalSummaryFilters } from '@/hooks/useTechnicalAchievementSummary'
 import { useAlert } from '@/hooks/useAlert'
 import { ParticipantAchievement, TechnicalAchievementSummaryData } from '@/services/technicalAchievementSummaryApi'
+import { exportApi } from '@/services/exportApi'
 import { DatePicker } from '@/components/ui/date-picker'
+
+/** Template key the backend dispatches on — see exportController.js. */
+const TAS_TEMPLATE_KEY = 'technical-achievement-summary-report'
+
+type ExportFormat = 'pdf' | 'excel' | 'word'
+
+const FORMAT_EXT: Record<ExportFormat, string> = {
+    pdf: 'pdf',
+    excel: 'xlsx',
+    word: 'docx',
+}
 
 const SECTION_TH = 'px-2 py-2 border border-[#D6D6D6] text-center font-semibold text-[13px] leading-tight bg-[#EEEEEE]'
 const TH = 'px-1.5 py-1 border border-[#D6D6D6] text-center font-semibold text-[12px] leading-tight'
@@ -215,15 +227,6 @@ function buildExportTables(sections: TechnicalAchievementSummaryData['sections']
     ]
 }
 
-function escapeHtml(value: string): string {
-    return value
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;')
-}
-
 function getSafeFileLabel(value: string): string {
     return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
 }
@@ -241,8 +244,7 @@ export const TechnicalAchievementSummary: React.FC = () => {
     const [selectedKvkId, setSelectedKvkId] = useState<string>('')
     const [appliedYear, setAppliedYear] = useState<number | null>(null)
     const [appliedKvkId, setAppliedKvkId] = useState<number | undefined>(undefined)
-    const [isExportingPdf, setIsExportingPdf] = useState(false)
-    const [isExportingExcel, setIsExportingExcel] = useState(false)
+    const [exportingFormat, setExportingFormat] = useState<ExportFormat | null>(null)
 
     const today = useMemo(() => new Date(), [])
     const todayIso = useMemo(() => {
@@ -293,129 +295,53 @@ export const TechnicalAchievementSummary: React.FC = () => {
         return filterOptions?.kvks.find((kvk) => kvk.kvkId === appliedKvkId)?.kvkName || `KVK ${appliedKvkId}`
     }, [canFilterByKvk, appliedKvkId, filterOptions?.kvks])
 
-    const handleDownloadReport = async () => {
+    /**
+     * Single export handler — posts the section payload to the backend, which
+     * produces the PDF/Excel/Word buffer from the shared template. Keeps
+     * format identical to the prior client-side output and avoids the
+     * html2pdf oklch() parsing issue that broke in production.
+     */
+    const handleExport = async (format: ExportFormat) => {
         if (!summaryData?.sections) return
-        setIsExportingPdf(true)
+        setExportingFormat(format)
         try {
-            const html2pdfModule = await import('html2pdf.js')
-            const html2pdf = html2pdfModule.default || html2pdfModule
-            const tables = buildExportTables(summaryData.sections)
+            const tables = buildExportTables(summaryData.sections).map((table) => ({
+                title: table.title,
+                headers: table.headers,
+                rows: table.rows ?? (table.row ? [table.row] : []),
+            }))
 
-            const tableHtml = tables.map((table) => {
-                const bodyRows = table.rows ?? (table.row ? [table.row] : [])
-                const tbody = bodyRows
-                    .map(
-                        (line) =>
-                            `<tr>${line.map((value) => `<td>${escapeHtml(String(value ?? ''))}</td>`).join('')}</tr>`,
-                    )
-                    .join('')
-                return `
-        <table class="tas-table">
-          <thead>
-            <tr><th class="table-title" colspan="${table.headers.length}">${escapeHtml(table.title)}</th></tr>
-            <tr>${table.headers.map((header) => `<th>${escapeHtml(String(header))}</th>`).join('')}</tr>
-          </thead>
-          <tbody>${tbody}</tbody>
-        </table>
-      `
-            }).join('')
+            const blob = await exportApi.exportData({
+                title: 'Technical Achievement Summary',
+                headers: [],
+                rows: [],
+                format,
+                templateKey: TAS_TEMPLATE_KEY,
+                rawData: {
+                    tables,
+                    reportingYear: summaryData.reportingYear,
+                    kvkLabel: appliedKvkLabel,
+                },
+            })
 
-            const reportElement = document.createElement('div')
-            reportElement.innerHTML = `
-        <div class="tas-report">
-          <style>
-            .tas-report { font-family: Arial, sans-serif; padding: 18px; color: #111; }
-            .tas-title { font-size: 20px; font-weight: 700; margin-bottom: 4px; }
-            .tas-meta { font-size: 12px; margin-bottom: 2px; }
-            .tas-table { width: 100%; border-collapse: collapse; margin-top: 12px; }
-            .tas-table th, .tas-table td { border: 1px solid #000; font-size: 9px; padding: 3px 4px; text-align: center; }
-            .tas-table .table-title { background: #f2f2f2; font-size: 11px; font-weight: 700; }
-          </style>
-          <div class="tas-title">Technical Achievement Summary</div>
-          <div class="tas-meta">Reporting Year: ${escapeHtml(String(summaryData.reportingYear))}</div>
-          <div class="tas-meta">KVK: ${escapeHtml(appliedKvkLabel)}</div>
-          ${tableHtml}
-        </div>
-      `
-
-            const filename = `technical-achievement-summary-${summaryData.reportingYear}-${getSafeFileLabel(appliedKvkLabel)}.pdf`
-            await html2pdf()
-                .set({
-                    margin: 0.2,
-                    filename,
-                    image: { type: 'jpeg', quality: 0.98 },
-                    html2canvas: { scale: 2, useCORS: true },
-                    jsPDF: { unit: 'in', format: 'a4', orientation: 'landscape' },
-                })
-                .from(reportElement)
-                .save()
+            const filename = `technical-achievement-summary-${summaryData.reportingYear}-${getSafeFileLabel(appliedKvkLabel)}.${FORMAT_EXT[format]}`
+            const url = URL.createObjectURL(blob)
+            const link = document.createElement('a')
+            link.href = url
+            link.download = filename
+            document.body.appendChild(link)
+            link.click()
+            document.body.removeChild(link)
+            URL.revokeObjectURL(url)
         } catch (error) {
-            console.error('Failed to generate technical summary PDF:', error)
+            console.error(`Failed to generate technical summary ${format.toUpperCase()}:`, error)
             alert({
                 title: 'Export Failed',
-                message: 'Failed to generate PDF report. Please try again.',
+                message: `Failed to generate ${format.toUpperCase()} report. Please try again.`,
                 variant: 'error',
             })
         } finally {
-            setIsExportingPdf(false)
-        }
-    }
-
-    const handleDownloadExcel = async () => {
-        if (!summaryData?.sections) return
-        setIsExportingExcel(true)
-        try {
-            const XLSX = await import('xlsx')
-            const tables = buildExportTables(summaryData.sections)
-            const sheet = XLSX.utils.aoa_to_sheet([])
-            const merges: Array<{ s: { r: number; c: number }; e: { r: number; c: number } }> = []
-            const maxColumns = Math.max(...tables.map((table) => table.headers.length))
-            let row = 0
-
-            XLSX.utils.sheet_add_aoa(sheet, [['Technical Achievement Summary']], { origin: { r: row, c: 0 } })
-            merges.push({ s: { r: row, c: 0 }, e: { r: row, c: maxColumns - 1 } })
-            row += 1
-
-            XLSX.utils.sheet_add_aoa(sheet, [[`Reporting Year: ${summaryData.reportingYear}`]], { origin: { r: row, c: 0 } })
-            merges.push({ s: { r: row, c: 0 }, e: { r: row, c: maxColumns - 1 } })
-            row += 1
-
-            XLSX.utils.sheet_add_aoa(sheet, [[`KVK: ${appliedKvkLabel}`]], { origin: { r: row, c: 0 } })
-            merges.push({ s: { r: row, c: 0 }, e: { r: row, c: maxColumns - 1 } })
-            row += 2
-
-            tables.forEach((table) => {
-                XLSX.utils.sheet_add_aoa(sheet, [[table.title]], { origin: { r: row, c: 0 } })
-                merges.push({ s: { r: row, c: 0 }, e: { r: row, c: table.headers.length - 1 } })
-                row += 1
-
-                XLSX.utils.sheet_add_aoa(sheet, [table.headers], { origin: { r: row, c: 0 } })
-                row += 1
-
-                const dataRows = table.rows ?? (table.row ? [table.row] : [])
-                dataRows.forEach((line) => {
-                    XLSX.utils.sheet_add_aoa(sheet, [line], { origin: { r: row, c: 0 } })
-                    row += 1
-                })
-                row += 1
-            })
-
-            sheet['!merges'] = merges
-            sheet['!cols'] = Array.from({ length: maxColumns }, () => ({ wch: 12 }))
-
-            const workbook = XLSX.utils.book_new()
-            XLSX.utils.book_append_sheet(workbook, sheet, 'Technical Summary')
-            const filename = `technical-achievement-summary-${summaryData.reportingYear}-${getSafeFileLabel(appliedKvkLabel)}.xlsx`
-            XLSX.writeFile(workbook, filename)
-        } catch (error) {
-            console.error('Failed to generate technical summary Excel:', error)
-            alert({
-                title: 'Export Failed',
-                message: 'Failed to generate Excel report. Please try again.',
-                variant: 'error',
-            })
-        } finally {
-            setIsExportingExcel(false)
+            setExportingFormat(null)
         }
     }
 
@@ -494,22 +420,24 @@ export const TechnicalAchievementSummary: React.FC = () => {
                     </div>
 
                     <div className="flex gap-3 mb-4">
-                        <button
-                            type="button"
-                            onClick={handleDownloadReport}
-                            disabled={!summaryData || isExportingPdf}
-                            className="px-4 py-2 bg-[#487749] text-white rounded-lg text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                            {isExportingPdf ? 'Generating PDF...' : 'Download Report'}
-                        </button>
-                        <button
-                            type="button"
-                            onClick={handleDownloadExcel}
-                            disabled={!summaryData || isExportingExcel}
-                            className="px-4 py-2 bg-[#487749] text-white rounded-lg text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                            {isExportingExcel ? 'Generating Excel...' : 'Download Excel'}
-                        </button>
+                        {(
+                            [
+                                { format: 'pdf', label: 'PDF' },
+                                { format: 'excel', label: 'Excel' },
+                                { format: 'word', label: 'Word' },
+                            ] as const
+                        ).map(({ format, label }) => (
+                            <button
+                                key={format}
+                                type="button"
+                                onClick={() => handleExport(format)}
+                                disabled={!summaryData || exportingFormat !== null}
+                                className="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-[#E0E0E0] bg-white text-[#487749] text-sm font-medium hover:bg-[#F5F5F5] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                            >
+                                <Download className="w-4 h-4" />
+                                {exportingFormat === format ? `${label}…` : label}
+                            </button>
+                        ))}
                     </div>
 
                     {(filterError || summaryError) && (


### PR DESCRIPTION
## Summary

- **Bug fix (prod):** Technical Achievement Summary PDF download was throwing \`Attempting to parse an unsupported color function \"oklch\"\` because \`html2pdf.js\`/\`html2canvas\`/\`jsPDF\` can't parse Tailwind 4's \`oklch()\` tokens. Puppeteer (real Chromium) handles them natively, so routing through the existing backend template system eliminates the error permanently.
- **UI parity:** Page now has three matching pill-style buttons (⬇ PDF / ⬇ Excel / ⬇ Word), same as the other report pages.
- **New Word export:** Page previously had only PDF + Excel; Word now included.

## Format

- **PDF** — HTML/CSS ported 1:1 from the previous client-side template into the backend. Visual output is identical; Puppeteer renders slightly sharper than html2canvas but the layout, fonts, borders, columns, and headings are preserved.
- **Excel** — Multi-section single-sheet layout using ExcelJS. Merged title row, reporting year + KVK rows, per-section title + header + data rows, spacer between sections. Same structure as the prior xlsx output.
- **Word** — New. Mirrors the PDF section structure: title heading, metadata paragraphs, per-section tables.

## Backend

- \`backend/utils/technicalSummaryExport.js\` (new):
  - \`generateTechnicalSummaryPdfBuffer(payload)\` — Puppeteer via \`exportHelper.generatePDF\`.
  - \`generateTechnicalSummaryExcelBuffer(payload)\` — ExcelJS.
  - \`generateTechnicalSummaryWordBuffer(payload)\` — docx.
- \`backend/controllers/exportController.js\`: dispatches the new \`technical-achievement-summary-report\` templateKey to the three generators in the PDF / Excel / Word switch cases. Existing templates untouched.

## Frontend

- \`frontend/src/pages/dashboard/forms/TechnicalAchievementSummary.tsx\`:
  - Drops the \`html2pdf.js\` and \`xlsx\` dynamic imports.
  - Single \`handleExport(format)\` posts to \`exportApi.exportData\` with the TAS templateKey and the section payload produced by the existing \`buildExportTables\` helper.
  - Three buttons (PDF / Excel / Word) replace the two old ones; matches the visual pattern used in other list pages (download icon + label).
  - Removed dead \`escapeHtml\` helper (only the old client-side PDF used it).

## Test plan

- [ ] Backend boots (\`npm start\`); \`/api/admin/masters/exportData\` accepts the new templateKey.
- [ ] Open Technical Achievement Summary → all three buttons visible.
- [ ] PDF: downloads, renders multi-section layout; headings, borders, metadata lines match previous format; no \`oklch\` error in prod console.
- [ ] Excel: downloads; multi-section layout with merged title rows and per-section data; visually equivalent to the prior xlsx output.
- [ ] Word: downloads; sections rendered as tables with the same headers/rows.
- [ ] No regression on other export endpoints (FLD, trainings, awards, etc.) — only the TAS templateKey branch is new; everything else untouched.

## Non-breaking

- No schema or seed changes.
- Other pages unchanged (other \`templateKey\` branches untouched).
- TAS page's \`buildExportTables\` shape unchanged; backend template matches prior output format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)