### PR TITLE
chore(soil-equipment): remove Soil Equipment from frontend nav + routes

### DIFF
--- a/frontend/src/config/route/achievements.ts
+++ b/frontend/src/config/route/achievements.ts
@@ -123,16 +123,6 @@ export const achievementsRoutes: RouteConfig[] = [
         siblings: [ROUTE_PATHS.ACHIEVEMENTS.PUBLICATIONS],
     },
     {
-        path: ROUTE_PATHS.ACHIEVEMENTS.SOIL_EQUIPMENT,
-        title: 'Soil Equipment',
-        category: 'Form Management',
-        subcategory: 'Achievements',
-        parent: ROUTE_PATHS.ACHIEVEMENTS.BASE,
-        moduleCode: 'achievements_soil_water_testing',
-        fields: FIELD_GROUPS.SOIL_EQUIPMENT,
-        siblings: ROUTE_SIBLING_GROUPS.SOIL_WATER_TESTING,
-    },
-    {
         path: ROUTE_PATHS.ACHIEVEMENTS.SOIL_ANALYSIS,
         title: 'Soil, Water and Plant analysis',
         category: 'Form Management',

--- a/frontend/src/config/routeSiblingGroups.ts
+++ b/frontend/src/config/routeSiblingGroups.ts
@@ -113,7 +113,6 @@ CFLD: [
 
     // Soil Water Testing Siblings — World Soil Day moved to the Meetings tab.
     SOIL_WATER_TESTING: [
-        ROUTE_PATHS.ACHIEVEMENTS.SOIL_EQUIPMENT,
         ROUTE_PATHS.ACHIEVEMENTS.SOIL_ANALYSIS,
     ],
 

--- a/frontend/src/pages/dashboard/forms/AchievementsTab.tsx
+++ b/frontend/src/pages/dashboard/forms/AchievementsTab.tsx
@@ -72,7 +72,6 @@ const sections: FeatureSection[] = [
         title: 'Soil and Water Testing',
         icon: <TestTube className="w-5 h-5" />,
         items: [
-            { label: 'Equipment Details', path: ROUTE_PATHS.ACHIEVEMENTS.SOIL_EQUIPMENT },
             { label: 'Analysis Details', path: ROUTE_PATHS.ACHIEVEMENTS.SOIL_ANALYSIS },
         ],
     },


### PR DESCRIPTION
## Summary
- \`AchievementsTab\` "Soil and Water Testing" group no longer lists "Equipment Details" — only "Analysis Details" remains.
- \`achievements\` route config drops the \`SOIL_EQUIPMENT\` entry so no \`<Route>\` mounts it. \`/forms/achievements/soil-equipment\` now falls through the catch-all and redirects to \`/dashboard\`.
- \`routeSiblingGroups.SOIL_WATER_TESTING\` reduced to just \`SOIL_ANALYSIS\`.
- Backend untouched (per instruction). Constants in \`ROUTE_PATHS\`, entity-type, field-name maps left in place — dead code from the UI side, not worth a wider rename sweep.

## Test plan
- [ ] Achievements tab: only "Analysis Details" under "Soil and Water Testing".
- [ ] Visit \`http://localhost:5173/forms/achievements/soil-equipment\` → redirects to \`/dashboard\`.
- [ ] \`bun run type-check\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)