### PR TITLE
fix(about-kvk): KVK Year of Sanction — year-only picker

### DIFF
--- a/frontend/src/components/admin/CreateUserModal.tsx
+++ b/frontend/src/components/admin/CreateUserModal.tsx
@@ -259,7 +259,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                 newErrors.districtId = 'District is required for this role'
             }
             if (showOrgForSubAdmin && orgRequired && !formData.orgId) {
-                newErrors.orgId = 'Organization is required for this role'
+                newErrors.orgId = 'Institute is required for this role'
             }
         }
         // KVK validation — skip when kvk_admin (auto-inherited)
@@ -885,7 +885,7 @@ export const CreateUserModal: React.FC<CreateUserModalProps> = ({
                         }}
                         emptyMessage={isSubAdmin
                             ? 'No KVKs available for your location'
-                            : 'No KVKs found. Please select Zone, State, District, Organization and University first.'}
+                            : 'No KVKs found. Please select Zone, State, District, Institute and Host first.'}
                         loadingMessage="Loading KVKs..."
                         cacheKey="kvks-by-university"
                         required={kvkRequired}

--- a/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
@@ -801,21 +801,26 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                     placeholder="Enter KVK name"
                                 />
                             </div>
-                            <FormInput
+                            <FormSelect
                                 label="Year of Sanction"
-                                type="date"
                                 required
-                                value={formData.yearOfSanctionDate ?? (formData.yearOfSanction ? `${formData.yearOfSanction}-01-01` : '')}
+                                value={formData.yearOfSanction ?? ''}
                                 onChange={(e) => {
-                                    const raw = e.target.value
-                                    const year = raw ? new Date(raw).getFullYear() : ''
+                                    const v = e.target.value
+                                    const year = v === '' ? '' : parseInt(v, 10)
                                     setFormData({
                                         ...formData,
-                                        yearOfSanctionDate: raw,
                                         yearOfSanction: typeof year === 'number' && !Number.isNaN(year) ? year : '',
                                     })
                                 }}
-                                placeholder="Select date"
+                                placeholder="Select year"
+                                options={Array.from(
+                                    { length: new Date().getFullYear() - 1970 + 1 },
+                                    (_, i) => {
+                                        const y = new Date().getFullYear() - i
+                                        return { value: y, label: String(y) }
+                                    },
+                                )}
                             />
                             <div className="md:col-span-1 lg:col-span-2">
                                 <FormInput

--- a/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
@@ -210,7 +210,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
             {(entityType === ENTITY_TYPES.KVK_EMPLOYEES) && (
                 <div className="space-y-6">
                     <FormSection title="Personal Details">
-                        <div className="grid grid-cols-2 gap-4">
+                        <div className="grid grid-cols-2 gap-6">
                             <FormInput
                                 label="Staff Name"
                                 required
@@ -226,7 +226,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 onChange={(e) => setFormData({ ...formData, dateOfBirth: new Date(e.target.value).toISOString() })}
                             />
                         </div>
-                        <div className="grid grid-cols-2 gap-4">
+                        <div className="grid grid-cols-2 gap-6 mt-6">
                             <FormInput
                                 label="Mobile"
                                 required
@@ -246,7 +246,14 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 placeholder="Email address"
                             />
                         </div>
-                        <div className="grid grid-cols-2 gap-4">
+                        <div className="grid grid-cols-2 gap-6 mt-6">
+                            <FormSelect
+                                label="Category"
+                                required
+                                value={formData.staffCategoryId ?? ''}
+                                onChange={(e) => setFormData({ ...formData, staffCategoryId: parseInt(e.target.value) })}
+                                options={staffCategories.map((c: any) => ({ value: c.staffCategoryId, label: c.categoryName }))}
+                            />
                             <FormInput
                                 label="Resume"
                                 value={formData.resumePath ?? ''}
@@ -340,7 +347,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                     </FormSection>
 
                     <FormSection title="Job Details">
-                        <div className="grid grid-cols-2 gap-4">
+                        <div className="grid grid-cols-2 gap-6">
                             <FormSelect
                                 label="Sanctioned Post"
                                 required
@@ -356,7 +363,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 options={Array.from({ length: 20 }, (_, i) => ({ value: i + 1, label: String(i + 1) }))}
                             />
                         </div>
-                        <div className="grid grid-cols-2 gap-4">
+                        <div className="grid grid-cols-2 gap-6 mt-6">
                             <FormSelect
                                 label="Discipline"
                                 required
@@ -372,7 +379,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 onChange={(e) => setFormData({ ...formData, dateOfJoining: new Date(e.target.value).toISOString() })}
                             />
                         </div>
-                        <div className="grid grid-cols-2 gap-4">
+                        <div className="grid grid-cols-2 gap-6 mt-6">
                             <FormSelect
                                 label="Job Type"
                                 value={formData.jobType ?? ''}
@@ -389,7 +396,7 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 options={payLevels.map((p: any) => ({ value: p.payLevelId, label: p.levelName }))}
                             />
                         </div>
-                        <div className="grid grid-cols-2 gap-4">
+                        <div className="grid grid-cols-2 gap-6 mt-6">
                             <FormSelect
                                 label="Pay Scale"
                                 value={formData.payScaleId ?? ''}
@@ -401,18 +408,6 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 value={formData.allowances ?? ''}
                                 onChange={(e) => setFormData({ ...formData, allowances: e.target.value })}
                                 placeholder="Allowances"
-                            />
-                        </div>
-                    </FormSection>
-
-                    <FormSection title="Other">
-                        <div className="grid grid-cols-2 gap-4">
-                            <FormSelect
-                                label="Category"
-                                required
-                                value={formData.staffCategoryId ?? ''}
-                                onChange={(e) => setFormData({ ...formData, staffCategoryId: parseInt(e.target.value) })}
-                                options={staffCategories.map((c: any) => ({ value: c.staffCategoryId, label: c.categoryName }))}
                             />
                         </div>
                     </FormSection>

--- a/frontend/src/utils/deleteHandlers.ts
+++ b/frontend/src/utils/deleteHandlers.ts
@@ -24,25 +24,25 @@ const CASCADE_DELETE_CONFIGS: Record<string, CascadeDeleteConfig> = {
         affectedRecords: [
             'All states in this zone',
             'All districts in those states',
-            'All organizations in those districts',
+            'All institutes in those districts',
             'All KVKs in this zone',
             'User zone assignments will be cleared',
         ],
     },
     [ENTITY_TYPES.ORGANIZATIONS]: {
-        title: 'Delete Organization',
+        title: 'Delete Institute',
         affectedRecords: [
-            'All universities in this organization',
-            'All KVKs in this organization',
-            'User organization assignments will be cleared',
+            'All hosts in this institute',
+            'All KVKs in this institute',
+            'User institute assignments will be cleared',
         ],
     },
     [ENTITY_TYPES.STATES]: {
         title: 'Delete State',
         affectedRecords: [
             'All districts in this state',
-            'All organizations in those districts',
-            'All universities in those organizations',
+            'All institutes in those districts',
+            'All hosts in those institutes',
             'All KVKs in this state',
             'User state assignments will be cleared',
         ],
@@ -50,17 +50,17 @@ const CASCADE_DELETE_CONFIGS: Record<string, CascadeDeleteConfig> = {
     [ENTITY_TYPES.DISTRICTS]: {
         title: 'Delete District',
         affectedRecords: [
-            'All organizations in this district',
-            'All universities in those organizations',
+            'All institutes in this district',
+            'All hosts in those institutes',
             'All KVKs in this district',
             'User district assignments will be cleared',
         ],
     },
     [ENTITY_TYPES.UNIVERSITIES]: {
-        title: 'Delete University',
+        title: 'Delete Host',
         affectedRecords: [
-            'All KVKs in this university',
-            'User university assignments will be cleared',
+            'All KVKs in this host',
+            'User host assignments will be cleared',
         ],
     },
 };

--- a/frontend/src/utils/exportUtils.ts
+++ b/frontend/src/utils/exportUtils.ts
@@ -16,6 +16,11 @@ const CUSTOM_LABELS: Record<string, string> = {
     'minTemperature': 'Min. Temperature 0C',
     'kvkName': 'KVK',
     'nutritionGardenCropResults': 'Crop production & consumption (results)',
+    // UI rename (labels only — data keys preserved):
+    // Organisation/Organization -> Institute, University -> Host
+    'orgName': 'Institute Name',
+    'organizationName': 'Institute Name',
+    'universityName': 'Host Name',
 }
 
 export function formatHeaderLabel(field: string): string {

--- a/frontend/src/utils/idFieldMap.ts
+++ b/frontend/src/utils/idFieldMap.ts
@@ -87,6 +87,7 @@ export const ENTITY_ID_FIELD_MAP: Record<string, string> = {
     [ENTITY_TYPES.KVK_EMPLOYEES]: 'kvkStaffId',
     [ENTITY_TYPES.KVK_STAFF_TRANSFERRED]: 'kvkStaffId',
     [ENTITY_TYPES.KVK_INFRASTRUCTURE]: 'infraId',
+    [ENTITY_TYPES.KVK_LAND_DETAILS]: 'landId',
     [ENTITY_TYPES.KVK_VEHICLES]: 'vehicleId',
     [ENTITY_TYPES.KVK_VEHICLE_DETAILS]: 'vehicleId',
     [ENTITY_TYPES.KVK_EQUIPMENTS]: 'equipmentId',


### PR DESCRIPTION
Closes #122

Stacked on top of #129 (issue #120 employee form).

## Summary
- #113 swapped the numeric input for `<input type=\"date\">` which renders a full calendar; the spec was year-only.
- Replace with a `FormSelect` populated from `1970 .. currentYear` (descending). Value stored as an `Int` in `yearOfSanction`; transient `yearOfSanctionDate` helper is removed.
- Backend Prisma column `kvk.yearOfSanction` is already `Int` — no schema change needed. `parseYearOfEstablishment` in `aboutKvkRepository` already accepts the integer.
- The KVK create form is the only place this field is edited (the master list + edit flow share `AboutKvkForms.tsx`).

## Test plan
- [ ] All Masters -> KVK Master -> Add: Year of Sanction shows a year dropdown, no month/day picker.
- [ ] Edit an existing KVK: previously-saved year appears selected; changing persists as Int.
- [ ] Submit with Year of Sanction left blank → required-field validation fires.
- [ ] Table column still renders the year.