### PR TITLE
refactor(masters): rename residuals — Organisation -> Institute, University -> Host

### DIFF
--- a/frontend/src/components/admin/CreateUserModal.tsx
+++ b/frontend/src/components/admin/CreateUserModal.tsx
@@ -259,7 +259,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 newErrors.districtId = 'District is required for this role'
             }
             if (showOrgForSubAdmin && orgRequired && !formData.orgId) {
-                newErrors.orgId = 'Organization is required for this role'
+                newErrors.orgId = 'Institute is required for this role'
             }
         }
         // KVK validation — skip when kvk_admin (auto-inherited)
@@ -885,7 +885,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                         }}
                         emptyMessage={isSubAdmin
                             ? 'No KVKs available for your location'
-                            : 'No KVKs found. Please select Zone, State, District, Organization and University first.'}
+                            : 'No KVKs found. Please select Zone, State, District, Institute and Host first.'}
                         loadingMessage="Loading KVKs..."
                         cacheKey="kvks-by-university"
                         required={kvkRequired}

--- a/frontend/src/utils/deleteHandlers.ts
+++ b/frontend/src/utils/deleteHandlers.ts
@@ -24,25 +24,25 @@ const CASCADE_DELETE_CONFIGS: Record<string, CascadeDeleteConfig> = {
         affectedRecords: [
             'All states in this zone',
             'All districts in those states',
-            'All organizations in those districts',
+            'All institutes in those districts',
             'All KVKs in this zone',
             'User zone assignments will be cleared',
         ],
     },
     [ENTITY_TYPES.ORGANIZATIONS]: {
-        title: 'Delete Organization',
+        title: 'Delete Institute',
         affectedRecords: [
-            'All universities in this organization',
-            'All KVKs in this organization',
-            'User organization assignments will be cleared',
+            'All hosts in this institute',
+            'All KVKs in this institute',
+            'User institute assignments will be cleared',
         ],
     },
     [ENTITY_TYPES.STATES]: {
         title: 'Delete State',
         affectedRecords: [
             'All districts in this state',
-            'All organizations in those districts',
-            'All universities in those organizations',
+            'All institutes in those districts',
+            'All hosts in those institutes',
             'All KVKs in this state',
             'User state assignments will be cleared',
         ],
@@ -50,17 +50,17 @@ const CASCADE_DELETE_CONFIGS: Record<string, CascadeDeleteConfig> = {
     [ENTITY_TYPES.DISTRICTS]: {
         title: 'Delete District',
         affectedRecords: [
-            'All organizations in this district',
-            'All universities in those organizations',
+            'All institutes in this district',
+            'All hosts in those institutes',
             'All KVKs in this district',
             'User district assignments will be cleared',
         ],
     },
     [ENTITY_TYPES.UNIVERSITIES]: {
-        title: 'Delete University',
+        title: 'Delete Host',
         affectedRecords: [
-            'All KVKs in this university',
-            'User university assignments will be cleared',
+            'All KVKs in this host',
+            'User host assignments will be cleared',
         ],
     },
 };

--- a/frontend/src/utils/exportUtils.ts
+++ b/frontend/src/utils/exportUtils.ts
@@ -16,6 +16,11 @@ const CUSTOM_LABELS: Record<string, string> = {
     'minTemperature': 'Min. Temperature 0C',
     'kvkName': 'KVK',
     'nutritionGardenCropResults': 'Crop production & consumption (results)',
+    // UI rename (labels only — data keys preserved):
+    // Organisation/Organization -> Institute, University -> Host
+    'orgName': 'Institute Name',
+    'organizationName': 'Institute Name',
+    'universityName': 'Host Name',
 }
 
 export function formatHeaderLabel(field: string): string {

--- a/frontend/src/utils/idFieldMap.ts
+++ b/frontend/src/utils/idFieldMap.ts
@@ -87,6 +87,7 @@ export const ENTITY_ID_FIELD_MAP: Record<string, string> = {
     [ENTITY_TYPES.KVK_EMPLOYEES]: 'kvkStaffId',
     [ENTITY_TYPES.KVK_STAFF_TRANSFERRED]: 'kvkStaffId',
     [ENTITY_TYPES.KVK_INFRASTRUCTURE]: 'infraId',
+    [ENTITY_TYPES.KVK_LAND_DETAILS]: 'landId',
     [ENTITY_TYPES.KVK_VEHICLES]: 'vehicleId',
     [ENTITY_TYPES.KVK_VEHICLE_DETAILS]: 'vehicleId',
     [ENTITY_TYPES.KVK_EQUIPMENTS]: 'equipmentId',


### PR DESCRIPTION
Closes #121

Stacked on top of #127 (issue #123 land-details).

## Summary
- Table column headers: add `orgName` / `organizationName` / `universityName` to `CUSTOM_LABELS` in `exportUtils.formatHeaderLabel` so master list pages show "Institute Name" / "Host Name" instead of the default camel-case derivation. DataTable calls `formatHeaderLabel` on every field, so this flows through to CSV exports too.
- Cascade delete modal (`deleteHandlers.ts`): rename modal titles (Delete Institute / Delete Host) + nested affected-records copy across Zones/States/Districts/Organizations/Universities.
- CreateUserModal residuals: validation message "Institute is required" and empty-KVK hint "Please select Zone, State, District, Institute and Host first".

Not touched (by design):
- Prisma models (`OrgMaster`, `UniversityMaster`) and DB columns — unchanged.
- Entity type keys (`ORGANIZATIONS`, `UNIVERSITIES`) and data accessors (`orgName`, `universityName`) — preserved.
- Role display names ("Organization Admin/User") — these are admin-scope roles, not OrgMaster dropdowns.
- FPO titles ("Farmer Producer Organizations"), LinkageForms generic "Name of Organization" input — unrelated concepts.

## Test plan
- [ ] All Masters -> Institute Master: table column header reads "Institute Name".
- [ ] All Masters -> Host Master: columns read "Institute Name" + "Host Name".
- [ ] Delete confirm modal for an institute/host shows renamed title + warnings.
- [ ] Create User modal: validation + empty-KVK hint use Institute/Host.
- [ ] CSV / Excel export column headers on the same lists match.