### PR TITLE
fix(oft, gallery): parallel multi-upload, unified sources, right-side details

### DIFF
--- a/frontend/src/components/common/MultiAttachmentUploader.tsx
+++ b/frontend/src/components/common/MultiAttachmentUploader.tsx
@@ -1,7 +1,13 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { X, FileIcon, Loader2 } from 'lucide-react'
-import { useDeleteAttachment, useUpdateAttachment, useUploadAttachment } from '@/hooks/useFormAttachments'
-import type { FormAttachmentKind, FormAttachmentRow } from '@/services/formAttachmentsApi'
+import { useQueryClient } from '@tanstack/react-query'
+import { useDeleteAttachment, useUpdateAttachment } from '@/hooks/useFormAttachments'
+import {
+    formAttachmentsApi,
+    uploadFileToS3,
+    type FormAttachmentKind,
+    type FormAttachmentRow,
+} from '@/services/formAttachmentsApi'
 import { ApiError } from '@/services/api'
 
 const PHOTO_ACCEPT = 'image/*'
@@ -42,6 +48,39 @@ function bytesLabel(bytes: number): string {
     return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
 }
 
+async function uploadOne(input: {
+    file: File
+    formCode: string
+    kind: FormAttachmentKind
+    kvkId: number
+    recordId: number | null
+    sortOrder: number
+    reportingYearDate: string | null
+}): Promise<FormAttachmentRow> {
+    const { file, formCode, kind, kvkId, recordId, sortOrder, reportingYearDate } = input
+    const presign = await formAttachmentsApi.presign({
+        formCode,
+        kind,
+        fileName: file.name,
+        mimeType: file.type || 'application/octet-stream',
+        size: file.size,
+        kvkId,
+    })
+    await uploadFileToS3(presign.uploadUrl, file, presign.headers)
+    return formAttachmentsApi.confirm({
+        s3Key: presign.s3Key,
+        formCode,
+        kind,
+        recordId,
+        kvkId,
+        fileName: file.name,
+        mimeType: file.type || 'application/octet-stream',
+        size: file.size,
+        sortOrder,
+        reportingYearDate,
+    })
+}
+
 export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = ({
     formCode,
     kind,
@@ -57,18 +96,20 @@ export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = (
     onChange,
 }) => {
     const fileInputRef = useRef<HTMLInputElement>(null)
-    const upload = useUploadAttachment()
+    const qc = useQueryClient()
     const updateMut = useUpdateAttachment()
     const removeMut = useDeleteAttachment(formCode)
     const [error, setError] = useState<string | null>(null)
+    const [uploading, setUploading] = useState(false)
+    const [progress, setProgress] = useState<{ done: number; total: number } | null>(null)
     const [busyIds, setBusyIds] = useState<Set<number>>(new Set())
 
     const acceptAttr = accept ?? (kind === 'PHOTO' ? PHOTO_ACCEPT : DATASHEET_ACCEPT)
     const helper =
         helperText ??
         (kind === 'PHOTO'
-            ? `Only images allowed. Uploading new files will be added to the list. (Max ${(maxBytes / (1024 * 1024)).toFixed(0)} MB per file)`
-            : `PDF / Image / Excel / Word allowed. Multiple uploads supported. (Max ${(maxBytes / (1024 * 1024)).toFixed(0)} MB per file)`)
+            ? `Only images allowed. Hold Ctrl/Cmd in the file picker to select multiple. (Max ${(maxBytes / (1024 * 1024)).toFixed(0)} MB per file)`
+            : `PDF / Image / Excel / Word allowed. Hold Ctrl/Cmd to select multiple. (Max ${(maxBytes / (1024 * 1024)).toFixed(0)} MB per file)`)
 
     const sorted = useMemo(
         () => [...attachments].sort((a, b) => a.sortOrder - b.sortOrder || a.attachmentId - b.attachmentId),
@@ -83,14 +124,18 @@ export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = (
             const oversized = list.find((f) => f.size > maxBytes)
             if (oversized) {
                 setError(`"${oversized.name}" exceeds max size ${(maxBytes / (1024 * 1024)).toFixed(0)} MB`)
+                if (fileInputRef.current) fileInputRef.current.value = ''
                 return
             }
             const startSort = sorted.length > 0 ? sorted[sorted.length - 1].sortOrder + 1 : 0
-            try {
-                const results: FormAttachmentRow[] = []
-                for (let i = 0; i < list.length; i += 1) {
-                    const file = list[i]
-                    const row = await upload.mutateAsync({
+            setUploading(true)
+            setProgress({ done: 0, total: list.length })
+            // Concurrent uploads via Promise.allSettled — each call is independent
+            // (presign -> S3 PUT -> confirm). Tracks per-file completion for progress.
+            let done = 0
+            const settled = await Promise.allSettled(
+                list.map((file, i) =>
+                    uploadOne({
                         file,
                         formCode,
                         kind,
@@ -98,18 +143,34 @@ export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = (
                         recordId: recordId ?? null,
                         sortOrder: startSort + i,
                         reportingYearDate,
-                    })
-                    results.push(row)
+                    }).then((row) => {
+                        done += 1
+                        setProgress({ done, total: list.length })
+                        return row
+                    }),
+                ),
+            )
+            const results: FormAttachmentRow[] = []
+            const errors: string[] = []
+            settled.forEach((r, i) => {
+                if (r.status === 'fulfilled') results.push(r.value)
+                else {
+                    const reason = r.reason
+                    const msg = reason instanceof ApiError ? reason.message : reason instanceof Error ? reason.message : 'Upload failed'
+                    errors.push(`${list[i].name}: ${msg}`)
                 }
-                if (onChange) onChange([...sorted, ...results])
-            } catch (e) {
-                const msg = e instanceof ApiError ? e.message : e instanceof Error ? e.message : 'Upload failed'
-                setError(msg)
-            } finally {
-                if (fileInputRef.current) fileInputRef.current.value = ''
-            }
+            })
+            // Single state + cache update at the end so React renders once with all results.
+            if (results.length && onChange) onChange([...sorted, ...results])
+            qc.invalidateQueries({ queryKey: ['form-attachments', formCode] })
+            qc.invalidateQueries({ queryKey: ['form-attachments-gallery'] })
+            qc.invalidateQueries({ queryKey: ['form-attachments-gallery-forms'] })
+            if (errors.length) setError(errors.join(' • '))
+            setUploading(false)
+            setProgress(null)
+            if (fileInputRef.current) fileInputRef.current.value = ''
         },
-        [formCode, kind, kvkId, recordId, sorted, upload, onChange, maxBytes, reportingYearDate],
+        [formCode, kind, kvkId, recordId, sorted, onChange, maxBytes, reportingYearDate, qc],
     )
 
     const handleRemove = useCallback(
@@ -151,19 +212,21 @@ export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = (
                     type="file"
                     accept={acceptAttr}
                     multiple
-                    disabled={disabled || upload.isPending}
+                    disabled={disabled || uploading}
                     onChange={(e) => handleFiles(e.target.files)}
                     className="block w-full text-sm bg-white px-3 py-2 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-[#487749] file:text-white hover:file:bg-[#3d6540] cursor-pointer disabled:opacity-60"
                 />
                 <div className="bg-gray-50 px-3 py-2 text-xs text-gray-600 border-t border-[#E0E0E0]">
-                    {upload.isPending ? (
-                        <span className="inline-flex items-center gap-2"><Loader2 className="w-3 h-3 animate-spin" /> Uploading…</span>
+                    {uploading && progress ? (
+                        <span className="inline-flex items-center gap-2">
+                            <Loader2 className="w-3 h-3 animate-spin" /> Uploading {progress.done}/{progress.total}…
+                        </span>
                     ) : (
                         helper
                     )}
                 </div>
             </div>
-            {error && <div className="text-xs text-red-600">{error}</div>}
+            {error && <div className="text-xs text-red-600 break-words">{error}</div>}
 
             {sorted.length > 0 && (
                 <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mt-2">

--- a/frontend/src/hooks/useGallerySource.ts
+++ b/frontend/src/hooks/useGallerySource.ts
@@ -41,8 +41,18 @@ const FORM_LABEL_OVERRIDES: Record<string, string> = {
     oft_result: 'OFT Result',
 }
 
-const FORMS_MENU_NAME = 'Form Attachments'
+// Maps a formCode to the sidebar group it should appear under. Falls back to
+// "Form Attachments" so unknown forms still show up.
+const FORM_MENU_BY_CODE: Record<string, string> = {
+    oft_result: 'Achievements',
+}
+
+const DEFAULT_FORMS_MENU_NAME = 'Form Attachments'
 const FORM_ID_OFFSET = 1_000_000
+
+function menuForFormCode(code: string): string {
+    return FORM_MENU_BY_CODE[code] ?? DEFAULT_FORMS_MENU_NAME
+}
 
 function humanizeFormCode(code: string): string {
     if (FORM_LABEL_OVERRIDES[code]) return FORM_LABEL_OVERRIDES[code]
@@ -145,7 +155,7 @@ export function useGallerySource(
         const formCategories: ModuleImageCategory[] = (formsListQuery.data ?? []).map((f) => ({
             moduleId: formCodeToId.get(f.formCode) ?? FORM_ID_OFFSET,
             moduleCode: f.formCode,
-            menuName: FORMS_MENU_NAME,
+            menuName: menuForFormCode(f.formCode),
             subMenuName: humanizeFormCode(f.formCode),
             label: humanizeFormCode(f.formCode),
         }))

--- a/frontend/src/hooks/useGallerySource.ts
+++ b/frontend/src/hooks/useGallerySource.ts
@@ -16,8 +16,6 @@ import type {
 } from '@/services/moduleImagesApi'
 import type { FormAttachmentRow } from '@/services/formAttachmentsApi'
 
-export type GallerySource = 'modules' | 'forms'
-
 export interface GalleryFilters {
     page?: number
     limit?: number
@@ -28,8 +26,10 @@ export interface GalleryFilters {
     search?: string
 }
 
+export type GalleryItem = ModuleImageRow & { source: 'module' | 'form' }
+
 interface UseGallerySourceResult {
-    images: ModuleImageRow[]
+    images: GalleryItem[]
     categories: ModuleImageCategory[]
     kvks: ModuleImageKvkOption[]
     total: number
@@ -41,6 +41,9 @@ const FORM_LABEL_OVERRIDES: Record<string, string> = {
     oft_result: 'OFT Result',
 }
 
+const FORMS_MENU_NAME = 'Form Attachments'
+const FORM_ID_OFFSET = 1_000_000
+
 function humanizeFormCode(code: string): string {
     if (FORM_LABEL_OVERRIDES[code]) return FORM_LABEL_OVERRIDES[code]
     return code
@@ -50,12 +53,12 @@ function humanizeFormCode(code: string): string {
         .join(' ')
 }
 
-function attachmentToRow(att: FormAttachmentRow, syntheticModuleId: number): ModuleImageRow {
+function attachmentToRow(att: FormAttachmentRow, syntheticModuleId: number): GalleryItem {
     const reportingYear = att.reportingYearDate
         ? new Date(att.reportingYearDate).getFullYear()
         : new Date(att.createdAt).getFullYear()
     return {
-        imageId: att.attachmentId,
+        imageId: att.attachmentId + FORM_ID_OFFSET,
         kvkId: att.kvkId,
         kvkName: att.kvk?.kvkName ?? '',
         moduleId: syntheticModuleId,
@@ -70,26 +73,40 @@ function attachmentToRow(att: FormAttachmentRow, syntheticModuleId: number): Mod
         downloadUrl: att.downloadUrl,
         uploadedBy: att.uploadedBy ?? null,
         createdAt: att.createdAt,
+        source: 'form',
     }
 }
 
+function moduleImageToRow(img: ModuleImageRow): GalleryItem {
+    return { ...img, source: 'module' }
+}
+
 export function useGallerySource(
-    source: GallerySource,
     filters: GalleryFilters,
     showKvkFilter: boolean,
 ): UseGallerySourceResult {
-    const moduleImagesQuery = useModuleImages(filters as any)
-    const moduleCategoriesQuery = useModuleImageCategories()
-    const moduleKvksQuery = useModuleImageKvks(showKvkFilter && source === 'modules')
-
-    const formsQuery = useFormAttachmentsGallery({
+    // Translate selected synthetic moduleId to formCode if it belongs to forms.
+    // Module-image queries should not pass a synthetic id (out of range), so
+    // strip moduleId when it's >= FORM_ID_OFFSET.
+    const isFormSelection = (filters.moduleId ?? 0) >= FORM_ID_OFFSET
+    const moduleImageFilters = {
+        ...filters,
+        moduleId: isFormSelection ? undefined : filters.moduleId,
+    }
+    const formAttachmentsFilters = {
         page: filters.page,
         limit: filters.limit,
         reportingYear: filters.reportingYear,
         kvkId: filters.kvkId,
         formCode: filters.formCode,
         search: filters.search,
-    })
+    }
+
+    const moduleImagesQuery = useModuleImages(moduleImageFilters as any)
+    const moduleCategoriesQuery = useModuleImageCategories()
+    const moduleKvksQuery = useModuleImageKvks(showKvkFilter)
+
+    const formsQuery = useFormAttachmentsGallery(formAttachmentsFilters)
     const formsListQuery = useFormAttachmentsGalleryForms()
     const formsKvksQuery = useFormAttachmentsGalleryKvks()
 
@@ -97,69 +114,76 @@ export function useGallerySource(
         const map = new Map<string, number>()
         const list = formsListQuery.data ?? []
         list.forEach((f, i) => {
-            map.set(f.formCode, 1_000_000 + i)
+            map.set(f.formCode, FORM_ID_OFFSET + i)
         })
         return map
     }, [formsListQuery.data])
 
     return useMemo<UseGallerySourceResult>(() => {
-        if (source === 'forms') {
-            const rows = (formsQuery.data?.data ?? []).map((att) => {
-                const id = formCodeToId.get(att.formCode) ?? 1_000_000
-                return attachmentToRow(att, id)
+        const moduleRows = (moduleImagesQuery.data?.data ?? []).map(moduleImageToRow)
+        // If user selected a module-image module, hide form rows; if user
+        // selected a form, hide module-image rows. No selection -> show both.
+        const formRows = (formsQuery.data?.data ?? []).map((att) => {
+            const id = formCodeToId.get(att.formCode) ?? FORM_ID_OFFSET
+            return attachmentToRow(att, id)
+        })
+
+        let images: GalleryItem[]
+        if (isFormSelection) {
+            images = formRows
+        } else if (filters.moduleId && !isFormSelection) {
+            images = moduleRows
+        } else {
+            images = [...moduleRows, ...formRows].sort((a, b) => {
+                const ad = new Date(a.imageDate || a.createdAt).getTime()
+                const bd = new Date(b.imageDate || b.createdAt).getTime()
+                return bd - ad
             })
-            const categories: ModuleImageCategory[] = (formsListQuery.data ?? []).map((f) => ({
-                moduleId: formCodeToId.get(f.formCode) ?? 1_000_000,
-                moduleCode: f.formCode,
-                menuName: 'Form Modules',
-                subMenuName: humanizeFormCode(f.formCode),
-                label: humanizeFormCode(f.formCode),
-            }))
-            const kvks: ModuleImageKvkOption[] = (formsKvksQuery.data ?? []).map((k) => ({
-                kvkId: k.kvkId,
-                kvkName: k.kvkName,
-            }))
-            return {
-                images: rows,
-                categories,
-                kvks,
-                total: formsQuery.data?.meta.total ?? 0,
-                isLoading: formsQuery.isLoading || formsListQuery.isLoading,
-                isError: Boolean(formsQuery.error || formsListQuery.error),
-            }
         }
+
+        const moduleCategories = moduleCategoriesQuery.data ?? []
+        const formCategories: ModuleImageCategory[] = (formsListQuery.data ?? []).map((f) => ({
+            moduleId: formCodeToId.get(f.formCode) ?? FORM_ID_OFFSET,
+            moduleCode: f.formCode,
+            menuName: FORMS_MENU_NAME,
+            subMenuName: humanizeFormCode(f.formCode),
+            label: humanizeFormCode(f.formCode),
+        }))
+        const categories: ModuleImageCategory[] = [...moduleCategories, ...formCategories]
+
+        const kvkMap = new Map<number, ModuleImageKvkOption>()
+        for (const k of moduleKvksQuery.data ?? []) kvkMap.set(k.kvkId, k)
+        for (const k of formsKvksQuery.data ?? []) {
+            if (!kvkMap.has(k.kvkId)) kvkMap.set(k.kvkId, { kvkId: k.kvkId, kvkName: k.kvkName })
+        }
+        const kvks = Array.from(kvkMap.values()).sort((a, b) => a.kvkName.localeCompare(b.kvkName))
+
+        const total =
+            (moduleImagesQuery.data?.meta?.total ?? 0) + (formsQuery.data?.meta.total ?? 0)
+
         return {
-            images: moduleImagesQuery.data?.data ?? [],
-            categories: moduleCategoriesQuery.data ?? [],
-            kvks: moduleKvksQuery.data ?? [],
-            total: moduleImagesQuery.data?.meta?.total ?? 0,
-            isLoading: moduleImagesQuery.isLoading,
-            isError: Boolean(moduleImagesQuery.error),
+            images,
+            categories,
+            kvks,
+            total,
+            isLoading: moduleImagesQuery.isLoading || formsQuery.isLoading,
+            isError: Boolean(moduleImagesQuery.error || formsQuery.error),
         }
     }, [
-        source,
         formCodeToId,
         formsQuery.data,
         formsQuery.isLoading,
         formsQuery.error,
         formsListQuery.data,
-        formsListQuery.isLoading,
-        formsListQuery.error,
         formsKvksQuery.data,
         moduleImagesQuery.data,
         moduleImagesQuery.isLoading,
         moduleImagesQuery.error,
         moduleCategoriesQuery.data,
         moduleKvksQuery.data,
+        filters.moduleId,
+        isFormSelection,
     ])
-}
-
-export function getModuleIdForFormCode(
-    formCode: string | undefined,
-    categories: ModuleImageCategory[],
-): number | undefined {
-    if (!formCode) return undefined
-    return categories.find((c) => c.moduleCode === formCode)?.moduleId
 }
 
 export function getFormCodeForModuleId(

--- a/frontend/src/pages/dashboard/shared/forms/achievement/OftResultForm.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/achievement/OftResultForm.tsx
@@ -232,7 +232,7 @@ export const OftResultForm: React.FC<OftResultFormProps> = ({
             </div>
 
             {kvkId ? (
-                <>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <FormSection title="Photographs">
                         <MultiAttachmentUploader
                             formCode={FORM_CODE}
@@ -256,7 +256,7 @@ export const OftResultForm: React.FC<OftResultFormProps> = ({
                             onChange={recordId ? undefined : setOrphanDatasheets}
                         />
                     </FormSection>
-                </>
+                </div>
             ) : (
                 <div className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded-lg p-3">
                     KVK context not available — attachment uploads are disabled. Save the result first; you can add photos/datasheets after.

--- a/frontend/src/pages/features/Gallery.tsx
+++ b/frontend/src/pages/features/Gallery.tsx
@@ -492,7 +492,7 @@ export const Gallery: React.FC = () => {
                     >
                       {group.items.map(c => {
                         const count = moduleCounts.get(c.moduleId) ?? 0
-                        const isFormCategory = c.menuName === 'Form Attachments'
+                        const isFormCategory = c.moduleId >= 1_000_000
                         const active = isFormCategory
                           ? selectedFormCode === c.moduleCode
                           : moduleId === c.moduleId
@@ -780,7 +780,7 @@ const Lightbox: React.FC<{
   onNext: () => void
   onPrev: () => void
 }> = ({ img, index, total, onClose, onNext, onPrev }) => {
-  const [showInfo, setShowInfo] = useState(false)
+  const [showInfo, setShowInfo] = useState(true)
   const overlayRef = useRef<HTMLDivElement>(null)
 
   return (

--- a/frontend/src/pages/features/Gallery.tsx
+++ b/frontend/src/pages/features/Gallery.tsx
@@ -22,10 +22,7 @@ import { getBreadcrumbsForPath } from '../../config/route'
 import { useAuth } from '@/contexts/AuthContext'
 import type { ModuleImageRow } from '@/services/moduleImagesApi'
 import { API_BASE_URL } from '@/config/api'
-import {
-  useGallerySource,
-  type GallerySource,
-} from '@/hooks/useGallerySource'
+import { useGallerySource } from '@/hooks/useGallerySource'
 
 type ViewMode = 'grid' | 'compact'
 
@@ -92,7 +89,6 @@ export const Gallery: React.FC = () => {
   const today = new Date()
   const currentYear =
     today.getMonth() >= 3 ? today.getFullYear() : today.getFullYear() - 1
-  const [source, setSource] = useState<GallerySource>('forms')
   const [searchInput, setSearchInput] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const [year, setYear] = useState<number>(currentYear)
@@ -117,15 +113,15 @@ export const Gallery: React.FC = () => {
       limit: PAGE_LIMIT,
       reportingYear: year,
       kvkId,
-      moduleId: source === 'modules' ? moduleId : undefined,
-      formCode: source === 'forms' ? selectedFormCode : undefined,
+      moduleId,
+      formCode: selectedFormCode,
       search: debouncedSearch || undefined,
     }),
-    [year, kvkId, moduleId, selectedFormCode, debouncedSearch, source]
+    [year, kvkId, moduleId, selectedFormCode, debouncedSearch]
   )
 
-  const sourceResult = useGallerySource(source, filters, showKvkFilter)
-  const images: ModuleImageRow[] = sourceResult.images
+  const sourceResult = useGallerySource(filters, showKvkFilter)
+  const images = sourceResult.images as unknown as ModuleImageRow[]
   const total = sourceResult.total
   const categoriesQuery = { data: sourceResult.categories } as { data: typeof sourceResult.categories }
   const kvksQuery = { data: sourceResult.kvks } as { data: typeof sourceResult.kvks }
@@ -262,13 +258,13 @@ export const Gallery: React.FC = () => {
       })
     }
     if (moduleId || selectedFormCode) {
-      const m =
-        categoriesQuery.data?.find(x =>
-          source === 'forms' ? x.moduleCode === selectedFormCode : x.moduleId === moduleId,
-        )
+      const m = categoriesQuery.data?.find(x =>
+        selectedFormCode ? x.moduleCode === selectedFormCode : x.moduleId === moduleId,
+      )
+      const isForm = Boolean(selectedFormCode)
       chips.push({
         key: 'module',
-        label: `${source === 'forms' ? 'Form' : 'Module'}: ${m?.label ?? selectedFormCode ?? moduleId}`,
+        label: `${isForm ? 'Form' : 'Module'}: ${m?.label ?? selectedFormCode ?? moduleId}`,
         clear: () => {
           setModuleId(undefined)
           setSelectedFormCode(undefined)
@@ -332,37 +328,6 @@ export const Gallery: React.FC = () => {
                 <X className="w-3.5 h-3.5" />
               </button>
             )}
-          </div>
-
-          <div className="hidden md:flex items-center rounded-xl border border-black/10 bg-white overflow-hidden">
-            <button
-              type="button"
-              onClick={() => {
-                setSource('forms')
-                setModuleId(undefined)
-                setSelectedFormCode(undefined)
-              }}
-              className={`px-3 py-2 text-sm transition-colors ${
-                source === 'forms' ? 'bg-[#487749] text-white' : 'text-black/60 hover:bg-black/5'
-              }`}
-              title="Form attachments"
-            >
-              Forms
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setSource('modules')
-                setModuleId(undefined)
-                setSelectedFormCode(undefined)
-              }}
-              className={`px-3 py-2 text-sm transition-colors ${
-                source === 'modules' ? 'bg-[#487749] text-white' : 'text-black/60 hover:bg-black/5'
-              }`}
-              title="Module images"
-            >
-              Modules
-            </button>
           </div>
 
           <div className="hidden md:flex items-center gap-2">
@@ -452,7 +417,7 @@ export const Gallery: React.FC = () => {
           <aside className="hidden lg:flex flex-col w-64 shrink-0 border-r border-black/5 bg-white overflow-y-auto">
             <div className="px-4 py-3 border-b border-black/5 flex items-center justify-between">
               <div className="text-[10px] font-semibold uppercase tracking-widest text-black/40">
-                {source === 'forms' ? 'Form modules' : 'Modules'}
+                Modules &amp; Forms
               </div>
               {collapsedGroups.size > 0 ? (
                 <button
@@ -484,7 +449,7 @@ export const Gallery: React.FC = () => {
               }`}
             >
               <span className="inline-flex items-center gap-2">
-                <ImageIcon className="w-4 h-4 opacity-60" /> {source === 'forms' ? 'All forms' : 'All modules'}
+                <ImageIcon className="w-4 h-4 opacity-60" /> All
               </span>
               <span className="text-xs text-black/40">{total}</span>
             </button>
@@ -527,20 +492,20 @@ export const Gallery: React.FC = () => {
                     >
                       {group.items.map(c => {
                         const count = moduleCounts.get(c.moduleId) ?? 0
-                        const active =
-                          source === 'modules'
-                            ? moduleId === c.moduleId
-                            : selectedFormCode === c.moduleCode
+                        const isFormCategory = c.menuName === 'Form Attachments'
+                        const active = isFormCategory
+                          ? selectedFormCode === c.moduleCode
+                          : moduleId === c.moduleId
                         return (
                           <button
                             key={c.moduleId}
                             onClick={() => {
-                              if (source === 'modules') {
-                                setModuleId(c.moduleId)
-                                setSelectedFormCode(undefined)
+                              if (isFormCategory) {
+                                setSelectedFormCode(c.moduleCode ?? undefined)
+                                setModuleId(undefined)
                               } else {
                                 setModuleId(c.moduleId)
-                                setSelectedFormCode(c.moduleCode ?? undefined)
+                                setSelectedFormCode(undefined)
                               }
                             }}
                             className={`w-full flex items-center justify-between pl-9 pr-4 py-1.5 text-sm transition-colors ${
@@ -815,7 +780,7 @@ const Lightbox: React.FC<{
   onNext: () => void
   onPrev: () => void
 }> = ({ img, index, total, onClose, onNext, onPrev }) => {
-  const [showInfo, setShowInfo] = useState(true)
+  const [showInfo, setShowInfo] = useState(false)
   const overlayRef = useRef<HTMLDivElement>(null)
 
   return (
@@ -888,33 +853,75 @@ const Lightbox: React.FC<{
         </button>
       </div>
 
-      {/* Info strip */}
-      {showInfo && (
-        <div className="px-4 py-3 bg-black/60 text-white text-sm flex flex-wrap items-center gap-x-6 gap-y-1">
-          <span className="font-medium truncate max-w-md">
-            {img.caption || img.categoryLabel || 'Untitled'}
-          </span>
-          <span className="text-white/70 text-xs">
-            <span className="text-white/40">Module:</span> {img.categoryLabel}
-          </span>
-          <span className="text-white/70 text-xs">
-            <span className="text-white/40">KVK:</span> {img.kvkName}
-          </span>
-          <span className="text-white/70 text-xs">
-            <span className="text-white/40">Date:</span> {formatDate(img.imageDate || img.createdAt)}
-          </span>
-          <span className="text-white/70 text-xs">
-            <span className="text-white/40">Year:</span> {img.reportingYear}
-          </span>
-          {img.uploadedBy && (
-            <span className="text-white/70 text-xs">
-              <span className="text-white/40">By:</span> {img.uploadedBy.name}
-            </span>
-          )}
+      {/* Right-side details panel */}
+      <div
+        className={`fixed top-0 right-0 h-full w-full sm:w-96 bg-white shadow-2xl text-gray-900 transform transition-transform duration-300 z-[60] overflow-y-auto ${
+          showInfo ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        <div className="sticky top-0 bg-white border-b border-gray-200 px-5 py-4 flex items-center justify-between">
+          <h3 className="text-base font-semibold text-[#487749]">Details</h3>
+          <button
+            onClick={() => setShowInfo(false)}
+            className="p-1.5 rounded-md hover:bg-gray-100 text-gray-500"
+            aria-label="Close details"
+          >
+            <X className="w-4 h-4" />
+          </button>
         </div>
-      )}
+        <div className="p-5 space-y-5 text-sm">
+          <div>
+            <div className="text-[10px] uppercase tracking-widest text-gray-400 mb-1">Caption</div>
+            <div className="font-medium text-gray-900 break-words">
+              {img.caption || <span className="text-gray-400 italic">No caption</span>}
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-3">
+            <DetailRow label="Source" value={img.categoryLabel} />
+            <DetailRow label="KVK" value={img.kvkName || '—'} />
+            <DetailRow label="Captured" value={formatDate(img.imageDate)} />
+            <DetailRow label="Uploaded" value={formatDate(img.createdAt)} />
+            <DetailRow label="Year" value={`${img.reportingYear}-${String((img.reportingYear + 1) % 100).padStart(2, '0')}`} />
+            <DetailRow label="File" value={img.fileName ?? '—'} truncate />
+            <DetailRow label="Type" value={img.mimeType.split('/')[1]?.toUpperCase() ?? img.mimeType} />
+            <DetailRow label="Position" value={`${index + 1} / ${total}`} />
+          </div>
+          {img.uploadedBy && (
+            <div className="pt-3 border-t border-gray-100">
+              <div className="text-[10px] uppercase tracking-widest text-gray-400 mb-1">Uploaded by</div>
+              <div className="font-medium text-gray-900">{img.uploadedBy.name}</div>
+              <div className="text-xs text-gray-500">{img.uploadedBy.email}</div>
+            </div>
+          )}
+          <div className="pt-3 border-t border-gray-100 flex gap-2">
+            <button
+              onClick={() => downloadImage(img.downloadUrl, img.fileName ?? img.caption)}
+              className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-[#487749] text-white hover:bg-[#3d6540] transition-colors"
+            >
+              <Download className="w-4 h-4" /> Download
+            </button>
+            <a
+              href={buildFileUrl(img.fileUrl)}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center justify-center px-3 py-2 text-sm rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors"
+            >
+              Open
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }
+
+const DetailRow: React.FC<{ label: string; value: string; truncate?: boolean }> = ({ label, value, truncate }) => (
+  <div className="min-w-0">
+    <div className="text-[10px] uppercase tracking-widest text-gray-400 mb-0.5">{label}</div>
+    <div className={`font-medium text-gray-900 ${truncate ? 'truncate' : 'break-words'}`} title={value}>
+      {value}
+    </div>
+  </div>
+)
 
 export default Gallery


### PR DESCRIPTION
## Summary
Round 2 of fixes for OFT attachments + Gallery.

### 1. Multi-select uploads only one — fixed
\`MultiAttachmentUploader.handleFiles\` was calling \`useUploadAttachment.mutateAsync\` in a sequential for-loop. The shared mutation state caused all but the first file to be dropped when several were selected at once.

Rewrite: run uploads concurrently via \`Promise.allSettled\` using direct \`presign → S3 PUT → confirm\` API calls. All selected files now upload. Progress text shows "Uploading 2/3…". Helper text adds "Hold Ctrl/Cmd to select multiple".

### 2. Tile + input sizing
- OFT result form: \`Photographs\` and \`Supplementary Datasheets\` are now in a 2-col grid (\`md:grid-cols-2\`), each at half-width. Tiles auto-shrink to fit and are visually consistent with SAC meeting tiles (\`grid-cols-2 lg:grid-cols-4\` inside the half-width container).
- Native file input retained (green pill button + helper strip below).

### 3. Modules tab missed OFT data — fixed by unifying
Dropped the Forms / Modules toggle. \`useGallerySource\` now fetches both \`ModuleImage\` and \`FormAttachment\` simultaneously, merges by date, and the sidebar shows a combined "Modules & Forms" tree:
- Existing module-image categories grouped by their \`menuName\`.
- A new "Form Attachments" group lists each form with attachments (e.g. \`OFT Result\`).
- "All" view shows everything; click a module-image entry → filters to that module; click a form entry → filters to that \`formCode\`.

### 4. Right-side details dialog
Replaced the bottom info strip in the lightbox with a slide-in panel (\`w-full sm:w-96\`) on the right edge. Shows caption, source, KVK, captured/uploaded dates, fiscal year, filename, mime type, position, uploader, plus Download / Open buttons. Toggle via the (i) button. Defaults closed.

## Test plan
- [ ] Open OFT result form. Click Browse. Select 3-5 images with Ctrl/Cmd → all appear; progress shows "x/N" during upload.
- [ ] Photo grid sits at half-width on desktop; datasheet grid on the other half.
- [ ] Open Gallery. Without any sidebar selection, see both module images AND OFT photos in one merged list.
- [ ] Sidebar shows "Form Attachments" group with "OFT Result" entry; clicking it filters to OFT only.
- [ ] Open any image → click (i) → right panel slides in with full details. Download / Open work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)