### PR TITLE
feat(oft, gallery): S3-backed multi attachments + Gallery source toggle

### DIFF
--- a/backend/controllers/formAttachmentController.js
+++ b/backend/controllers/formAttachmentController.js
@@ -1,0 +1,44 @@
+const formAttachmentService = require('../services/formAttachmentService');
+
+function send(res, p) {
+    return p
+        .then((data) => res.status(200).json(data))
+        .catch((err) => {
+            const status = err.statusCode || 400;
+            return res.status(status).json({ error: err.message, code: err.code, field: err.field });
+        });
+}
+
+const formAttachmentController = {
+    presignUpload: (req, res) => send(res, formAttachmentService.presignUpload(req.body || {}, req.user)),
+
+    confirmUpload: (req, res) => send(res, formAttachmentService.confirmUpload(req.body || {}, req.user)),
+
+    list: (req, res) => send(res, formAttachmentService.listByRecord({
+        formCode: req.query.formCode,
+        recordId: req.query.recordId,
+        kvkId: req.query.kvkId,
+        kind: req.query.kind,
+    }, req.user)),
+
+    attachToRecord: (req, res) => send(res, formAttachmentService.attachToRecord(req.body || {}, req.user)),
+
+    update: (req, res) => send(res, formAttachmentService.updateAttachment(req.params.attachmentId, req.body || {}, req.user)),
+
+    remove: (req, res) => send(res, formAttachmentService.deleteAttachment(req.params.attachmentId, req.user)),
+
+    gallery: (req, res) => send(res, formAttachmentService.listForGallery({
+        page: req.query.page,
+        limit: req.query.limit,
+        kvkId: req.query.kvkId,
+        formCode: req.query.formCode,
+        reportingYear: req.query.reportingYear,
+        search: req.query.search,
+    }, req.user)),
+
+    galleryForms: (req, res) => send(res, formAttachmentService.listForms(req.user)),
+
+    galleryKvks: (req, res) => send(res, formAttachmentService.listKvks(req.user)),
+};
+
+module.exports = formAttachmentController;

--- a/backend/middleware/validateFormRobustness.js
+++ b/backend/middleware/validateFormRobustness.js
@@ -143,8 +143,11 @@ function validateNoFutureDates(body) {
         const dt = parseDateOnly(value);
         if (!dt) continue;
 
-        // Allow future dates only for "target date"-type fields.
-        if (String(key).toLowerCase().includes('target')) continue;
+        // Allow future dates for forward-looking fields (target, expected, planned).
+        const lowerKey = String(key).toLowerCase();
+        if (lowerKey.includes('target')) continue;
+        if (lowerKey.includes('expected')) continue;
+        if (lowerKey.includes('planned')) continue;
 
         if (dt.getTime() > today.getTime()) {
             throw new ValidationError(`"${key}" cannot be in the future`, key);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1037.0",
+        "@aws-sdk/s3-request-presigner": "^3.1037.0",
         "@prisma/adapter-pg": "^7.2.0",
         "@prisma/client": "^7.2.0",
         "@sparticuz/chromium": "^133.0.0",
@@ -25,10 +27,898 @@
         "pg": "^8.17.1",
         "prisma": "^7.2.0",
         "puppeteer": "^24.37.2",
-        "puppeteer-core": "^24.37.2"
+        "puppeteer-core": "^24.37.2",
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@types/node": "^25.0.9"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1037.0.tgz",
+      "integrity": "sha512-DBmA1jAW8ST6C4srBxeL1/RLIir/d8WOm4s4mi59mGp6mBktHM59Kwb7GuURaCO60cotuce5zr0sKpMLPcBQyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-node": "^3.972.36",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
+        "@aws-sdk/middleware-expect-continue": "^3.972.10",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.13",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.34",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-blob-browser": "^4.2.15",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/hash-stream-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/md5-js": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.16",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.5.tgz",
+      "integrity": "sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.19",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
+      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.31.tgz",
+      "integrity": "sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.33.tgz",
+      "integrity": "sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.35.tgz",
+      "integrity": "sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-login": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.35.tgz",
+      "integrity": "sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.36.tgz",
+      "integrity": "sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-ini": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.31.tgz",
+      "integrity": "sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.35.tgz",
+      "integrity": "sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/token-providers": "3.1036.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.35.tgz",
+      "integrity": "sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
+      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
+      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.13.tgz",
+      "integrity": "sha512-b6QUe2hQX9XsnCzp6mtzVaERhganDKeb8lmGL6pVhr7rRVH9S9keDFW7uKytuuqmcY5943FixoGqn/QL+sbUBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/crc64-nvme": "^3.972.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.34.tgz",
+      "integrity": "sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.35.tgz",
+      "integrity": "sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.3.tgz",
+      "integrity": "sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1037.0.tgz",
+      "integrity": "sha512-rZQS8DxrqPYXzOvaoysf6L4fHmgFbndZz3GfUMhlHG1iWmcQqH7v0AGhpjyNBY3cYAX8+CAkOkD4VUrntnHNbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.22.tgz",
+      "integrity": "sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.34",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1036.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1036.0.tgz",
+      "integrity": "sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.21.tgz",
+      "integrity": "sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -91,7 +981,8 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.2.tgz",
       "integrity": "sha512-zfWWa+V2ViDCY/cmUfRqeWY1yLto+EpxjXnZzenB1TyxsTiXaTWeZFIZw6mac52BsuQm0RjCnisjBtdBaXOI6w==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.6",
@@ -185,6 +1076,18 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@prisma/adapter-pg": {
       "version": "7.2.0",
@@ -378,6 +1281,725 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
+      "integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
+      "integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
+      "integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.6.tgz",
+      "integrity": "sha512-5zhmo2AkstmM/RMKYP0NHfmuYWBR+/umlmSuALgajLxf0X0rLE6d17MfzTxpzkILWVhwvCJkCyPH0AfMlbaucQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.5.tgz",
+      "integrity": "sha512-h1IJsbgMDA+jaTjrco/JsyfWOgHRJBv8myB1y4AEI2fjIzD6ktZ7pFAyTw+gwN9GKIAygvC6db0mq0j8N2rFOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
+      "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@sparticuz/chromium": {
@@ -799,6 +2421,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -1240,8 +2868,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -1332,7 +2959,8 @@
       "version": "0.0.1566079",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/docx": {
       "version": "9.5.1",
@@ -1636,11 +3264,21 @@
         "node": ">=8.3.0"
       }
     },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1763,6 +3401,42 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
@@ -2076,6 +3750,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.6.tgz",
       "integrity": "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2982,6 +4657,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3033,6 +4723,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.1.tgz",
       "integrity": "sha512-EIR+jXdYNSMOrpRp7g6WgQr7SaZNZfS7IzZIO0oTNEeibq956JxeD15t3Jk3zZH0KH8DmOIx38qJfQenoE8bXQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.10.0",
         "pg-pool": "^3.11.0",
@@ -3201,6 +4892,7 @@
       "integrity": "sha512-jSdHWgWOgFF24+nRyyNRVBIgGDQEsMEF8KPHvhBBg3jWyR9fUAK0Nq9ThUmiGlNgq2FA7vSk/ZoCvefod+a8qg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.2.0",
         "@prisma/dev": "0.17.0",
@@ -3635,8 +5327,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -3950,6 +5641,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/tar-fs": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
@@ -4144,12 +5847,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/valibot": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1037.0",
+    "@aws-sdk/s3-request-presigner": "^3.1037.0",
     "@prisma/adapter-pg": "^7.2.0",
     "@prisma/client": "^7.2.0",
     "@sparticuz/chromium": "^133.0.0",
@@ -47,7 +49,8 @@
     "pg": "^8.17.1",
     "prisma": "^7.2.0",
     "puppeteer": "^24.37.2",
-    "puppeteer-core": "^24.37.2"
+    "puppeteer-core": "^24.37.2",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.0.9"

--- a/backend/prisma/kvk/about-kvk/kvk_schema.prisma
+++ b/backend/prisma/kvk/about-kvk/kvk_schema.prisma
@@ -93,6 +93,7 @@ model Kvk {
   trainingAchievements          TrainingAchievement[]
   users                         User[]
   moduleImages                  ModuleImage[]
+  formAttachments               FormAttachment[]
   targets                       Target[]
   kvkImpactActivities           KvkImpactActivity[]
   entrepreneurships             Entrepreneurship[]

--- a/backend/prisma/kvk/form_attachments_schema.prisma
+++ b/backend/prisma/kvk/form_attachments_schema.prisma
@@ -1,0 +1,32 @@
+enum FormAttachmentKind {
+  PHOTO
+  DATASHEET
+  DOCUMENT
+}
+
+model FormAttachment {
+  attachmentId      Int                @id @default(autoincrement()) @map("attachment_id")
+  kvkId             Int                @map("kvk_id")
+  formCode          String             @map("form_code")
+  recordId          Int?               @map("record_id")
+  kind              FormAttachmentKind @default(PHOTO)
+  s3Key             String             @map("s3_key")
+  fileName          String?            @map("file_name")
+  mimeType          String             @map("mime_type")
+  size              Int                @default(0)
+  caption           String?
+  sortOrder         Int                @default(0) @map("sort_order")
+  reportingYearDate DateTime?          @map("reporting_year_date")
+  uploadedByUserId  Int?               @map("uploaded_by_user_id")
+  createdAt         DateTime           @default(now()) @map("created_at")
+  updatedAt         DateTime           @updatedAt @map("updated_at")
+  kvk               Kvk                @relation(fields: [kvkId], references: [kvkId], onDelete: Cascade)
+  uploadedBy        User?              @relation(fields: [uploadedByUserId], references: [userId], onDelete: SetNull)
+
+  @@index([kvkId, formCode, recordId])
+  @@index([formCode, recordId])
+  @@index([kvkId, formCode, kind, createdAt])
+  @@index([reportingYearDate])
+  @@index([uploadedByUserId])
+  @@map("form_attachments")
+}

--- a/backend/prisma/migrations/20260428000000_add_form_attachments/migration.sql
+++ b/backend/prisma/migrations/20260428000000_add_form_attachments/migration.sql
@@ -1,0 +1,44 @@
+-- Generic form attachment storage backed by S3.
+-- Used by OFT (photographs, supplementary datasheets) and other forms going forward.
+-- Legacy single-file columns on existing tables (e.g. oft_result_report.photograph_*)
+-- remain in place for backfill — new uploads write to form_attachments.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'FormAttachmentKind') THEN
+        CREATE TYPE "FormAttachmentKind" AS ENUM ('PHOTO', 'DATASHEET', 'DOCUMENT');
+    END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS "form_attachments" (
+    "attachment_id"        SERIAL PRIMARY KEY,
+    "kvk_id"               INTEGER NOT NULL,
+    "form_code"            TEXT NOT NULL,
+    "record_id"            INTEGER,
+    "kind"                 "FormAttachmentKind" NOT NULL DEFAULT 'PHOTO',
+    "s3_key"               TEXT NOT NULL,
+    "file_name"            TEXT,
+    "mime_type"            TEXT NOT NULL,
+    "size"                 INTEGER NOT NULL DEFAULT 0,
+    "caption"              TEXT,
+    "sort_order"           INTEGER NOT NULL DEFAULT 0,
+    "reporting_year_date"  TIMESTAMP(3),
+    "uploaded_by_user_id"  INTEGER,
+    "created_at"           TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"           TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "form_attachments_kvk_id_fkey"
+        FOREIGN KEY ("kvk_id") REFERENCES "kvk"("kvk_id") ON DELETE CASCADE,
+    CONSTRAINT "form_attachments_uploaded_by_user_id_fkey"
+        FOREIGN KEY ("uploaded_by_user_id") REFERENCES "users"("user_id") ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS "form_attachments_kvk_form_record_idx"
+    ON "form_attachments" ("kvk_id", "form_code", "record_id");
+CREATE INDEX IF NOT EXISTS "form_attachments_form_record_idx"
+    ON "form_attachments" ("form_code", "record_id");
+CREATE INDEX IF NOT EXISTS "form_attachments_kvk_form_kind_created_idx"
+    ON "form_attachments" ("kvk_id", "form_code", "kind", "created_at");
+CREATE INDEX IF NOT EXISTS "form_attachments_reporting_year_date_idx"
+    ON "form_attachments" ("reporting_year_date");
+CREATE INDEX IF NOT EXISTS "form_attachments_uploaded_by_idx"
+    ON "form_attachments" ("uploaded_by_user_id");

--- a/backend/prisma/superadmin/user/user_schema.prisma
+++ b/backend/prisma/superadmin/user/user_schema.prisma
@@ -96,6 +96,7 @@ model User {
   createdNotifications Notification[]       @relation("CreatedNotifications")
   loginActivities    UserLoginActivity[]
   moduleImages       ModuleImage[]
+  formAttachments    FormAttachment[]
   targets            Target[]              @relation("UserTargets")
   refreshTokens      RefreshToken[]
   transfersPerformed StaffTransferHistory[]

--- a/backend/repositories/formAttachmentRepository.js
+++ b/backend/repositories/formAttachmentRepository.js
@@ -1,0 +1,173 @@
+const prisma = require('../config/prisma');
+
+const SELECT = {
+    attachmentId: true,
+    kvkId: true,
+    formCode: true,
+    recordId: true,
+    kind: true,
+    s3Key: true,
+    fileName: true,
+    mimeType: true,
+    size: true,
+    caption: true,
+    sortOrder: true,
+    reportingYearDate: true,
+    uploadedByUserId: true,
+    createdAt: true,
+    updatedAt: true,
+    kvk: { select: { kvkId: true, kvkName: true } },
+    uploadedBy: { select: { userId: true, name: true, email: true } },
+};
+
+async function create(data) {
+    return prisma.formAttachment.create({ data, select: SELECT });
+}
+
+async function findById(attachmentId) {
+    return prisma.formAttachment.findUnique({
+        where: { attachmentId },
+        select: SELECT,
+    });
+}
+
+async function findByIds(attachmentIds) {
+    if (!Array.isArray(attachmentIds) || attachmentIds.length === 0) return [];
+    return prisma.formAttachment.findMany({
+        where: { attachmentId: { in: attachmentIds.map(Number).filter((n) => !Number.isNaN(n)) } },
+        select: SELECT,
+    });
+}
+
+async function listByRecord({ formCode, recordId, kvkId, kind }) {
+    const where = { formCode };
+    if (recordId !== undefined && recordId !== null) where.recordId = Number(recordId);
+    if (kvkId) where.kvkId = Number(kvkId);
+    if (kind) where.kind = kind;
+    return prisma.formAttachment.findMany({
+        where,
+        orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+        select: SELECT,
+    });
+}
+
+async function listForGallery({
+    page = 1,
+    limit = 50,
+    kvkId,
+    formCode,
+    kind = 'PHOTO',
+    reportingYear,
+    search,
+}) {
+    const where = { kind };
+    if (kvkId) where.kvkId = Number(kvkId);
+    if (formCode) where.formCode = formCode;
+    if (reportingYear) {
+        const yearNum = Number(reportingYear);
+        if (!Number.isNaN(yearNum)) {
+            where.reportingYearDate = {
+                gte: new Date(`${yearNum}-04-01T00:00:00.000Z`),
+                lt: new Date(`${yearNum + 1}-04-01T00:00:00.000Z`),
+            };
+        }
+    }
+    if (search) {
+        where.OR = [
+            { caption: { contains: search, mode: 'insensitive' } },
+            { fileName: { contains: search, mode: 'insensitive' } },
+        ];
+    }
+    const safePage = Math.max(1, Number(page) || 1);
+    const safeLimit = Math.min(200, Math.max(1, Number(limit) || 50));
+    const [total, data] = await Promise.all([
+        prisma.formAttachment.count({ where }),
+        prisma.formAttachment.findMany({
+            where,
+            orderBy: [{ createdAt: 'desc' }, { attachmentId: 'desc' }],
+            skip: (safePage - 1) * safeLimit,
+            take: safeLimit,
+            select: SELECT,
+        }),
+    ]);
+    return {
+        data,
+        meta: {
+            page: safePage,
+            limit: safeLimit,
+            total,
+            totalPages: Math.ceil(total / safeLimit),
+        },
+    };
+}
+
+async function update(attachmentId, data) {
+    return prisma.formAttachment.update({
+        where: { attachmentId },
+        data,
+        select: SELECT,
+    });
+}
+
+async function deleteByIds(attachmentIds) {
+    if (!Array.isArray(attachmentIds) || attachmentIds.length === 0) return { count: 0 };
+    return prisma.formAttachment.deleteMany({
+        where: { attachmentId: { in: attachmentIds.map(Number).filter((n) => !Number.isNaN(n)) } },
+    });
+}
+
+async function attachToRecord({ attachmentIds, formCode, recordId, kvkId }) {
+    if (!Array.isArray(attachmentIds) || attachmentIds.length === 0) return { count: 0 };
+    const ids = attachmentIds.map(Number).filter((n) => !Number.isNaN(n));
+    return prisma.formAttachment.updateMany({
+        where: {
+            attachmentId: { in: ids },
+            kvkId,
+            formCode,
+            OR: [{ recordId: null }, { recordId }],
+        },
+        data: { recordId },
+    });
+}
+
+async function distinctFormCodes({ kvkId, kind = 'PHOTO' }) {
+    const where = { kind };
+    if (kvkId) where.kvkId = Number(kvkId);
+    const rows = await prisma.formAttachment.groupBy({
+        by: ['formCode'],
+        where,
+        _count: { _all: true },
+        orderBy: { formCode: 'asc' },
+    });
+    return rows.map((r) => ({ formCode: r.formCode, count: r._count._all }));
+}
+
+async function distinctKvks({ kind = 'PHOTO' }) {
+    const rows = await prisma.formAttachment.groupBy({
+        by: ['kvkId'],
+        where: { kind },
+        _count: { _all: true },
+    });
+    if (rows.length === 0) return [];
+    const kvks = await prisma.kvk.findMany({
+        where: { kvkId: { in: rows.map((r) => r.kvkId) } },
+        select: { kvkId: true, kvkName: true },
+    });
+    const counts = new Map(rows.map((r) => [r.kvkId, r._count._all]));
+    return kvks
+        .map((k) => ({ kvkId: k.kvkId, kvkName: k.kvkName, count: counts.get(k.kvkId) || 0 }))
+        .sort((a, b) => a.kvkName.localeCompare(b.kvkName));
+}
+
+module.exports = {
+    create,
+    findById,
+    findByIds,
+    listByRecord,
+    listForGallery,
+    update,
+    deleteByIds,
+    attachToRecord,
+    distinctFormCodes,
+    distinctKvks,
+};

--- a/backend/routes/formAttachmentRoutes.js
+++ b/backend/routes/formAttachmentRoutes.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const router = express.Router();
+const formAttachmentController = require('../controllers/formAttachmentController');
+const { authenticateToken, requireRole } = require('../middleware/auth.js');
+
+const kvkRoles = ['kvk_admin', 'kvk_user', 'kvk_staff'];
+const allRoles = [...kvkRoles, 'super_admin', 'zone_admin', 'state_admin', 'district_admin', 'org_admin', 'kvk_viewer'];
+const writeRoles = [...kvkRoles, 'super_admin'];
+
+router.use(authenticateToken);
+
+router.post('/presign', requireRole(writeRoles), formAttachmentController.presignUpload);
+router.post('/confirm', requireRole(writeRoles), formAttachmentController.confirmUpload);
+router.post('/attach', requireRole(writeRoles), formAttachmentController.attachToRecord);
+
+router.get('/', requireRole(allRoles), formAttachmentController.list);
+
+router.get('/gallery', requireRole(allRoles), formAttachmentController.gallery);
+router.get('/gallery/forms', requireRole(allRoles), formAttachmentController.galleryForms);
+router.get('/gallery/kvks', requireRole(allRoles), formAttachmentController.galleryKvks);
+
+router.patch('/:attachmentId', requireRole(writeRoles), formAttachmentController.update);
+router.delete('/:attachmentId', requireRole(writeRoles), formAttachmentController.remove);
+
+module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -69,6 +69,9 @@ router.use('/admin/masters', publicationRoutes);
 router.use('/admin/masters', otherMastersRoutes);
 router.use('/admin/masters', exportRoutes);
 router.use('/users', userRoutes);
+// Form attachments (S3-backed) — mounted before validateFormRobustness because
+// the body shape (s3Key, kind, size) is not a form payload.
+router.use('/forms/attachments', require('./formAttachmentRoutes.js'));
 // Robust payload validation for all form saves (numbers + dates).
 router.use('/forms', validateFormRobustness);
 router.use('/forms', normalizeReportingYearRequest);

--- a/backend/services/formAttachmentService.js
+++ b/backend/services/formAttachmentService.js
@@ -1,0 +1,226 @@
+const formAttachmentRepository = require('../repositories/formAttachmentRepository');
+const s3 = require('./storage/s3Service');
+const { ValidationError, NotFoundError, UnauthorizedError } = require('../utils/errorHandler');
+
+const KIND = { PHOTO: 'PHOTO', DATASHEET: 'DATASHEET', DOCUMENT: 'DOCUMENT' };
+
+const MAX_BYTES = {
+    PHOTO: 5 * 1024 * 1024,
+    DATASHEET: 5 * 1024 * 1024,
+    DOCUMENT: 10 * 1024 * 1024,
+};
+
+const ALLOWED_MIME_PREFIXES = {
+    PHOTO: ['image/'],
+    DATASHEET: [
+        'application/pdf',
+        'image/',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml',
+        'text/csv',
+        'text/plain',
+    ],
+    DOCUMENT: [
+        'application/pdf',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml',
+        'text/csv',
+        'text/plain',
+    ],
+};
+
+function assertKvkAccess(user, kvkId) {
+    if (!user) throw new UnauthorizedError();
+    if (user.kvkId && user.kvkId !== Number(kvkId)) {
+        throw new UnauthorizedError('Cannot upload attachment for a different KVK');
+    }
+}
+
+function assertCanMutate(user, attachment) {
+    if (!user) throw new UnauthorizedError();
+    if (user.kvkId && attachment.kvkId !== user.kvkId) {
+        throw new UnauthorizedError('Cannot modify attachment from a different KVK');
+    }
+}
+
+function validateUploadInput({ kind, fileName, mimeType, size }) {
+    if (!kind || !KIND[kind]) {
+        throw new ValidationError(`Invalid attachment kind: ${kind}`);
+    }
+    if (!mimeType || typeof mimeType !== 'string') {
+        throw new ValidationError('mimeType is required');
+    }
+    const allowed = ALLOWED_MIME_PREFIXES[kind] || [];
+    const ok = allowed.some((p) => mimeType.toLowerCase().startsWith(p.toLowerCase()));
+    if (!ok) {
+        throw new ValidationError(`mimeType ${mimeType} is not allowed for ${kind}`);
+    }
+    const max = MAX_BYTES[kind];
+    if (typeof size !== 'number' || size <= 0) {
+        throw new ValidationError('size must be a positive number');
+    }
+    if (size > max) {
+        throw new ValidationError(`File exceeds max size ${(max / (1024 * 1024)).toFixed(0)}MB for ${kind}`);
+    }
+    if (!fileName || typeof fileName !== 'string' || fileName.length > 255) {
+        throw new ValidationError('fileName is required and must be < 255 chars');
+    }
+}
+
+async function presignUpload({ formCode, kind, fileName, mimeType, size, kvkId }, user) {
+    assertKvkAccess(user, kvkId);
+    validateUploadInput({ kind, fileName, mimeType, size });
+    if (!s3.isConfigured()) {
+        throw new ValidationError('Object storage not configured on server');
+    }
+    const s3Key = s3.buildAttachmentKey({ formCode, fileName, mimeType });
+    const uploadUrl = await s3.presignPut({ key: s3Key, mimeType });
+    return {
+        s3Key,
+        uploadUrl,
+        expiresIn: s3.PUT_TTL_SECONDS,
+        headers: { 'Content-Type': mimeType },
+    };
+}
+
+async function confirmUpload(payload, user) {
+    const {
+        s3Key,
+        formCode,
+        kind,
+        recordId,
+        kvkId,
+        fileName,
+        mimeType,
+        size,
+        caption,
+        sortOrder,
+        reportingYearDate,
+    } = payload || {};
+    assertKvkAccess(user, kvkId);
+    validateUploadInput({ kind, fileName, mimeType, size });
+    if (!s3Key || typeof s3Key !== 'string' || !s3Key.startsWith(`forms/${formCode}/`)) {
+        throw new ValidationError('s3Key does not match formCode');
+    }
+    const data = {
+        kvkId: Number(kvkId),
+        formCode: String(formCode),
+        recordId: recordId !== undefined && recordId !== null ? Number(recordId) : null,
+        kind,
+        s3Key,
+        fileName,
+        mimeType,
+        size: Number(size),
+        caption: caption ? String(caption).slice(0, 1000) : null,
+        sortOrder: typeof sortOrder === 'number' ? sortOrder : 0,
+        reportingYearDate: reportingYearDate ? new Date(reportingYearDate) : null,
+        uploadedByUserId: user?.userId || null,
+    };
+    const row = await formAttachmentRepository.create(data);
+    return decorate(row);
+}
+
+async function listByRecord(params, user) {
+    if (!user) throw new UnauthorizedError();
+    const filters = { ...params };
+    if (user.kvkId && !filters.kvkId) filters.kvkId = user.kvkId;
+    const rows = await formAttachmentRepository.listByRecord(filters);
+    return Promise.all(rows.map(decorate));
+}
+
+async function attachToRecord({ attachmentIds, formCode, recordId, kvkId }, user) {
+    assertKvkAccess(user, kvkId);
+    return formAttachmentRepository.attachToRecord({
+        attachmentIds,
+        formCode,
+        recordId: Number(recordId),
+        kvkId: Number(kvkId),
+    });
+}
+
+async function updateAttachment(attachmentId, patch, user) {
+    const existing = await formAttachmentRepository.findById(Number(attachmentId));
+    if (!existing) throw new NotFoundError('Attachment');
+    assertCanMutate(user, existing);
+    const data = {};
+    if (patch.caption !== undefined) data.caption = patch.caption ? String(patch.caption).slice(0, 1000) : null;
+    if (patch.sortOrder !== undefined) data.sortOrder = Number(patch.sortOrder);
+    const updated = await formAttachmentRepository.update(Number(attachmentId), data);
+    return decorate(updated);
+}
+
+async function deleteAttachment(attachmentId, user) {
+    const existing = await formAttachmentRepository.findById(Number(attachmentId));
+    if (!existing) throw new NotFoundError('Attachment');
+    assertCanMutate(user, existing);
+    await formAttachmentRepository.deleteByIds([Number(attachmentId)]);
+    if (existing.s3Key) {
+        try { await s3.deleteOne(existing.s3Key); } catch { /* best-effort */ }
+    }
+    return { ok: true };
+}
+
+async function deleteManyByRecord({ formCode, recordId, kvkId }, user) {
+    if (!user) throw new UnauthorizedError();
+    const rows = await formAttachmentRepository.listByRecord({ formCode, recordId, kvkId });
+    if (rows.length === 0) return { count: 0 };
+    rows.forEach((r) => assertCanMutate(user, r));
+    const ids = rows.map((r) => r.attachmentId);
+    await formAttachmentRepository.deleteByIds(ids);
+    try { await s3.deleteMany(rows.map((r) => r.s3Key)); } catch { /* best-effort */ }
+    return { count: ids.length };
+}
+
+async function listForGallery(params, user) {
+    if (!user) throw new UnauthorizedError();
+    const filters = { ...params, kind: 'PHOTO' };
+    if (user.kvkId) filters.kvkId = user.kvkId;
+    const result = await formAttachmentRepository.listForGallery(filters);
+    const data = await Promise.all(result.data.map(decorate));
+    return { data, meta: result.meta };
+}
+
+async function listForms(user) {
+    if (!user) throw new UnauthorizedError();
+    return formAttachmentRepository.distinctFormCodes({ kvkId: user.kvkId, kind: 'PHOTO' });
+}
+
+async function listKvks(user) {
+    if (!user) throw new UnauthorizedError();
+    if (user.kvkId) {
+        return formAttachmentRepository.distinctKvks({ kind: 'PHOTO' })
+            .then((all) => all.filter((k) => k.kvkId === user.kvkId));
+    }
+    return formAttachmentRepository.distinctKvks({ kind: 'PHOTO' });
+}
+
+async function decorate(row) {
+    if (!row) return row;
+    const url = row.s3Key
+        ? await s3.presignGet({ key: row.s3Key, downloadFileName: row.fileName || undefined })
+        : null;
+    return {
+        ...row,
+        fileUrl: url,
+        downloadUrl: url,
+    };
+}
+
+module.exports = {
+    presignUpload,
+    confirmUpload,
+    listByRecord,
+    attachToRecord,
+    updateAttachment,
+    deleteAttachment,
+    deleteManyByRecord,
+    listForGallery,
+    listForms,
+    listKvks,
+    KIND,
+    MAX_BYTES,
+};

--- a/backend/services/forms/oftService.js
+++ b/backend/services/forms/oftService.js
@@ -2,6 +2,9 @@ const oftRepository = require('../../repositories/forms/oftRepository.js');
 const { ValidationError, NotFoundError } = require('../../utils/errorHandler.js');
 const { OFT_STATUS, normalizeOftStatus, canTransition } = require('../../constants/oftStatus.js');
 const { validateFileSize } = require('../../utils/fileValidation.js');
+const formAttachmentService = require('../formAttachmentService.js');
+
+const OFT_RESULT_FORM_CODE = 'oft_result';
 
 const oftService = {
     createOft: async (data, user) => {
@@ -64,6 +67,7 @@ const oftService = {
 
         const result = await oftRepository.createResultReportTx(id, payload);
         await oftRepository.updateStatus(id, OFT_STATUS.COMPLETED);
+        await _linkAttachments(payload, result, source, user);
         return result;
     },
 
@@ -78,7 +82,9 @@ const oftService = {
 
         const sourceRows = await oftRepository.getTechnologyOptionsByOftId(id);
         _validateResultPayload(payload, sourceRows);
-        return oftRepository.updateResultReportTx(id, payload);
+        const result = await oftRepository.updateResultReportTx(id, payload);
+        await _linkAttachments(payload, result, source, user);
+        return result;
     },
 
     getResult: async (id, user) => {
@@ -86,7 +92,16 @@ const oftService = {
         if (!source) throw new NotFoundError('OFT record');
         const result = await oftRepository.getResultByOftId(id);
         if (!result) throw new NotFoundError('OFT result report');
-        return result;
+        const attachments = await formAttachmentService.listByRecord({
+            formCode: OFT_RESULT_FORM_CODE,
+            recordId: result.oftResultReportId,
+            kvkId: source.kvkId,
+        }, user);
+        return {
+            ...result,
+            photos: attachments.filter((a) => a.kind === 'PHOTO'),
+            datasheets: attachments.filter((a) => a.kind === 'DATASHEET'),
+        };
     },
 
     deleteOft: async (id, user) => {
@@ -129,8 +144,20 @@ function _validateResultPayload(payload, sourceRows = []) {
         });
     });
 
-    validateFileSize({ size: payload.supplementaryDatasheetSize }, 2 * 1024 * 1024, 'Supplementary Datasheet');
-    validateFileSize({ size: payload.photographSize }, 1 * 1024 * 1024, 'Photograph');
+    validateFileSize({ size: payload.supplementaryDatasheetSize }, 5 * 1024 * 1024, 'Supplementary Datasheet');
+    validateFileSize({ size: payload.photographSize }, 5 * 1024 * 1024, 'Photograph');
+}
+
+async function _linkAttachments(payload, result, source, user) {
+    if (!result?.oftResultReportId || !source?.kvkId) return;
+    const ids = Array.isArray(payload?.attachmentIds) ? payload.attachmentIds : [];
+    if (ids.length === 0) return;
+    await formAttachmentService.attachToRecord({
+        attachmentIds: ids,
+        formCode: OFT_RESULT_FORM_CODE,
+        recordId: result.oftResultReportId,
+        kvkId: source.kvkId,
+    }, user);
 }
 
 module.exports = oftService;

--- a/backend/services/storage/s3Service.js
+++ b/backend/services/storage/s3Service.js
@@ -1,0 +1,107 @@
+const path = require('path');
+const { v4: uuidv4 } = require('uuid');
+const {
+    S3Client,
+    PutObjectCommand,
+    GetObjectCommand,
+    DeleteObjectCommand,
+    DeleteObjectsCommand,
+} = require('@aws-sdk/client-s3');
+const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
+const { ValidationError } = require('../../utils/errorHandler.js');
+
+const REGION = process.env.AWS_REGION;
+const BUCKET = process.env.AWS_S3_BUCKET;
+const PUT_TTL_SECONDS = 60 * 5;
+const GET_TTL_SECONDS = 60 * 60;
+
+let cachedClient = null;
+function client() {
+    if (cachedClient) return cachedClient;
+    if (!REGION || !BUCKET) {
+        throw new Error('S3 not configured: set AWS_REGION and AWS_S3_BUCKET');
+    }
+    cachedClient = new S3Client({
+        region: REGION,
+        credentials: process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY ? {
+            accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+        } : undefined,
+    });
+    return cachedClient;
+}
+
+const SAFE_FORM_CODE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
+const ALLOWED_EXT = new Set([
+    'pdf', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg',
+    'xls', 'xlsx', 'doc', 'docx', 'csv', 'txt',
+]);
+
+function sanitizeExt(fileName, mimeType) {
+    let ext = (path.extname(fileName || '') || '').replace(/^\./, '').toLowerCase();
+    if (!ext && mimeType) {
+        const fromMime = mimeType.split('/')[1] || '';
+        ext = fromMime.replace(/^vnd\..*$/, '').toLowerCase();
+    }
+    if (!ext || !ALLOWED_EXT.has(ext)) ext = 'bin';
+    return ext;
+}
+
+function buildAttachmentKey({ formCode, fileName, mimeType }) {
+    if (!formCode || !SAFE_FORM_CODE.test(formCode)) {
+        throw new ValidationError('Invalid formCode for attachment');
+    }
+    const ext = sanitizeExt(fileName, mimeType);
+    const id = uuidv4();
+    return `forms/${formCode}/${id}.${ext}`;
+}
+
+async function presignPut({ key, mimeType, expiresIn = PUT_TTL_SECONDS }) {
+    const cmd = new PutObjectCommand({
+        Bucket: BUCKET,
+        Key: key,
+        ContentType: mimeType || 'application/octet-stream',
+    });
+    return getSignedUrl(client(), cmd, { expiresIn });
+}
+
+async function presignGet({ key, downloadFileName, expiresIn = GET_TTL_SECONDS }) {
+    const cmd = new GetObjectCommand({
+        Bucket: BUCKET,
+        Key: key,
+        ResponseContentDisposition: downloadFileName
+            ? `inline; filename="${downloadFileName.replace(/"/g, '')}"`
+            : undefined,
+    });
+    return getSignedUrl(client(), cmd, { expiresIn });
+}
+
+async function deleteOne(key) {
+    if (!key) return;
+    await client().send(new DeleteObjectCommand({ Bucket: BUCKET, Key: key }));
+}
+
+async function deleteMany(keys) {
+    if (!Array.isArray(keys) || keys.length === 0) return;
+    const objects = keys.filter(Boolean).map((k) => ({ Key: k }));
+    if (objects.length === 0) return;
+    await client().send(new DeleteObjectsCommand({
+        Bucket: BUCKET,
+        Delete: { Objects: objects, Quiet: true },
+    }));
+}
+
+function isConfigured() {
+    return Boolean(REGION && BUCKET);
+}
+
+module.exports = {
+    buildAttachmentKey,
+    presignPut,
+    presignGet,
+    deleteOne,
+    deleteMany,
+    isConfigured,
+    PUT_TTL_SECONDS,
+    GET_TTL_SECONDS,
+};

--- a/frontend/src/components/common/MultiAttachmentUploader.tsx
+++ b/frontend/src/components/common/MultiAttachmentUploader.tsx
@@ -1,0 +1,264 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { X, FileIcon, Loader2 } from 'lucide-react'
+import { useDeleteAttachment, useUpdateAttachment, useUploadAttachment } from '@/hooks/useFormAttachments'
+import type { FormAttachmentKind, FormAttachmentRow } from '@/services/formAttachmentsApi'
+import { ApiError } from '@/services/api'
+
+const PHOTO_ACCEPT = 'image/*'
+const DATASHEET_ACCEPT = [
+    'application/pdf',
+    'image/*',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    '.pdf,.xls,.xlsx,.doc,.docx',
+].join(',')
+
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024
+
+export interface MultiAttachmentUploaderProps {
+    title: string
+    helperText?: string
+    formCode: string
+    kind: FormAttachmentKind
+    kvkId: number
+    recordId?: number | null
+    attachments: FormAttachmentRow[]
+    accept?: string
+    maxBytes?: number
+    showCaption?: boolean
+    disabled?: boolean
+    reportingYearDate?: string | null
+    onChange?: (rows: FormAttachmentRow[]) => void
+}
+
+function isImage(att: FormAttachmentRow): boolean {
+    return att.mimeType?.startsWith('image/') || false
+}
+
+function bytesLabel(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+    return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = ({
+    title,
+    helperText,
+    formCode,
+    kind,
+    kvkId,
+    recordId,
+    attachments,
+    accept,
+    maxBytes = DEFAULT_MAX_BYTES,
+    showCaption = kind === 'PHOTO',
+    disabled = false,
+    reportingYearDate = null,
+    onChange,
+}) => {
+    const fileInputRef = useRef<HTMLInputElement>(null)
+    const upload = useUploadAttachment()
+    const updateMut = useUpdateAttachment()
+    const removeMut = useDeleteAttachment(formCode)
+    const [error, setError] = useState<string | null>(null)
+    const [busyIds, setBusyIds] = useState<Set<number>>(new Set())
+
+    const acceptAttr = accept ?? (kind === 'PHOTO' ? PHOTO_ACCEPT : DATASHEET_ACCEPT)
+    const helper = helperText ?? `Max ${(maxBytes / (1024 * 1024)).toFixed(0)} MB per file. Multiple uploads allowed.`
+
+    const sorted = useMemo(
+        () => [...attachments].sort((a, b) => a.sortOrder - b.sortOrder || a.attachmentId - b.attachmentId),
+        [attachments],
+    )
+
+    const handleFiles = useCallback(
+        async (files: FileList | null) => {
+            if (!files || files.length === 0) return
+            setError(null)
+            const list = Array.from(files)
+            const oversized = list.find((f) => f.size > maxBytes)
+            if (oversized) {
+                setError(`"${oversized.name}" exceeds max size ${(maxBytes / (1024 * 1024)).toFixed(0)} MB`)
+                return
+            }
+            const startSort = sorted.length > 0 ? sorted[sorted.length - 1].sortOrder + 1 : 0
+            try {
+                const results: FormAttachmentRow[] = []
+                for (let i = 0; i < list.length; i += 1) {
+                    const file = list[i]
+                    const row = await upload.mutateAsync({
+                        file,
+                        formCode,
+                        kind,
+                        kvkId,
+                        recordId: recordId ?? null,
+                        sortOrder: startSort + i,
+                        reportingYearDate,
+                    })
+                    results.push(row)
+                }
+                if (onChange) onChange([...sorted, ...results])
+            } catch (e) {
+                const msg = e instanceof ApiError ? e.message : e instanceof Error ? e.message : 'Upload failed'
+                setError(msg)
+            } finally {
+                if (fileInputRef.current) fileInputRef.current.value = ''
+            }
+        },
+        [formCode, kind, kvkId, recordId, sorted, upload, onChange, maxBytes, reportingYearDate],
+    )
+
+    const handleRemove = useCallback(
+        async (att: FormAttachmentRow) => {
+            setBusyIds((prev) => new Set(prev).add(att.attachmentId))
+            try {
+                await removeMut.mutateAsync(att.attachmentId)
+                if (onChange) onChange(sorted.filter((s) => s.attachmentId !== att.attachmentId))
+            } catch (e) {
+                setError(e instanceof Error ? e.message : 'Delete failed')
+            } finally {
+                setBusyIds((prev) => {
+                    const next = new Set(prev)
+                    next.delete(att.attachmentId)
+                    return next
+                })
+            }
+        },
+        [removeMut, sorted, onChange],
+    )
+
+    const handleCaption = useCallback(
+        async (att: FormAttachmentRow, caption: string) => {
+            try {
+                const updated = await updateMut.mutateAsync({ attachmentId: att.attachmentId, caption })
+                if (onChange) onChange(sorted.map((s) => (s.attachmentId === att.attachmentId ? updated : s)))
+            } catch (e) {
+                setError(e instanceof Error ? e.message : 'Caption save failed')
+            }
+        },
+        [updateMut, sorted, onChange],
+    )
+
+    return (
+        <div className="space-y-3">
+            <div>
+                <div className="text-sm font-semibold text-[#487749] mb-1">{title}</div>
+                <label
+                    className={`flex flex-col gap-1 px-3 py-2 border rounded-lg cursor-pointer hover:bg-gray-50 ${
+                        disabled || upload.isPending ? 'opacity-60 cursor-not-allowed' : ''
+                    }`}
+                >
+                    <span className="text-sm text-gray-700">
+                        {upload.isPending ? (
+                            <span className="inline-flex items-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> Uploading…</span>
+                        ) : (
+                            'Browse… No files selected.'
+                        )}
+                    </span>
+                    <span className="text-xs text-gray-500">{helper}</span>
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept={acceptAttr}
+                        multiple
+                        className="hidden"
+                        disabled={disabled || upload.isPending}
+                        onChange={(e) => handleFiles(e.target.files)}
+                    />
+                </label>
+                {error && <div className="text-xs text-red-600 mt-1">{error}</div>}
+            </div>
+
+            {sorted.length > 0 && (
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+                    {sorted.map((att) => (
+                        <AttachmentTile
+                            key={att.attachmentId}
+                            attachment={att}
+                            showCaption={showCaption}
+                            isBusy={busyIds.has(att.attachmentId)}
+                            disabled={disabled}
+                            onRemove={() => handleRemove(att)}
+                            onCaptionChange={(c) => handleCaption(att, c)}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    )
+}
+
+interface TileProps {
+    attachment: FormAttachmentRow
+    showCaption: boolean
+    isBusy: boolean
+    disabled: boolean
+    onRemove: () => void
+    onCaptionChange: (caption: string) => void
+}
+
+const AttachmentTile: React.FC<TileProps> = ({ attachment, showCaption, isBusy, disabled, onRemove, onCaptionChange }) => {
+    const [caption, setCaption] = useState(attachment.caption ?? '')
+    const debounceRef = useRef<number | null>(null)
+
+    const handleCaptionInput = (value: string) => {
+        setCaption(value)
+        if (debounceRef.current) window.clearTimeout(debounceRef.current)
+        debounceRef.current = window.setTimeout(() => onCaptionChange(value), 600)
+    }
+
+    const isImg = isImage(attachment)
+
+    return (
+        <div className="relative rounded-lg overflow-hidden bg-white border shadow-sm flex flex-col">
+            <div className="relative aspect-square bg-gray-100">
+                {isImg ? (
+                    <img
+                        src={attachment.fileUrl}
+                        alt={attachment.caption ?? attachment.fileName ?? 'attachment'}
+                        className="w-full h-full object-cover"
+                        loading="lazy"
+                    />
+                ) : (
+                    <a
+                        href={attachment.downloadUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="w-full h-full flex flex-col items-center justify-center gap-2 text-gray-600 hover:bg-gray-50"
+                    >
+                        <FileIcon className="w-10 h-10" />
+                        <span className="text-xs px-2 text-center break-all line-clamp-2">{attachment.fileName}</span>
+                    </a>
+                )}
+                <button
+                    type="button"
+                    aria-label="Remove"
+                    disabled={disabled || isBusy}
+                    onClick={onRemove}
+                    className="absolute top-1.5 right-1.5 inline-flex items-center justify-center w-6 h-6 rounded-full bg-red-500 text-white shadow hover:bg-red-600 disabled:opacity-60"
+                >
+                    {isBusy ? <Loader2 className="w-3 h-3 animate-spin" /> : <X className="w-3 h-3" />}
+                </button>
+            </div>
+            <div className="px-2 py-2 text-xs text-gray-700 space-y-1">
+                {showCaption ? (
+                    <input
+                        type="text"
+                        value={caption}
+                        onChange={(e) => handleCaptionInput(e.target.value)}
+                        placeholder="Caption…"
+                        className="w-full bg-transparent outline-none text-sm border-b border-dotted border-gray-300 focus:border-[#487749]"
+                    />
+                ) : (
+                    <div className="truncate font-medium" title={attachment.fileName ?? ''}>{attachment.fileName}</div>
+                )}
+                <div className="text-[10px] text-gray-500 flex justify-between gap-1">
+                    <span className="truncate">{attachment.mimeType}</span>
+                    <span>{bytesLabel(attachment.size)}</span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/hooks/useFormAttachments.ts
+++ b/frontend/src/hooks/useFormAttachments.ts
@@ -1,0 +1,124 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+    formAttachmentsApi,
+    uploadFileToS3,
+    type ConfirmUploadInput,
+    type FormAttachmentKind,
+    type FormAttachmentRow,
+    type GalleryFilters,
+} from '@/services/formAttachmentsApi'
+
+const recordKey = (formCode: string, recordId: number | null | undefined, kvkId?: number, kind?: FormAttachmentKind) =>
+    ['form-attachments', formCode, recordId ?? null, kvkId ?? null, kind ?? null] as const
+
+export function useFormAttachments(params: {
+    formCode: string
+    recordId?: number | null
+    kvkId?: number
+    kind?: FormAttachmentKind
+    enabled?: boolean
+}) {
+    const { formCode, recordId, kvkId, kind, enabled = true } = params
+    return useQuery<FormAttachmentRow[]>({
+        queryKey: recordKey(formCode, recordId, kvkId, kind),
+        queryFn: () => formAttachmentsApi.listByRecord({ formCode, recordId, kvkId, kind }),
+        enabled: enabled && Boolean(formCode),
+        staleTime: 30_000,
+    })
+}
+
+export function useUploadAttachment() {
+    const qc = useQueryClient()
+    return useMutation({
+        mutationFn: async (input: {
+            file: File
+            formCode: string
+            kind: FormAttachmentKind
+            kvkId: number
+            recordId?: number | null
+            caption?: string | null
+            sortOrder?: number
+            reportingYearDate?: string | null
+        }) => {
+            const { file, formCode, kind, kvkId, recordId, caption, sortOrder, reportingYearDate } = input
+            const presign = await formAttachmentsApi.presign({
+                formCode,
+                kind,
+                fileName: file.name,
+                mimeType: file.type || 'application/octet-stream',
+                size: file.size,
+                kvkId,
+            })
+            await uploadFileToS3(presign.uploadUrl, file, presign.headers)
+            const confirmInput: ConfirmUploadInput = {
+                s3Key: presign.s3Key,
+                formCode,
+                kind,
+                recordId: recordId ?? null,
+                kvkId,
+                fileName: file.name,
+                mimeType: file.type || 'application/octet-stream',
+                size: file.size,
+                caption: caption ?? null,
+                sortOrder,
+                reportingYearDate: reportingYearDate ?? null,
+            }
+            return formAttachmentsApi.confirm(confirmInput)
+        },
+        onSuccess: (row) => {
+            qc.invalidateQueries({ queryKey: ['form-attachments', row.formCode] })
+            qc.invalidateQueries({ queryKey: ['form-attachments-gallery'] })
+            qc.invalidateQueries({ queryKey: ['form-attachments-gallery-forms'] })
+            qc.invalidateQueries({ queryKey: ['form-attachments-gallery-kvks'] })
+        },
+    })
+}
+
+export function useUpdateAttachment() {
+    const qc = useQueryClient()
+    return useMutation({
+        mutationFn: ({ attachmentId, ...patch }: { attachmentId: number; caption?: string | null; sortOrder?: number }) =>
+            formAttachmentsApi.update(attachmentId, patch),
+        onSuccess: (row) => {
+            qc.invalidateQueries({ queryKey: ['form-attachments', row.formCode] })
+            qc.invalidateQueries({ queryKey: ['form-attachments-gallery'] })
+        },
+    })
+}
+
+export function useDeleteAttachment(formCode: string) {
+    const qc = useQueryClient()
+    return useMutation({
+        mutationFn: (attachmentId: number) => formAttachmentsApi.remove(attachmentId),
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: ['form-attachments', formCode] })
+            qc.invalidateQueries({ queryKey: ['form-attachments-gallery'] })
+            qc.invalidateQueries({ queryKey: ['form-attachments-gallery-forms'] })
+        },
+    })
+}
+
+export function useFormAttachmentsGallery(filters: GalleryFilters) {
+    return useQuery({
+        queryKey: ['form-attachments-gallery', filters],
+        queryFn: () => formAttachmentsApi.gallery(filters),
+        staleTime: 30_000,
+        placeholderData: (prev) => prev,
+    })
+}
+
+export function useFormAttachmentsGalleryForms() {
+    return useQuery({
+        queryKey: ['form-attachments-gallery-forms'],
+        queryFn: () => formAttachmentsApi.galleryForms(),
+        staleTime: 60_000,
+    })
+}
+
+export function useFormAttachmentsGalleryKvks() {
+    return useQuery({
+        queryKey: ['form-attachments-gallery-kvks'],
+        queryFn: () => formAttachmentsApi.galleryKvks(),
+        staleTime: 60_000,
+    })
+}

--- a/frontend/src/hooks/useGallerySource.ts
+++ b/frontend/src/hooks/useGallerySource.ts
@@ -1,0 +1,171 @@
+import { useMemo } from 'react'
+import {
+    useModuleImageCategories,
+    useModuleImageKvks,
+    useModuleImages,
+} from './useModuleImages'
+import {
+    useFormAttachmentsGallery,
+    useFormAttachmentsGalleryForms,
+    useFormAttachmentsGalleryKvks,
+} from './useFormAttachments'
+import type {
+    ModuleImageCategory,
+    ModuleImageKvkOption,
+    ModuleImageRow,
+} from '@/services/moduleImagesApi'
+import type { FormAttachmentRow } from '@/services/formAttachmentsApi'
+
+export type GallerySource = 'modules' | 'forms'
+
+export interface GalleryFilters {
+    page?: number
+    limit?: number
+    reportingYear?: number
+    kvkId?: number
+    moduleId?: number
+    formCode?: string
+    search?: string
+}
+
+interface UseGallerySourceResult {
+    images: ModuleImageRow[]
+    categories: ModuleImageCategory[]
+    kvks: ModuleImageKvkOption[]
+    total: number
+    isLoading: boolean
+    isError: boolean
+}
+
+const FORM_LABEL_OVERRIDES: Record<string, string> = {
+    oft_result: 'OFT Result',
+}
+
+function humanizeFormCode(code: string): string {
+    if (FORM_LABEL_OVERRIDES[code]) return FORM_LABEL_OVERRIDES[code]
+    return code
+        .split(/[_-]/)
+        .filter(Boolean)
+        .map((s) => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase())
+        .join(' ')
+}
+
+function attachmentToRow(att: FormAttachmentRow, syntheticModuleId: number): ModuleImageRow {
+    const reportingYear = att.reportingYearDate
+        ? new Date(att.reportingYearDate).getFullYear()
+        : new Date(att.createdAt).getFullYear()
+    return {
+        imageId: att.attachmentId,
+        kvkId: att.kvkId,
+        kvkName: att.kvk?.kvkName ?? '',
+        moduleId: syntheticModuleId,
+        moduleCode: att.formCode,
+        categoryLabel: humanizeFormCode(att.formCode),
+        caption: att.caption ?? '',
+        imageDate: att.createdAt,
+        reportingYear,
+        mimeType: att.mimeType,
+        fileName: att.fileName,
+        fileUrl: att.fileUrl,
+        downloadUrl: att.downloadUrl,
+        uploadedBy: att.uploadedBy ?? null,
+        createdAt: att.createdAt,
+    }
+}
+
+export function useGallerySource(
+    source: GallerySource,
+    filters: GalleryFilters,
+    showKvkFilter: boolean,
+): UseGallerySourceResult {
+    const moduleImagesQuery = useModuleImages(filters as any)
+    const moduleCategoriesQuery = useModuleImageCategories()
+    const moduleKvksQuery = useModuleImageKvks(showKvkFilter && source === 'modules')
+
+    const formsQuery = useFormAttachmentsGallery({
+        page: filters.page,
+        limit: filters.limit,
+        reportingYear: filters.reportingYear,
+        kvkId: filters.kvkId,
+        formCode: filters.formCode,
+        search: filters.search,
+    })
+    const formsListQuery = useFormAttachmentsGalleryForms()
+    const formsKvksQuery = useFormAttachmentsGalleryKvks()
+
+    const formCodeToId = useMemo(() => {
+        const map = new Map<string, number>()
+        const list = formsListQuery.data ?? []
+        list.forEach((f, i) => {
+            map.set(f.formCode, 1_000_000 + i)
+        })
+        return map
+    }, [formsListQuery.data])
+
+    return useMemo<UseGallerySourceResult>(() => {
+        if (source === 'forms') {
+            const rows = (formsQuery.data?.data ?? []).map((att) => {
+                const id = formCodeToId.get(att.formCode) ?? 1_000_000
+                return attachmentToRow(att, id)
+            })
+            const categories: ModuleImageCategory[] = (formsListQuery.data ?? []).map((f) => ({
+                moduleId: formCodeToId.get(f.formCode) ?? 1_000_000,
+                moduleCode: f.formCode,
+                menuName: 'Form Modules',
+                subMenuName: humanizeFormCode(f.formCode),
+                label: humanizeFormCode(f.formCode),
+            }))
+            const kvks: ModuleImageKvkOption[] = (formsKvksQuery.data ?? []).map((k) => ({
+                kvkId: k.kvkId,
+                kvkName: k.kvkName,
+            }))
+            return {
+                images: rows,
+                categories,
+                kvks,
+                total: formsQuery.data?.meta.total ?? 0,
+                isLoading: formsQuery.isLoading || formsListQuery.isLoading,
+                isError: Boolean(formsQuery.error || formsListQuery.error),
+            }
+        }
+        return {
+            images: moduleImagesQuery.data?.data ?? [],
+            categories: moduleCategoriesQuery.data ?? [],
+            kvks: moduleKvksQuery.data ?? [],
+            total: moduleImagesQuery.data?.meta?.total ?? 0,
+            isLoading: moduleImagesQuery.isLoading,
+            isError: Boolean(moduleImagesQuery.error),
+        }
+    }, [
+        source,
+        formCodeToId,
+        formsQuery.data,
+        formsQuery.isLoading,
+        formsQuery.error,
+        formsListQuery.data,
+        formsListQuery.isLoading,
+        formsListQuery.error,
+        formsKvksQuery.data,
+        moduleImagesQuery.data,
+        moduleImagesQuery.isLoading,
+        moduleImagesQuery.error,
+        moduleCategoriesQuery.data,
+        moduleKvksQuery.data,
+    ])
+}
+
+export function getModuleIdForFormCode(
+    formCode: string | undefined,
+    categories: ModuleImageCategory[],
+): number | undefined {
+    if (!formCode) return undefined
+    return categories.find((c) => c.moduleCode === formCode)?.moduleId
+}
+
+export function getFormCodeForModuleId(
+    moduleId: number | undefined,
+    categories: ModuleImageCategory[],
+): string | undefined {
+    if (!moduleId) return undefined
+    return categories.find((c) => c.moduleId === moduleId)?.moduleCode ?? undefined
+}

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -1386,6 +1386,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                                             ? selectedOftItem.technologyOptions
                                             : []
                                     }
+                                    kvkId={selectedOftItem?.kvkId ?? null}
                                     onClose={() => {
                                         setIsOftResultPageOpen(false)
                                         setSelectedOftId(null)

--- a/frontend/src/pages/dashboard/shared/forms/achievement/OftResultForm.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/achievement/OftResultForm.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Modal } from '@/components/ui/Modal'
 import { DynamicReportTableBuilder, ResultTable } from '@/components/common/dynamic-table/DynamicReportTableBuilder'
-import { FormInput, FormTextArea, FormSection } from '../shared/FormComponents'
+import { FormTextArea, FormSection } from '../shared/FormComponents'
+import { MultiAttachmentUploader } from '@/components/common/MultiAttachmentUploader'
+import { useFormAttachments } from '@/hooks/useFormAttachments'
+import type { FormAttachmentRow } from '@/services/formAttachmentsApi'
+
+const FORM_CODE = 'oft_result'
 
 export interface OftResultFormValue {
     finalRecommendation: string
@@ -9,13 +14,11 @@ export interface OftResultFormValue {
     farmersParticipationProcess: string
     resultText: string
     remark: string
-    supplementaryDatasheetSize?: number
-    supplementaryDatasheetName?: string
-    supplementaryDatasheetMime?: string
-    photographSize?: number
-    photographName?: string
-    photographMime?: string
     tables: ResultTable[]
+    attachmentIds?: number[]
+    photos?: FormAttachmentRow[]
+    datasheets?: FormAttachmentRow[]
+    oftResultReportId?: number | null
 }
 
 interface OftResultFormProps {
@@ -25,6 +28,7 @@ interface OftResultFormProps {
     onSubmit: (value: OftResultFormValue) => Promise<void>
     embedded?: boolean
     sourceRows?: Array<{ optionKey: string; optionName: string }>
+    kvkId?: number | null
 }
 
 const defaultValue: OftResultFormValue = {
@@ -35,20 +39,6 @@ const defaultValue: OftResultFormValue = {
     remark: '',
     tables: [],
 }
-
-const SUPPLEMENTARY_ACCEPT = [
-    'application/pdf',
-    'image/*',
-    'application/vnd.ms-excel',
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    'application/msword',
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    '.pdf,.xls,.xlsx,.doc,.docx',
-].join(',')
-
-const SUPPLEMENTARY_MIME_RE = /^(application\/pdf|image\/|application\/vnd\.ms-excel|application\/vnd\.openxmlformats-officedocument\.spreadsheetml|application\/msword|application\/vnd\.openxmlformats-officedocument\.wordprocessingml)/i
-
-const SUPPLEMENTARY_EXT_RE = /\.(pdf|png|jpe?g|gif|webp|bmp|svg|xls|xlsx|doc|docx)$/i
 
 function buildSeedTables(
     sourceRows: Array<{ optionKey: string; optionName: string }>
@@ -142,9 +132,18 @@ function normalizeInitialValue(
     }
 }
 
-export const OftResultForm: React.FC<OftResultFormProps> = ({ mode, initialValue, onClose, onSubmit, embedded = false, sourceRows = [] }) => {
+export const OftResultForm: React.FC<OftResultFormProps> = ({
+    mode,
+    initialValue,
+    onClose,
+    onSubmit,
+    embedded = false,
+    sourceRows = [],
+    kvkId,
+}) => {
     const [submitting, setSubmitting] = useState(false)
     const [value, setValue] = useState<OftResultFormValue>(normalizeInitialValue(initialValue, sourceRows))
+    const recordId = (initialValue?.oftResultReportId ?? null) as number | null
 
     const title = useMemo(() => mode === 'create' ? 'Add OFT Result' : 'Edit OFT Result', [mode])
 
@@ -152,11 +151,46 @@ export const OftResultForm: React.FC<OftResultFormProps> = ({ mode, initialValue
         setValue(normalizeInitialValue(initialValue, sourceRows))
     }, [initialValue, mode, sourceRows])
 
+    const initialPhotos = (initialValue?.photos ?? []) as FormAttachmentRow[]
+    const initialDatasheets = (initialValue?.datasheets ?? []) as FormAttachmentRow[]
+
+    const photosQuery = useFormAttachments({
+        formCode: FORM_CODE,
+        recordId,
+        kvkId: kvkId ?? undefined,
+        kind: 'PHOTO',
+        enabled: Boolean(kvkId && recordId),
+    })
+    const datasheetsQuery = useFormAttachments({
+        formCode: FORM_CODE,
+        recordId,
+        kvkId: kvkId ?? undefined,
+        kind: 'DATASHEET',
+        enabled: Boolean(kvkId && recordId),
+    })
+
+    const [orphanPhotos, setOrphanPhotos] = useState<FormAttachmentRow[]>(
+        recordId ? [] : initialPhotos.filter((p) => p.recordId == null),
+    )
+    const [orphanDatasheets, setOrphanDatasheets] = useState<FormAttachmentRow[]>(
+        recordId ? [] : initialDatasheets.filter((d) => d.recordId == null),
+    )
+
+    const photos = recordId ? (photosQuery.data ?? initialPhotos) : orphanPhotos
+    const datasheets = recordId ? (datasheetsQuery.data ?? initialDatasheets) : orphanDatasheets
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault()
+        if (!kvkId) {
+            alert('KVK context missing — cannot save attachments.')
+            return
+        }
         setSubmitting(true)
         try {
-            await onSubmit(value)
+            const attachmentIds = [...photos, ...datasheets]
+                .filter((a) => !a.recordId)
+                .map((a) => a.attachmentId)
+            await onSubmit({ ...value, attachmentIds })
             onClose()
         } finally {
             setSubmitting(false)
@@ -195,53 +229,48 @@ export const OftResultForm: React.FC<OftResultFormProps> = ({ mode, initialValue
                     value={value.remark}
                     onChange={(e) => setValue((v) => ({ ...v, remark: e.target.value }))}
                 />
-                <div>
-                    <FormInput
-                        label="Supplementary Datasheet (PDF/Image/Excel/Word, max 2 MB)"
-                        type="file"
-                        accept={SUPPLEMENTARY_ACCEPT}
-                        helperText={`Selected: ${value.supplementaryDatasheetName || 'None'}`}
-                        onChange={(e) => {
-                            const input = e.target as HTMLInputElement
-                            const file = input.files?.[0]
-                            if (file && !SUPPLEMENTARY_MIME_RE.test(file.type) && !SUPPLEMENTARY_EXT_RE.test(file.name)) {
-                                alert('Supplementary Datasheet must be PDF, image, Excel, or Word.')
-                                input.value = ''
-                                return
-                            }
-                            setValue((v) => ({
-                                ...v,
-                                supplementaryDatasheetName: file?.name,
-                                supplementaryDatasheetSize: file?.size,
-                                supplementaryDatasheetMime: file?.type,
-                            }))
-                        }}
-                    />
-                </div>
-                <div>
-                    <FormInput
-                        label="Photograph (image only, max 1 MB)"
-                        type="file"
-                        accept="image/*"
-                        helperText={`Selected: ${value.photographName || 'None'}`}
-                        onChange={(e) => {
-                            const input = e.target as HTMLInputElement
-                            const file = input.files?.[0]
-                            if (file && !file.type.startsWith('image/')) {
-                                alert('Photograph must be an image file.')
-                                input.value = ''
-                                return
-                            }
-                            setValue((v) => ({
-                                ...v,
-                                photographName: file?.name,
-                                photographSize: file?.size,
-                                photographMime: file?.type,
-                            }))
-                        }}
-                    />
-                </div>
             </div>
+
+            {kvkId ? (
+                <>
+                    <FormSection title="Photographs">
+                        <div className="text-xs text-gray-500 mb-2">
+                            Only images allowed. Uploading new files will be added to the list. Multiple uploads supported. (Max 5 MB per file)
+                        </div>
+                        <MultiAttachmentUploader
+                            title=""
+                            formCode={FORM_CODE}
+                            kind="PHOTO"
+                            kvkId={kvkId}
+                            recordId={recordId}
+                            attachments={photos}
+                            showCaption
+                            onChange={recordId ? undefined : setOrphanPhotos}
+                        />
+                    </FormSection>
+
+                    <FormSection title="Supplementary Datasheets">
+                        <div className="text-xs text-gray-500 mb-2">
+                            PDF / Image / Excel / Word supported. Multiple uploads allowed. (Max 5 MB per file)
+                        </div>
+                        <MultiAttachmentUploader
+                            title=""
+                            formCode={FORM_CODE}
+                            kind="DATASHEET"
+                            kvkId={kvkId}
+                            recordId={recordId}
+                            attachments={datasheets}
+                            showCaption={false}
+                            onChange={recordId ? undefined : setOrphanDatasheets}
+                        />
+                    </FormSection>
+                </>
+            ) : (
+                <div className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                    KVK context not available — attachment uploads are disabled. Save the result first; you can add photos/datasheets after.
+                </div>
+            )}
+
             <FormSection title="Dynamic Result Tables">
                 <DynamicReportTableBuilder
                     tables={value.tables || []}

--- a/frontend/src/pages/features/Gallery.tsx
+++ b/frontend/src/pages/features/Gallery.tsx
@@ -20,13 +20,12 @@ import {
 import { Breadcrumbs } from '../../components/common/Breadcrumbs'
 import { getBreadcrumbsForPath } from '../../config/route'
 import { useAuth } from '@/contexts/AuthContext'
-import {
-  useModuleImageCategories,
-  useModuleImageKvks,
-  useModuleImages,
-} from '@/hooks/useModuleImages'
 import type { ModuleImageRow } from '@/services/moduleImagesApi'
 import { API_BASE_URL } from '@/config/api'
+import {
+  useGallerySource,
+  type GallerySource,
+} from '@/hooks/useGallerySource'
 
 type ViewMode = 'grid' | 'compact'
 
@@ -89,6 +88,7 @@ export const Gallery: React.FC = () => {
   const showKvkFilter = user?.role !== 'kvk_admin' && user?.role !== 'kvk_user'
 
   const currentYear = new Date().getFullYear()
+  const [source, setSource] = useState<GallerySource>('forms')
   const [searchInput, setSearchInput] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const [year, setYear] = useState<number>(currentYear)
@@ -105,24 +105,27 @@ export const Gallery: React.FC = () => {
     return () => clearTimeout(t)
   }, [searchInput])
 
+  const [selectedFormCode, setSelectedFormCode] = useState<string | undefined>(undefined)
+
   const filters = useMemo(
     () => ({
       page: 1,
       limit: PAGE_LIMIT,
       reportingYear: year,
       kvkId,
-      moduleId,
+      moduleId: source === 'modules' ? moduleId : undefined,
+      formCode: source === 'forms' ? selectedFormCode : undefined,
       search: debouncedSearch || undefined,
     }),
-    [year, kvkId, moduleId, debouncedSearch]
+    [year, kvkId, moduleId, selectedFormCode, debouncedSearch, source]
   )
 
-  const imagesQuery = useModuleImages(filters)
-  const categoriesQuery = useModuleImageCategories()
-  const kvksQuery = useModuleImageKvks(showKvkFilter)
-
-  const images: ModuleImageRow[] = imagesQuery.data?.data ?? []
-  const total = imagesQuery.data?.meta?.total ?? 0
+  const sourceResult = useGallerySource(source, filters, showKvkFilter)
+  const images: ModuleImageRow[] = sourceResult.images
+  const total = sourceResult.total
+  const categoriesQuery = { data: sourceResult.categories } as { data: typeof sourceResult.categories }
+  const kvksQuery = { data: sourceResult.kvks } as { data: typeof sourceResult.kvks }
+  const imagesQuery = { isLoading: sourceResult.isLoading } as { isLoading: boolean }
 
   const yearOptions = useMemo(() => {
     const arr: number[] = []
@@ -254,12 +257,18 @@ export const Gallery: React.FC = () => {
         clear: () => setKvkId(undefined),
       })
     }
-    if (moduleId) {
-      const m = categoriesQuery.data?.find(x => x.moduleId === moduleId)
+    if (moduleId || selectedFormCode) {
+      const m =
+        categoriesQuery.data?.find(x =>
+          source === 'forms' ? x.moduleCode === selectedFormCode : x.moduleId === moduleId,
+        )
       chips.push({
         key: 'module',
-        label: `Module: ${m?.label ?? moduleId}`,
-        clear: () => setModuleId(undefined),
+        label: `${source === 'forms' ? 'Form' : 'Module'}: ${m?.label ?? selectedFormCode ?? moduleId}`,
+        clear: () => {
+          setModuleId(undefined)
+          setSelectedFormCode(undefined)
+        },
       })
     }
     if (year !== currentYear) {
@@ -272,6 +281,7 @@ export const Gallery: React.FC = () => {
     setSearchInput('')
     setKvkId(undefined)
     setModuleId(undefined)
+    setSelectedFormCode(undefined)
     setYear(currentYear)
   }
 
@@ -318,6 +328,37 @@ export const Gallery: React.FC = () => {
                 <X className="w-3.5 h-3.5" />
               </button>
             )}
+          </div>
+
+          <div className="hidden md:flex items-center rounded-xl border border-black/10 bg-white overflow-hidden">
+            <button
+              type="button"
+              onClick={() => {
+                setSource('forms')
+                setModuleId(undefined)
+                setSelectedFormCode(undefined)
+              }}
+              className={`px-3 py-2 text-sm transition-colors ${
+                source === 'forms' ? 'bg-[#487749] text-white' : 'text-black/60 hover:bg-black/5'
+              }`}
+              title="Form attachments"
+            >
+              Forms
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setSource('modules')
+                setModuleId(undefined)
+                setSelectedFormCode(undefined)
+              }}
+              className={`px-3 py-2 text-sm transition-colors ${
+                source === 'modules' ? 'bg-[#487749] text-white' : 'text-black/60 hover:bg-black/5'
+              }`}
+              title="Module images"
+            >
+              Modules
+            </button>
           </div>
 
           <div className="hidden md:flex items-center gap-2">
@@ -407,7 +448,7 @@ export const Gallery: React.FC = () => {
           <aside className="hidden lg:flex flex-col w-64 shrink-0 border-r border-black/5 bg-white overflow-y-auto">
             <div className="px-4 py-3 border-b border-black/5 flex items-center justify-between">
               <div className="text-[10px] font-semibold uppercase tracking-widest text-black/40">
-                Modules
+                {source === 'forms' ? 'Form modules' : 'Modules'}
               </div>
               {collapsedGroups.size > 0 ? (
                 <button
@@ -428,15 +469,18 @@ export const Gallery: React.FC = () => {
               )}
             </div>
             <button
-              onClick={() => setModuleId(undefined)}
+              onClick={() => {
+                setModuleId(undefined)
+                setSelectedFormCode(undefined)
+              }}
               className={`flex items-center justify-between px-4 py-2.5 text-sm transition-colors ${
-                moduleId === undefined
+                moduleId === undefined && selectedFormCode === undefined
                   ? 'bg-[#487749]/10 text-[#3d6540] font-semibold'
                   : 'hover:bg-black/5 text-black/75'
               }`}
             >
               <span className="inline-flex items-center gap-2">
-                <ImageIcon className="w-4 h-4 opacity-60" /> All modules
+                <ImageIcon className="w-4 h-4 opacity-60" /> {source === 'forms' ? 'All forms' : 'All modules'}
               </span>
               <span className="text-xs text-black/40">{total}</span>
             </button>
@@ -479,11 +523,22 @@ export const Gallery: React.FC = () => {
                     >
                       {group.items.map(c => {
                         const count = moduleCounts.get(c.moduleId) ?? 0
-                        const active = moduleId === c.moduleId
+                        const active =
+                          source === 'modules'
+                            ? moduleId === c.moduleId
+                            : selectedFormCode === c.moduleCode
                         return (
                           <button
                             key={c.moduleId}
-                            onClick={() => setModuleId(c.moduleId)}
+                            onClick={() => {
+                              if (source === 'modules') {
+                                setModuleId(c.moduleId)
+                                setSelectedFormCode(undefined)
+                              } else {
+                                setModuleId(c.moduleId)
+                                setSelectedFormCode(c.moduleCode ?? undefined)
+                              }
+                            }}
                             className={`w-full flex items-center justify-between pl-9 pr-4 py-1.5 text-sm transition-colors ${
                               active
                                 ? 'bg-[#487749]/10 text-[#3d6540] font-semibold border-l-2 border-[#487749]'

--- a/frontend/src/services/formAttachmentsApi.ts
+++ b/frontend/src/services/formAttachmentsApi.ts
@@ -1,0 +1,129 @@
+import { apiClient } from './api'
+
+export type FormAttachmentKind = 'PHOTO' | 'DATASHEET' | 'DOCUMENT'
+
+export interface FormAttachmentRow {
+    attachmentId: number
+    kvkId: number
+    formCode: string
+    recordId: number | null
+    kind: FormAttachmentKind
+    s3Key: string
+    fileName: string | null
+    mimeType: string
+    size: number
+    caption: string | null
+    sortOrder: number
+    reportingYearDate: string | null
+    uploadedByUserId: number | null
+    createdAt: string
+    updatedAt: string
+    fileUrl: string
+    downloadUrl: string
+    kvk?: { kvkId: number; kvkName: string }
+    uploadedBy?: { userId: number; name: string; email: string } | null
+}
+
+export interface PresignResponse {
+    s3Key: string
+    uploadUrl: string
+    expiresIn: number
+    headers: Record<string, string>
+}
+
+export interface ConfirmUploadInput {
+    s3Key: string
+    formCode: string
+    kind: FormAttachmentKind
+    recordId?: number | null
+    kvkId: number
+    fileName: string
+    mimeType: string
+    size: number
+    caption?: string | null
+    sortOrder?: number
+    reportingYearDate?: string | null
+}
+
+export interface PresignInput {
+    formCode: string
+    kind: FormAttachmentKind
+    fileName: string
+    mimeType: string
+    size: number
+    kvkId: number
+}
+
+export interface GalleryFilters {
+    page?: number
+    limit?: number
+    kvkId?: number
+    formCode?: string
+    reportingYear?: number
+    search?: string
+}
+
+export interface GalleryListResponse {
+    data: FormAttachmentRow[]
+    meta: { page: number; limit: number; total: number; totalPages: number }
+}
+
+export interface GalleryFormGroup {
+    formCode: string
+    count: number
+}
+
+export interface GalleryKvkOption {
+    kvkId: number
+    kvkName: string
+    count: number
+}
+
+const BASE = '/forms/attachments'
+
+export const formAttachmentsApi = {
+    presign: (body: PresignInput) =>
+        apiClient.post<PresignResponse>(`${BASE}/presign`, body),
+
+    confirm: (body: ConfirmUploadInput) =>
+        apiClient.post<FormAttachmentRow>(`${BASE}/confirm`, body),
+
+    attach: (body: { attachmentIds: number[]; formCode: string; recordId: number; kvkId: number }) =>
+        apiClient.post<{ count: number }>(`${BASE}/attach`, body),
+
+    listByRecord: (params: { formCode: string; recordId?: number | null; kvkId?: number; kind?: FormAttachmentKind }) => {
+        const qs = new URLSearchParams()
+        Object.entries(params).forEach(([k, v]) => {
+            if (v !== undefined && v !== null && v !== '') qs.set(k, String(v))
+        })
+        return apiClient.get<FormAttachmentRow[]>(`${BASE}?${qs.toString()}`)
+    },
+
+    update: (attachmentId: number, body: { caption?: string | null; sortOrder?: number }) =>
+        apiClient.patch<FormAttachmentRow>(`${BASE}/${attachmentId}`, body),
+
+    remove: (attachmentId: number) =>
+        apiClient.delete<{ ok: true }>(`${BASE}/${attachmentId}`),
+
+    gallery: (filters: GalleryFilters) => {
+        const qs = new URLSearchParams()
+        Object.entries(filters || {}).forEach(([k, v]) => {
+            if (v !== undefined && v !== null && v !== '') qs.set(k, String(v))
+        })
+        return apiClient.get<GalleryListResponse>(`${BASE}/gallery?${qs.toString()}`)
+    },
+
+    galleryForms: () => apiClient.get<GalleryFormGroup[]>(`${BASE}/gallery/forms`),
+    galleryKvks: () => apiClient.get<GalleryKvkOption[]>(`${BASE}/gallery/kvks`),
+}
+
+export async function uploadFileToS3(uploadUrl: string, file: File, headers: Record<string, string>): Promise<void> {
+    const res = await fetch(uploadUrl, {
+        method: 'PUT',
+        body: file,
+        headers,
+    })
+    if (!res.ok) {
+        throw new Error(`S3 upload failed: ${res.status} ${res.statusText}`)
+    }
+}


### PR DESCRIPTION
## Summary
End-to-end S3 attachment system for OFT (and future forms), wired into Gallery.

### Backend
- New \`FormAttachment\` table (\`kvkId\`, \`formCode\`, \`recordId\`, \`kind\` PHOTO/DATASHEET/DOCUMENT, \`s3Key\`, \`caption\`, \`sortOrder\`, ...).
- \`services/storage/s3Service.js\` (AWS SDK v3): \`buildAttachmentKey\`, \`presignPut\`, \`presignGet\`, \`deleteOne/Many\`. Layout: \`s3://<bucket>/forms/<formCode>/<uuid>.<ext>\`.
- New repo / service / controller / routes mounted at \`/api/forms/attachments\` (before \`validateFormRobustness\` since payloads aren't form bodies).
- Endpoints: \`POST /presign\`, \`/confirm\`, \`/attach\`; \`GET /\`, \`/gallery\`, \`/gallery/forms\`, \`/gallery/kvks\`; \`PATCH /:id\`, \`DELETE /:id\`.
- \`oftService.addResult / editResult\` accept \`attachmentIds[]\` and link orphan uploads to \`oftResultReportId\`. \`getResult\` returns \`{ photos, datasheets }\` arrays with presigned read URLs.
- Legacy \`OftResultReport.photograph_*\` / \`supplementary_datasheet_*\` columns kept for backfill; new uploads use \`form_attachments\`.
- \`oftService\` size caps: photograph 1 MB → 5 MB, datasheet 2 MB → 5 MB.
- \`validateFormRobustness\`: future dates allowed for fields containing \`expected\` or \`planned\` (matches existing \`target\` behaviour) so \`expectedCompletionDate\` can be future.

### Frontend
- \`<MultiAttachmentUploader>\`: direct browser→S3 PUT via presigned URL, uniform aspect-square thumbnails, red-X delete, debounced caption editor, error surface, multi-file picker.
- \`OftResultForm\`: single photo + single datasheet inputs replaced; both multi-upload, 5 MB per file. KVK context is required (warns inline if missing). Caller \`DataManagementView\` passes \`kvkId={selectedOftItem?.kvkId}\`.
- New \`formAttachmentsApi\` + \`useFormAttachments\` (TanStack Query): list / upload / update / delete + gallery hooks.
- \`Gallery\` now has a \`Forms / Modules\` source toggle (default \`Forms\`). Sidebar shows form modules with counts; \`useGallerySource\` adapter normalises both sources to \`ModuleImageRow\` so render path is shared.

### Storage
- AWS env vars wired in \`backend/.env\` (gitignored). Bucket CORS set programmatically (PUT/GET/HEAD/POST from localhost + Vercel hosts).

### Smoke test (local, against dev DB + bucket)
- presign → S3 PUT → confirm row → gallery list → delete: all 200 ✓.

## Test plan
- [ ] Open OFT result form; upload 2-3 images and 1-2 datasheets; verify thumbnails render with captions.
- [ ] Save result; reopen and confirm attachments persist with \`recordId\` set (no orphans).
- [ ] Delete a thumbnail; confirm S3 object removed (best-effort).
- [ ] Set OFT \`Expected Completion Date\` to a future date; backend accepts.
- [ ] Open Gallery → "Forms" tab → click \`OFT Result\` in sidebar → uploaded photos appear with KVK / form / year filters.
- [ ] Toggle to "Modules" tab; existing module-image gallery still works.
- [ ] Super_admin sees KVK filter; \`kvk_admin\` only sees their own KVK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)