### PR TITLE
feat(s3-migration) PR-B: SAC + Farmer Award + KVK Staff + UUID record IDs

### DIFF
--- a/backend/prisma/kvk/form_attachments_schema.prisma
+++ b/backend/prisma/kvk/form_attachments_schema.prisma
@@ -8,7 +8,7 @@ model FormAttachment {
   attachmentId      Int                @id @default(autoincrement()) @map("attachment_id")
   kvkId             Int                @map("kvk_id")
   formCode          String             @map("form_code")
-  recordId          Int?               @map("record_id")
+  recordId          String?            @map("record_id")
   kind              FormAttachmentKind @default(PHOTO)
   s3Key             String             @map("s3_key")
   fileName          String?            @map("file_name")

--- a/backend/prisma/migrations/20260428100000_form_attachment_record_id_to_text/migration.sql
+++ b/backend/prisma/migrations/20260428100000_form_attachment_record_id_to_text/migration.sql
@@ -1,0 +1,6 @@
+-- Widen form_attachments.record_id from INTEGER to TEXT so UUID-keyed forms
+-- (FarmerAward, SuccessStory, etc.) can attach via the same table.
+
+ALTER TABLE "form_attachments"
+    ALTER COLUMN "record_id" TYPE TEXT
+    USING ("record_id"::text);

--- a/backend/repositories/formAttachmentRepository.js
+++ b/backend/repositories/formAttachmentRepository.js
@@ -41,7 +41,7 @@ async function findByIds(attachmentIds) {
 
 async function listByRecord({ formCode, recordId, kvkId, kind }) {
     const where = { formCode };
-    if (recordId !== undefined && recordId !== null) where.recordId = Number(recordId);
+    if (recordId !== undefined && recordId !== null) where.recordId = String(recordId);
     if (kvkId) where.kvkId = Number(kvkId);
     if (kind) where.kind = kind;
     return prisma.formAttachment.findMany({
@@ -134,14 +134,15 @@ async function deleteByIds(attachmentIds) {
 async function attachToRecord({ attachmentIds, formCode, recordId, kvkId }) {
     if (!Array.isArray(attachmentIds) || attachmentIds.length === 0) return { count: 0 };
     const ids = attachmentIds.map(Number).filter((n) => !Number.isNaN(n));
+    const recordIdStr = String(recordId);
     return prisma.formAttachment.updateMany({
         where: {
             attachmentId: { in: ids },
             kvkId,
             formCode,
-            OR: [{ recordId: null }, { recordId }],
+            OR: [{ recordId: null }, { recordId: recordIdStr }],
         },
-        data: { recordId },
+        data: { recordId: recordIdStr },
     });
 }
 

--- a/backend/services/formAttachmentService.js
+++ b/backend/services/formAttachmentService.js
@@ -112,7 +112,7 @@ async function confirmUpload(payload, user) {
     const data = {
         kvkId: Number(kvkId),
         formCode: String(formCode),
-        recordId: recordId !== undefined && recordId !== null ? Number(recordId) : null,
+        recordId: recordId !== undefined && recordId !== null ? String(recordId) : null,
         kind,
         s3Key,
         fileName,
@@ -140,7 +140,7 @@ async function attachToRecord({ attachmentIds, formCode, recordId, kvkId }, user
     return formAttachmentRepository.attachToRecord({
         attachmentIds,
         formCode,
-        recordId: Number(recordId),
+        recordId: String(recordId),
         kvkId: Number(kvkId),
     });
 }

--- a/backend/services/forms/aboutKvkService.js
+++ b/backend/services/forms/aboutKvkService.js
@@ -3,9 +3,19 @@ const prisma = require('../../config/prisma.js');
 const { ValidationError } = require('../../utils/errorHandler.js');
 const { parseReportingYearDate, ensureNotFutureDate } = require('../../utils/reportingYearUtils.js');
 const { sanitizeDate, sanitizeString } = require('../../utils/dataSanitizer.js');
+const { createAttachmentBinding } = require('./formAttachmentBinding.js');
 
 /** Roles scoped to a specific KVK */
 const KVK_ROLES = ['kvk_admin', 'kvk_user'];
+
+const STAFF_ATTACHMENTS = createAttachmentBinding({
+    formCode: 'kvk_staff',
+    primaryKey: 'kvkStaffId',
+});
+
+function entityHasAttachments(entityName) {
+    return entityName === 'kvk-employees' || entityName === 'kvk-staff-transferred';
+}
 
 /**
  * About KVK Service
@@ -93,6 +103,9 @@ class AboutKvkService {
             }
         }
 
+        if (entityHasAttachments(entityName)) {
+            return STAFF_ATTACHMENTS.decorate(entity, user);
+        }
         return entity;
     }
 
@@ -160,13 +173,24 @@ class AboutKvkService {
             }
         }
 
+        // Strip attachmentIds before passing to repo (only kvk-staff carries them).
+        const hasAttachments = entityHasAttachments(entityName);
+        const { payload: rawWithoutAtt, attachmentIds } = hasAttachments
+            ? STAFF_ATTACHMENTS.strip(data)
+            : { payload: data, attachmentIds: [] };
+
         // Sanitize optional enum fields: convert empty strings to null
-        const sanitizedData = this.sanitizeEnumFields(entityName, data);
+        const sanitizedData = this.sanitizeEnumFields(entityName, rawWithoutAtt);
 
         // Convert numeric fields
         const finalData = this.sanitizeNumericFields(entityName, sanitizedData);
 
-        return await aboutKvkRepository.create(entityName, finalData);
+        const created = await aboutKvkRepository.create(entityName, finalData);
+        if (hasAttachments) {
+            await STAFF_ATTACHMENTS.attach(created, attachmentIds, user);
+            return STAFF_ATTACHMENTS.decorate(created, user);
+        }
+        return created;
     }
 
     async update(entityName, id, data, user = null) {
@@ -189,8 +213,14 @@ class AboutKvkService {
             throw new Error('Cannot change kvkId');
         }
 
+        // Strip attachmentIds before passing to repo (only kvk-staff carries them).
+        const hasAttachments = entityHasAttachments(entityName);
+        const { payload: rawWithoutAtt, attachmentIds } = hasAttachments
+            ? STAFF_ATTACHMENTS.strip(data)
+            : { payload: data, attachmentIds: [] };
+
         // Sanitize data: remove read-only fields and nested objects
-        const sanitizedData = this.sanitizeUpdateData(entityName, data);
+        const sanitizedData = this.sanitizeUpdateData(entityName, rawWithoutAtt);
 
         // Sanitize optional enum fields: convert empty strings to null
         const enumSanitized = this.sanitizeEnumFields(entityName, sanitizedData);
@@ -198,7 +228,12 @@ class AboutKvkService {
         // Convert numeric fields
         const finalData = this.sanitizeNumericFields(entityName, enumSanitized);
 
-        return await aboutKvkRepository.update(entityName, id, finalData);
+        const updated = await aboutKvkRepository.update(entityName, id, finalData);
+        if (hasAttachments) {
+            await STAFF_ATTACHMENTS.attach(updated ?? currentEntity, attachmentIds, user);
+            return STAFF_ATTACHMENTS.decorate(updated, user);
+        }
+        return updated;
     }
 
     async delete(entityName, id, user = null) {
@@ -221,7 +256,11 @@ class AboutKvkService {
             }
         }
 
-        return await aboutKvkRepository.deleteEntity(entityName, id);
+        const deleted = await aboutKvkRepository.deleteEntity(entityName, id);
+        if (entityHasAttachments(entityName)) {
+            await STAFF_ATTACHMENTS.cleanup(currentEntity, user);
+        }
+        return deleted;
     }
 
     /**

--- a/backend/services/forms/aryaCurrentYearService.js
+++ b/backend/services/forms/aryaCurrentYearService.js
@@ -1,83 +1,47 @@
 const aryaCurrentYearRepository = require('../../repositories/forms/aryaCurrentYearRepository');
 const reportCacheInvalidationService = require('../reports/reportCacheInvalidationService.js');
-const formAttachmentService = require('../formAttachmentService.js');
+const { createAttachmentBinding } = require('./formAttachmentBinding');
 
-const FORM_CODE = 'arya_current_year';
-
-function stripAttachmentIds(data) {
-    if (!data || typeof data !== 'object') return { payload: data, attachmentIds: [] };
-    const { attachmentIds, ...rest } = data;
-    return { payload: rest, attachmentIds: Array.isArray(attachmentIds) ? attachmentIds : [] };
-}
-
-async function decorate(record, user) {
-    if (!record?.aryaCurrentYearId || !record.kvkId) return record;
-    const photos = await formAttachmentService.listByRecord({
-        formCode: FORM_CODE,
-        recordId: record.aryaCurrentYearId,
-        kvkId: record.kvkId,
-        kind: 'PHOTO',
-    }, user);
-    return { ...record, photos };
-}
+const attachments = createAttachmentBinding({
+    formCode: 'arya_current_year',
+    primaryKey: 'aryaCurrentYearId',
+});
 
 const aryaCurrentYearService = {
     getAll: async (filters, user) => {
         const rows = await aryaCurrentYearRepository.findAll(filters, user);
-        if (!Array.isArray(rows)) return rows;
-        return Promise.all(rows.map((r) => decorate(r, user)));
+        return attachments.decorateMany(rows, user);
     },
 
     getById: async (id, user) => {
         const record = await aryaCurrentYearRepository.findById(id, user);
-        return decorate(record, user);
+        return attachments.decorate(record, user);
     },
 
     create: async (data, user) => {
-        const { payload, attachmentIds } = stripAttachmentIds(data);
+        const { payload, attachmentIds } = attachments.strip(data);
         const result = await aryaCurrentYearRepository.create(payload, user);
-        if (attachmentIds.length > 0 && result?.aryaCurrentYearId && result.kvkId) {
-            await formAttachmentService.attachToRecord({
-                attachmentIds,
-                formCode: FORM_CODE,
-                recordId: result.aryaCurrentYearId,
-                kvkId: result.kvkId,
-            }, user);
-        }
+        await attachments.attach(result, attachmentIds, user);
         await reportCacheInvalidationService.invalidateDataSourceForKvk('aryaCurrent', result?.kvkId || user?.kvkId);
-        return decorate(result, user);
+        return attachments.decorate(result, user);
     },
 
     update: async (id, data, user) => {
-        const { payload, attachmentIds } = stripAttachmentIds(data);
+        const { payload, attachmentIds } = attachments.strip(data);
         const existing = await aryaCurrentYearRepository.findById(id, user);
         const result = await aryaCurrentYearRepository.update(id, payload, user);
-        const recordId = result?.aryaCurrentYearId ?? Number(id);
-        const kvkId = result?.kvkId ?? existing?.kvkId;
-        if (attachmentIds.length > 0 && recordId && kvkId) {
-            await formAttachmentService.attachToRecord({
-                attachmentIds,
-                formCode: FORM_CODE,
-                recordId,
-                kvkId,
-            }, user);
-        }
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('aryaCurrent', kvkId || user?.kvkId);
-        return decorate(result, user);
+        await attachments.attach(result ?? existing, attachmentIds, user);
+        await reportCacheInvalidationService.invalidateDataSourceForKvk(
+            'aryaCurrent',
+            result?.kvkId || existing?.kvkId || user?.kvkId,
+        );
+        return attachments.decorate(result, user);
     },
 
     delete: async (id, user) => {
         const existing = await aryaCurrentYearRepository.findById(id, user);
         const result = await aryaCurrentYearRepository.delete(id, user);
-        if (existing?.aryaCurrentYearId && existing?.kvkId) {
-            try {
-                await formAttachmentService.deleteManyByRecord({
-                    formCode: FORM_CODE,
-                    recordId: existing.aryaCurrentYearId,
-                    kvkId: existing.kvkId,
-                }, user);
-            } catch { /* best-effort */ }
-        }
+        await attachments.cleanup(existing, user);
         await reportCacheInvalidationService.invalidateDataSourceForKvk('aryaCurrent', existing?.kvkId || user?.kvkId);
         return result;
     },

--- a/backend/services/forms/farmerAwardService.js
+++ b/backend/services/forms/farmerAwardService.js
@@ -1,6 +1,12 @@
 const farmerAwardRepository = require('../../repositories/forms/farmerAwardRepository.js');
 const { RepositoryError } = require('../../utils/repositoryHelpers');
 const reportCacheInvalidationService = require('../reports/reportCacheInvalidationService.js');
+const { createAttachmentBinding } = require('./formAttachmentBinding.js');
+
+const attachments = createAttachmentBinding({
+    formCode: 'farmer_award',
+    primaryKey: 'farmerAwardId',
+});
 
 /**
  * Farmer Award Service
@@ -15,12 +21,14 @@ class FarmerAwardService {
      */
     async createFarmerAward(data, user) {
         try {
-            const result = await farmerAwardRepository.create(data, user);
+            const { payload, attachmentIds } = attachments.strip(data);
+            const result = await farmerAwardRepository.create(payload, user);
+            await attachments.attach(result, attachmentIds, user);
             await reportCacheInvalidationService.invalidateDataSourceForKvk(
                 'farmerAward',
                 result?.kvkId || user?.kvkId,
             );
-            return result;
+            return attachments.decorate(result, user);
         } catch (error) {
             if (error instanceof RepositoryError) {
                 throw error;
@@ -37,7 +45,12 @@ class FarmerAwardService {
      */
     async getAllFarmerAwards(filters = {}, user) {
         try {
-            return await farmerAwardRepository.findAll(filters, user);
+            const rows = await farmerAwardRepository.findAll(filters, user);
+            if (rows && Array.isArray(rows.data)) {
+                rows.data = await attachments.decorateMany(rows.data, user);
+                return rows;
+            }
+            return attachments.decorateMany(rows, user);
         } catch (error) {
             if (error instanceof RepositoryError) {
                 throw error;
@@ -54,7 +67,8 @@ class FarmerAwardService {
      */
     async getFarmerAwardById(id, user) {
         try {
-            return await farmerAwardRepository.findById(id, user);
+            const record = await farmerAwardRepository.findById(id, user);
+            return attachments.decorate(record, user);
         } catch (error) {
             if (error instanceof RepositoryError) {
                 throw error;
@@ -72,12 +86,15 @@ class FarmerAwardService {
      */
     async updateFarmerAward(id, data, user) {
         try {
-            const result = await farmerAwardRepository.update(id, data, user);
+            const { payload, attachmentIds } = attachments.strip(data);
+            const existing = await farmerAwardRepository.findById(id, user);
+            const result = await farmerAwardRepository.update(id, payload, user);
+            await attachments.attach(result ?? existing, attachmentIds, user);
             await reportCacheInvalidationService.invalidateDataSourceForKvk(
                 'farmerAward',
                 result?.kvkId || user?.kvkId,
             );
-            return result;
+            return attachments.decorate(result, user);
         } catch (error) {
             if (error instanceof RepositoryError) {
                 throw error;
@@ -96,6 +113,7 @@ class FarmerAwardService {
         try {
             const existing = await farmerAwardRepository.findById(id, user);
             const result = await farmerAwardRepository.delete(id, user);
+            await attachments.cleanup(existing, user);
             await reportCacheInvalidationService.invalidateDataSourceForKvk(
                 'farmerAward',
                 existing?.kvkId || user?.kvkId,

--- a/backend/services/forms/formAttachmentBinding.js
+++ b/backend/services/forms/formAttachmentBinding.js
@@ -1,0 +1,95 @@
+const formAttachmentService = require('../formAttachmentService');
+
+const KIND_KEY = {
+    PHOTO: 'photos',
+    DATASHEET: 'datasheets',
+    DOCUMENT: 'documents',
+};
+
+/**
+ * Factory that returns the strip / attach / decorate / cleanup helpers a form
+ * service needs to bind itself to FormAttachment without duplicating boilerplate.
+ *
+ * Usage:
+ *   const binding = createAttachmentBinding({
+ *     formCode: 'sac_meeting',
+ *     primaryKey: 'sacMeetingId',
+ *   });
+ *
+ *   const create = async (data, user) => {
+ *     const { payload, attachmentIds } = binding.strip(data);
+ *     const result = await repo.create(payload, user);
+ *     await binding.attach(result, attachmentIds, user);
+ *     return binding.decorate(result, user);
+ *   };
+ */
+function createAttachmentBinding({ formCode, primaryKey, kvkKey = 'kvkId' }) {
+    if (!formCode || !primaryKey) {
+        throw new Error('createAttachmentBinding requires formCode and primaryKey');
+    }
+
+    function strip(data) {
+        if (!data || typeof data !== 'object') {
+            return { payload: data, attachmentIds: [] };
+        }
+        const { attachmentIds, ...rest } = data;
+        return {
+            payload: rest,
+            attachmentIds: Array.isArray(attachmentIds) ? attachmentIds : [],
+        };
+    }
+
+    async function attach(record, attachmentIds, user) {
+        if (!Array.isArray(attachmentIds) || attachmentIds.length === 0) return;
+        const recordId = record?.[primaryKey];
+        const kvkId = record?.[kvkKey];
+        if (!recordId || !kvkId) return;
+        await formAttachmentService.attachToRecord({
+            attachmentIds,
+            formCode,
+            recordId,
+            kvkId,
+        }, user);
+    }
+
+    async function decorate(record, user) {
+        if (!record || typeof record !== 'object') return record;
+        const recordId = record[primaryKey];
+        const kvkId = record[kvkKey];
+        if (!recordId || !kvkId) return record;
+        const attachments = await formAttachmentService.listByRecord({
+            formCode,
+            recordId,
+            kvkId,
+        }, user);
+        const groups = { photos: [], datasheets: [], documents: [] };
+        for (const att of attachments) {
+            const key = KIND_KEY[att.kind] || 'documents';
+            groups[key].push(att);
+        }
+        return { ...record, ...groups };
+    }
+
+    async function decorateMany(rows, user) {
+        if (!Array.isArray(rows)) return rows;
+        return Promise.all(rows.map((r) => decorate(r, user)));
+    }
+
+    async function cleanup(record, user) {
+        if (!record) return;
+        const recordId = record[primaryKey];
+        const kvkId = record[kvkKey];
+        if (!recordId || !kvkId) return;
+        try {
+            await formAttachmentService.deleteManyByRecord({
+                formCode,
+                recordId,
+                kvkId,
+            }, user);
+        } catch { /* best-effort */ }
+    }
+
+    return { strip, attach, decorate, decorateMany, cleanup, formCode };
+}
+
+module.exports = { createAttachmentBinding };

--- a/backend/services/forms/meetingsService.js
+++ b/backend/services/forms/meetingsService.js
@@ -1,20 +1,48 @@
 const meetingsRepository = require('../../repositories/forms/meetingsRepository');
+const { createAttachmentBinding } = require('./formAttachmentBinding');
+
+const sacAttachments = createAttachmentBinding({
+    formCode: 'sac_meeting',
+    primaryKey: 'sacMeetingId',
+});
 
 const meetingsService = {
     sac: {
-        findAll: async (filters, user) => await meetingsRepository.sac.findAll(filters, user),
-        findById: async (id, user) => await meetingsRepository.sac.findById(id, user),
-        create: async (data, user) => await meetingsRepository.sac.create(data, user),
-        update: async (id, data, user) => await meetingsRepository.sac.update(id, data, user),
-        delete: async (id, user) => await meetingsRepository.sac.delete(id, user),
+        findAll: async (filters, user) => {
+            const rows = await meetingsRepository.sac.findAll(filters, user);
+            return sacAttachments.decorateMany(rows, user);
+        },
+        findById: async (id, user) => {
+            const record = await meetingsRepository.sac.findById(id, user);
+            return sacAttachments.decorate(record, user);
+        },
+        create: async (data, user) => {
+            const { payload, attachmentIds } = sacAttachments.strip(data);
+            const result = await meetingsRepository.sac.create(payload, user);
+            await sacAttachments.attach(result, attachmentIds, user);
+            return sacAttachments.decorate(result, user);
+        },
+        update: async (id, data, user) => {
+            const { payload, attachmentIds } = sacAttachments.strip(data);
+            const existing = await meetingsRepository.sac.findById(id, user);
+            const result = await meetingsRepository.sac.update(id, payload, user);
+            await sacAttachments.attach(result ?? existing, attachmentIds, user);
+            return sacAttachments.decorate(result, user);
+        },
+        delete: async (id, user) => {
+            const existing = await meetingsRepository.sac.findById(id, user);
+            const result = await meetingsRepository.sac.delete(id, user);
+            await sacAttachments.cleanup(existing, user);
+            return result;
+        },
     },
     other: {
-        findAll: async (filters, user) => await meetingsRepository.other.findAll(filters, user),
-        findById: async (id, user) => await meetingsRepository.other.findById(id, user),
-        create: async (data, user) => await meetingsRepository.other.create(data, user),
-        update: async (id, data, user) => await meetingsRepository.other.update(id, data, user),
-        delete: async (id, user) => await meetingsRepository.other.delete(id, user),
-    }
+        findAll: async (filters, user) => meetingsRepository.other.findAll(filters, user),
+        findById: async (id, user) => meetingsRepository.other.findById(id, user),
+        create: async (data, user) => meetingsRepository.other.create(data, user),
+        update: async (id, data, user) => meetingsRepository.other.update(id, data, user),
+        delete: async (id, user) => meetingsRepository.other.delete(id, user),
+    },
 };
 
 module.exports = meetingsService;

--- a/backend/services/forms/oftService.js
+++ b/backend/services/forms/oftService.js
@@ -2,9 +2,12 @@ const oftRepository = require('../../repositories/forms/oftRepository.js');
 const { ValidationError, NotFoundError } = require('../../utils/errorHandler.js');
 const { OFT_STATUS, normalizeOftStatus, canTransition } = require('../../constants/oftStatus.js');
 const { validateFileSize } = require('../../utils/fileValidation.js');
-const formAttachmentService = require('../formAttachmentService.js');
+const { createAttachmentBinding } = require('./formAttachmentBinding.js');
 
-const OFT_RESULT_FORM_CODE = 'oft_result';
+const resultAttachments = createAttachmentBinding({
+    formCode: 'oft_result',
+    primaryKey: 'oftResultReportId',
+});
 
 const oftService = {
     createOft: async (data, user) => {
@@ -65,10 +68,15 @@ const oftService = {
         const sourceRows = await oftRepository.getTechnologyOptionsByOftId(id);
         _validateResultPayload(payload, sourceRows);
 
+        const { attachmentIds } = resultAttachments.strip(payload);
         const result = await oftRepository.createResultReportTx(id, payload);
         await oftRepository.updateStatus(id, OFT_STATUS.COMPLETED);
-        await _linkAttachments(payload, result, source, user);
-        return result;
+        await resultAttachments.attach(
+            { ...result, kvkId: source.kvkId },
+            attachmentIds,
+            user,
+        );
+        return resultAttachments.decorate({ ...result, kvkId: source.kvkId }, user);
     },
 
     editResult: async (id, payload, user) => {
@@ -82,9 +90,14 @@ const oftService = {
 
         const sourceRows = await oftRepository.getTechnologyOptionsByOftId(id);
         _validateResultPayload(payload, sourceRows);
+        const { attachmentIds } = resultAttachments.strip(payload);
         const result = await oftRepository.updateResultReportTx(id, payload);
-        await _linkAttachments(payload, result, source, user);
-        return result;
+        await resultAttachments.attach(
+            { ...result, kvkId: source.kvkId },
+            attachmentIds,
+            user,
+        );
+        return resultAttachments.decorate({ ...result, kvkId: source.kvkId }, user);
     },
 
     getResult: async (id, user) => {
@@ -92,16 +105,7 @@ const oftService = {
         if (!source) throw new NotFoundError('OFT record');
         const result = await oftRepository.getResultByOftId(id);
         if (!result) throw new NotFoundError('OFT result report');
-        const attachments = await formAttachmentService.listByRecord({
-            formCode: OFT_RESULT_FORM_CODE,
-            recordId: result.oftResultReportId,
-            kvkId: source.kvkId,
-        }, user);
-        return {
-            ...result,
-            photos: attachments.filter((a) => a.kind === 'PHOTO'),
-            datasheets: attachments.filter((a) => a.kind === 'DATASHEET'),
-        };
+        return resultAttachments.decorate({ ...result, kvkId: source.kvkId }, user);
     },
 
     deleteOft: async (id, user) => {
@@ -146,18 +150,6 @@ function _validateResultPayload(payload, sourceRows = []) {
 
     validateFileSize({ size: payload.supplementaryDatasheetSize }, 5 * 1024 * 1024, 'Supplementary Datasheet');
     validateFileSize({ size: payload.photographSize }, 5 * 1024 * 1024, 'Photograph');
-}
-
-async function _linkAttachments(payload, result, source, user) {
-    if (!result?.oftResultReportId || !source?.kvkId) return;
-    const ids = Array.isArray(payload?.attachmentIds) ? payload.attachmentIds : [];
-    if (ids.length === 0) return;
-    await formAttachmentService.attachToRecord({
-        attachmentIds: ids,
-        formCode: OFT_RESULT_FORM_CODE,
-        recordId: result.oftResultReportId,
-        kvkId: source.kvkId,
-    }, user);
 }
 
 module.exports = oftService;

--- a/backend/services/forms/raweFetService.js
+++ b/backend/services/forms/raweFetService.js
@@ -1,80 +1,38 @@
 const raweFetRepository = require('../../repositories/forms/raweFetRepository');
-const formAttachmentService = require('../formAttachmentService.js');
+const { createAttachmentBinding } = require('./formAttachmentBinding');
 
-const FORM_CODE = 'rawe_fet';
-
-function stripAttachmentIds(data) {
-    if (!data || typeof data !== 'object') return { payload: data, attachmentIds: [] };
-    const { attachmentIds, ...rest } = data;
-    return { payload: rest, attachmentIds: Array.isArray(attachmentIds) ? attachmentIds : [] };
-}
-
-async function decorate(record, user) {
-    if (!record?.raweProgrammeId || !record.kvkId) return record;
-    const attachments = await formAttachmentService.listByRecord({
-        formCode: FORM_CODE,
-        recordId: record.raweProgrammeId,
-        kvkId: record.kvkId,
-    }, user);
-    return {
-        ...record,
-        photos: attachments.filter((a) => a.kind === 'PHOTO'),
-        documents: attachments.filter((a) => a.kind !== 'PHOTO'),
-    };
-}
+const attachments = createAttachmentBinding({
+    formCode: 'rawe_fet',
+    primaryKey: 'raweProgrammeId',
+});
 
 const raweFetService = {
     create: async (data, user) => {
-        const { payload, attachmentIds } = stripAttachmentIds(data);
+        const { payload, attachmentIds } = attachments.strip(data);
         const result = await raweFetRepository.create(payload, user);
-        if (attachmentIds.length > 0 && result?.raweProgrammeId && result.kvkId) {
-            await formAttachmentService.attachToRecord({
-                attachmentIds,
-                formCode: FORM_CODE,
-                recordId: result.raweProgrammeId,
-                kvkId: result.kvkId,
-            }, user);
-        }
-        return decorate(result, user);
+        await attachments.attach(result, attachmentIds, user);
+        return attachments.decorate(result, user);
     },
     findAll: async (filters, user) => {
         const rows = await raweFetRepository.findAll(filters, user);
-        if (!Array.isArray(rows)) return rows;
-        return Promise.all(rows.map((r) => decorate(r, user)));
+        return attachments.decorateMany(rows, user);
     },
     findById: async (id, user) => {
         const record = await raweFetRepository.findById(id, user);
         if (!record) throw new Error('Record not found');
-        return decorate(record, user);
+        return attachments.decorate(record, user);
     },
     update: async (id, data, user) => {
-        const { payload, attachmentIds } = stripAttachmentIds(data);
+        const { payload, attachmentIds } = attachments.strip(data);
         const existing = await raweFetRepository.findById(id, user);
         const result = await raweFetRepository.update(id, payload, user);
-        const recordId = result?.raweProgrammeId ?? Number(id);
-        const kvkId = result?.kvkId ?? existing?.kvkId;
-        if (attachmentIds.length > 0 && recordId && kvkId) {
-            await formAttachmentService.attachToRecord({
-                attachmentIds,
-                formCode: FORM_CODE,
-                recordId,
-                kvkId,
-            }, user);
-        }
-        return decorate(result, user);
+        await attachments.attach(result ?? existing, attachmentIds, user);
+        return attachments.decorate(result, user);
     },
     delete: async (id, user) => {
         const existing = await raweFetRepository.findById(id, user);
         const result = await raweFetRepository.delete(id, user);
-        if (existing?.raweProgrammeId && existing?.kvkId) {
-            try {
-                await formAttachmentService.deleteManyByRecord({
-                    formCode: FORM_CODE,
-                    recordId: existing.raweProgrammeId,
-                    kvkId: existing.kvkId,
-                }, user);
-            } catch { /* best-effort */ }
-        }
+        await attachments.cleanup(existing, user);
         return result;
     },
     findAllAttachmentTypes: async () => raweFetRepository.findAllAttachmentTypes(),

--- a/frontend/src/components/common/FormAttachmentSection.tsx
+++ b/frontend/src/components/common/FormAttachmentSection.tsx
@@ -9,7 +9,7 @@ export interface FormAttachmentSectionProps {
     formCode: string
     kind: FormAttachmentKind
     kvkId?: number | null
-    recordId?: number | null
+    recordId?: string | number | null
     showCaption?: boolean
     helperText?: string
     initialAttachments?: FormAttachmentRow[]

--- a/frontend/src/components/common/MultiAttachmentUploader.tsx
+++ b/frontend/src/components/common/MultiAttachmentUploader.tsx
@@ -27,7 +27,7 @@ export interface MultiAttachmentUploaderProps {
     formCode: string
     kind: FormAttachmentKind
     kvkId: number
-    recordId?: number | null
+    recordId?: string | number | null
     attachments: FormAttachmentRow[]
     accept?: string
     maxBytes?: number
@@ -53,7 +53,7 @@ async function uploadOne(input: {
     formCode: string
     kind: FormAttachmentKind
     kvkId: number
-    recordId: number | null
+    recordId: string | number | null
     sortOrder: number
     reportingYearDate: string | null
 }): Promise<FormAttachmentRow> {

--- a/frontend/src/hooks/useFormAttachments.ts
+++ b/frontend/src/hooks/useFormAttachments.ts
@@ -8,12 +8,16 @@ import {
     type GalleryFilters,
 } from '@/services/formAttachmentsApi'
 
-const recordKey = (formCode: string, recordId: number | null | undefined, kvkId?: number, kind?: FormAttachmentKind) =>
-    ['form-attachments', formCode, recordId ?? null, kvkId ?? null, kind ?? null] as const
+const recordKey = (
+    formCode: string,
+    recordId: string | number | null | undefined,
+    kvkId?: number,
+    kind?: FormAttachmentKind,
+) => ['form-attachments', formCode, recordId ?? null, kvkId ?? null, kind ?? null] as const
 
 export function useFormAttachments(params: {
     formCode: string
-    recordId?: number | null
+    recordId?: string | number | null
     kvkId?: number
     kind?: FormAttachmentKind
     enabled?: boolean
@@ -35,7 +39,7 @@ export function useUploadAttachment() {
             formCode: string
             kind: FormAttachmentKind
             kvkId: number
-            recordId?: number | null
+            recordId?: string | number | null
             caption?: string | null
             sortOrder?: number
             reportingYearDate?: string | null

--- a/frontend/src/hooks/useFormAttachmentsField.ts
+++ b/frontend/src/hooks/useFormAttachmentsField.ts
@@ -7,7 +7,7 @@ interface Params {
     formCode: string
     kind: FormAttachmentKind
     kvkId?: number | null
-    recordId?: number | null
+    recordId?: string | number | null
     initialAttachments?: FormAttachmentRow[]
 }
 

--- a/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
@@ -5,7 +5,6 @@ import { FormInput, FormSelect, FormTextArea, FormSection } from './shared/FormC
 import { State, District, Organization, University } from '@/types/masterData'
 import { useMasterData } from '@/hooks/useMasterData'
 import { useAuth } from '@/contexts/AuthContext'
-import { X } from 'lucide-react'
 import {
     useSanctionedPosts,
     useInfraMasters,
@@ -17,6 +16,7 @@ import {
     AccountTypeEnum
 } from '@/hooks/forms/useAboutKvkData'
 import { useStaffCategories, usePayLevels, usePayScales, useDisciplines, useFundingSources, useAssetFundingSources, useEquipmentTypes, useEquipmentMasters } from '@/hooks/useOtherMastersData'
+import { FormAttachmentSection } from '@/components/common/FormAttachmentSection'
 import { DependentDropdown } from '@/components/common/DependentDropdown'
 import { masterDataApi } from '@/services/masterDataApi'
 import { useUniversityHostFields } from '@/hooks/useUniversityHostFields'
@@ -366,89 +366,18 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 placeholder="Resume link"
                             />
                         </div>
-                        <FormSection title="Staff Photos" className="mt-2" noGrid={true}>
-                            <FormInput
-                                label=""
-                                type="file"
-                                multiple
-                                accept="image/*"
-                                onChange={(e: any) => {
-                                    const files = e.target.files;
-                                    if (!files || files.length === 0) return;
-                                    const readers: Promise<any>[] = Array.from(files).map((file) => {
-                                        return new Promise((resolve) => {
-                                            const reader = new FileReader();
-                                            reader.onloadend = () => {
-                                                resolve({
-                                                    preview: reader.result as string,
-                                                    image: reader.result as string,
-                                                    caption: ''
-                                                });
-                                            };
-                                            reader.readAsDataURL(file as unknown as Blob);
-                                        });
-                                    });
-
-                                    Promise.all(readers).then((newPhotos) => {
-                                        setFormData((prev: any) => {
-                                            const currentPhotos = Array.isArray(prev.photoPath) ? [...prev.photoPath] : [];
-                                            return { ...prev, photoPath: [...currentPhotos, ...newPhotos] };
-                                        });
-                                    });
-                                }}
-                                helperText="Only images allowed. Uploading new files will be added to the list. Only the first image uploaded will appear in the table. (Max 2MB per file)"
-                            />
-
-                            {/* Existing photo gallery rendering */}
-                            {Array.isArray(formData.photoPath) && formData.photoPath.length > 0 && (
-                                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mt-4">
-                                    {formData.photoPath.map((item: any, idx: number) => {
-                                        const src = item.preview || (typeof item.image === 'string' ? (item.image.startsWith('data:') || item.image.startsWith('http') ? item.image : `${import.meta.env.VITE_API_URL || ''}${item.image.startsWith('/') ? '' : '/'}${item.image}`) : '');
-                                        return (
-                                            <div key={idx} className="relative bg-white border border-gray-200 rounded-xl p-2 shadow-sm flex flex-col group">
-                                                <div className="relative aspect-square mb-2 overflow-hidden rounded-lg border border-gray-50">
-                                                    <img
-                                                        src={src}
-                                                        className="w-full h-full object-cover transition-transform group-hover:scale-105"
-                                                        alt={`Staff ${idx + 1}`}
-                                                    />
-                                                    <button
-                                                        type="button"
-                                                        onClick={() => {
-                                                            setFormData((prev: any) => {
-                                                                const photos = [...(Array.isArray(prev.photoPath) ? prev.photoPath : [])];
-                                                                photos.splice(idx, 1);
-                                                                return { ...prev, photoPath: photos.length > 0 ? photos : null };
-                                                            });
-                                                        }}
-                                                        className="absolute top-1 right-1 p-1 bg-red-500 text-white rounded-full shadow-lg hover:bg-red-600 transition-colors z-10 scale-90"
-                                                    >
-                                                        <X className="w-3 h-3 stroke-[2.5]" />
-                                                    </button>
-                                                </div>
-                                                <div className="space-y-1 mt-auto">
-                                                    <textarea
-                                                        placeholder="Caption..."
-                                                        className="w-full text-[12px] font-medium bg-gray-50/50 border border-gray-100 rounded-md focus:bg-white focus:ring-1 focus:ring-green-200 px-2 py-1.5 outline-none transition-all placeholder:text-gray-400 text-gray-700 min-h-[3.5rem] resize-none"
-                                                        value={item.caption || ''}
-                                                        onChange={(e) => {
-                                                            setFormData((prev: any) => {
-                                                                const photos = [...(Array.isArray(prev.photoPath) ? prev.photoPath : [])];
-                                                                if (photos[idx]) {
-                                                                    photos[idx] = { ...photos[idx], caption: e.target.value };
-                                                                }
-                                                                return { ...prev, photoPath: photos };
-                                                            });
-                                                        }}
-                                                        rows={3}
-                                                    />
-                                                </div>
-                                            </div>
-                                        );
-                                    })}
-                                </div>
-                            )}
-                        </FormSection>
+                        <FormAttachmentSection
+                            title="Staff Photos"
+                            formCode="kvk_staff"
+                            kind="PHOTO"
+                            kvkId={formData.kvkId ?? null}
+                            recordId={formData.kvkStaffId ?? formData.id ?? null}
+                            showCaption
+                            initialAttachments={formData?.photos}
+                            onAttachmentIdsChange={(ids) =>
+                                setFormData((prev: any) => ({ ...prev, attachmentIds: ids }))
+                            }
+                        />
                     </FormSection>
 
                     <FormSection title="Job Details">

--- a/frontend/src/pages/dashboard/shared/forms/AwardRecognitionForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/AwardRecognitionForms.tsx
@@ -1,13 +1,15 @@
 import React, { useMemo, useCallback, useEffect } from 'react'
-import { X } from 'lucide-react'
 import { ENTITY_TYPES } from '@/constants/entityConstants'
 import { ExtendedEntityType } from '@/utils/masterUtils'
-import { FormInput, FormSection } from './shared/FormComponents'
+import { FormInput } from './shared/FormComponents'
 import { MasterDataDropdown } from '@/components/common/MasterDataDropdown'
 import { useAuth } from '@/contexts/AuthContext'
 import { useKvkEmployees } from '@/hooks/forms/useAboutKvkData'
 import { createStaffOptions } from '@/utils/formHelpers'
 import { cleanIndianMobileInput } from '@/utils/indianPhone'
+import { FormAttachmentSection } from '@/components/common/FormAttachmentSection'
+
+const FARMER_AWARD_FORM_CODE = 'farmer_award'
 
 interface AwardRecognitionProps {
     entityType: ExtendedEntityType | null
@@ -148,147 +150,23 @@ export const AwardRecognition: React.FC<AwardRecognitionProps> = ({
         [setFormData]
     )
 
-    const handleFileChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-        const files = e.target.files;
-        if (files && files.length > 0) {
-            const newFiles = Array.from(files);
-            const previews: string[] = [];
-            let count = 0;
+    const handleAttachmentIds = useCallback(
+        (ids: number[]) => setFormData((prev: any) => ({ ...prev, attachmentIds: ids })),
+        [setFormData],
+    )
 
-            newFiles.forEach((file, index) => {
-                const reader = new FileReader();
-                reader.onloadend = () => {
-                    previews[index] = reader.result as string;
-                    count++;
-                    if (count === newFiles.length) {
-                        const existingPhotos = Array.isArray(formData[field]) ? formData[field] : [];
-                        setFormData((prev: any) => ({
-                            ...prev,
-                            [field]: [
-                                ...existingPhotos,
-                                ...newFiles.map((f, i) => ({
-                                    file: f,
-                                    preview: previews[i],
-                                    image: previews[i],
-                                    caption: ''
-                                }))
-                            ]
-                        }));
-                    }
-                };
-                reader.readAsDataURL(file);
-            });
-        }
-    };
-
-    const removePhoto = (field: string, index: number) => {
-        const photos = [...(Array.isArray(formData[field]) ? formData[field] : [])];
-        photos.splice(index, 1);
-        setFormData((prev: any) => ({ ...prev, [field]: photos }));
-    };
-
-    const updateCaption = (field: string, index: number, caption: string) => {
-        const photos = [...(Array.isArray(formData[field]) ? formData[field] : [])];
-        if (photos[index]) {
-            photos[index] = { ...photos[index], caption };
-            setFormData((prev: any) => ({ ...prev, [field]: photos }));
-        }
-    };
-
-    const renderPhotoFields = (field: string) => (
-        <FormSection title="Photographs" className="col-span-1 mt-2" noGrid={true}>
-            <FormInput
-                label=""
-                required={!Array.isArray(formData[field]) || formData[field].length === 0}
-                type="file"
-                multiple
-                accept="image/*"
-                onChange={handleFileChange(field)}
-                helperText="Only images allowed. Uploading new files will be added to the list. Only the first image uploaded will appear in the table. (Max 5MB per file)"
-            />
-
-            {Array.isArray(formData[field]) && formData[field].length > 0 && (
-                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mt-4">
-                    {formData[field].map((item: any, idx: number) => {
-                        const src = item.preview || (typeof item.image === 'string' ? (item.image.startsWith('data:') || item.image.startsWith('http') ? item.image : `${import.meta.env.VITE_API_URL || ''}${item.image.startsWith('/') ? '' : '/'}${item.image}`) : '');
-                        return (
-                            <div key={idx} className="relative bg-white border border-gray-200 rounded-xl p-2 shadow-sm flex flex-col group">
-                                <div className="relative aspect-square mb-2 overflow-hidden rounded-lg border border-gray-50">
-                                    <img
-                                        src={src}
-                                        className="w-full h-full object-cover transition-transform group-hover:scale-105"
-                                        alt={`P ${idx + 1}`}
-                                    />
-                                    <button
-                                        type="button"
-                                        onClick={() => removePhoto(field, idx)}
-                                        className="absolute top-1 right-1 p-1 bg-red-500 text-white rounded-full shadow-lg hover:bg-red-600 transition-colors z-10 scale-90"
-                                    >
-                                        <X className="w-3 h-3 stroke-[2.5]" />
-                                    </button>
-                                </div>
-                                <div className="space-y-1 mt-auto">
-                                    <textarea
-                                        placeholder="Caption..."
-                                        className="w-full text-[11px] font-bold bg-transparent border-none focus:ring-0 px-1 py-0 outline-none transition-all placeholder:text-gray-300 text-gray-700 min-h-[2.5rem] resize-none"
-                                        value={item.caption || ''}
-                                        onChange={(e) => updateCaption(field, idx, e.target.value)}
-                                        rows={2}
-                                    />
-                                </div>
-                            </div>
-                        );
-                    })}
-                </div>
-            )}
-        </FormSection>
-    );
-
-    // Normalize incoming photographs data when editing
-    useEffect(() => {
-        // Only normalize if we are editing an existing record and have an ID
-        if (!formData.id) return;
-
-        const photoFields = ['photographs', 'image'];
-        let hasChanges = false;
-        const newData = { ...formData };
-
-        photoFields.forEach(field => {
-            const rawValue = formData[field];
-            if (rawValue && typeof rawValue === 'string') {
-                if (rawValue.startsWith('[') || rawValue.startsWith('{')) {
-                    try {
-                        const parsed = JSON.parse(rawValue);
-                        const arrayToMap = Array.isArray(parsed) ? parsed : [parsed];
-                        newData[field] = arrayToMap
-                            .filter((item: any) => item && (typeof item === 'string' || item.image || item.preview || item.url))
-                            .map((item: any) => {
-                                if (typeof item === 'string') return { preview: item, image: item, caption: '' };
-                                const url = item.image || item.url || item.path || item.preview || '';
-                                return { preview: url, image: url, caption: item.caption || '' };
-                            });
-                        hasChanges = true;
-                    } catch (e) {
-                        console.error('Photo parsing error:', e);
-                    }
-                } else if (rawValue.trim() !== '' && !rawValue.includes('object Object')) {
-                    const values = rawValue.includes(',') ? rawValue.split(',') : [rawValue];
-                    newData[field] = values
-                        .filter((v: string) => v && v.trim() !== '')
-                        .map((s: string) => ({
-                            preview: s.trim(),
-                            image: s.trim(),
-                            caption: ''
-                        }));
-                    hasChanges = true;
-                }
-            }
-        });
-
-        if (hasChanges) {
-            setFormData(newData);
-        }
-    }, [formData.id, formData.entityType, setFormData]); // Only depend on identity change
+    const renderFarmerAwardPhotos = () => (
+        <FormAttachmentSection
+            title="Photographs"
+            formCode={FARMER_AWARD_FORM_CODE}
+            kind="PHOTO"
+            kvkId={formData.kvkId ?? null}
+            recordId={formData.farmerAwardId ?? formData.id ?? null}
+            showCaption
+            initialAttachments={formData?.photos}
+            onAttachmentIdsChange={handleAttachmentIds}
+        />
+    )
 
     if (!entityType) return null
 
@@ -440,7 +318,7 @@ export const AwardRecognition: React.FC<AwardRecognitionProps> = ({
                             value={formData.conferringAuthority ?? ''}
                             onChange={handleConferringAuthorityChange}
                         />
-                        {renderPhotoFields('image')}
+                        {renderFarmerAwardPhotos()}
                     </div>
                 </div>
             )}

--- a/frontend/src/pages/dashboard/shared/forms/meetings/MeetingForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/meetings/MeetingForms.tsx
@@ -1,11 +1,13 @@
 import React, { useCallback, useMemo } from 'react'
 import { ENTITY_TYPES } from '@/constants/entityConstants'
 import { ExtendedEntityType } from '@/utils/masterUtils'
-import { FormInput, FormTextArea, FormSelect, FormSection } from '../shared/FormComponents'
+import { FormInput, FormTextArea, FormSelect } from '../shared/FormComponents'
 import { useYears } from '@/hooks/useOtherMastersData'
 import { MasterDataDropdown } from '@/components/common/MasterDataDropdown'
 import { createMasterDataOptions } from '@/utils/formHelpers'
-import { X } from 'lucide-react'
+import { FormAttachmentSection } from '@/components/common/FormAttachmentSection'
+
+const SAC_FORM_CODE = 'sac_meeting'
 
 interface MeetingFormsProps {
     entityType: ExtendedEntityType | null
@@ -62,190 +64,30 @@ export const MeetingForms: React.FC<MeetingFormsProps> = ({
         [formData, setFormData]
     )
 
-    const handleFileChange = useCallback(
-        (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-            const files = e.target.files;
-            if (files && files.length > 0) {
-                // Strict image-only validation for SAC meetings section if applicable
-                if (entityType === ENTITY_TYPES.MISC_MEETINGS_SAC) {
-                    const hasNonImage = Array.from(files).some(file => !file.type.startsWith('image/'));
-                    if (hasNonImage) {
-                        alert('Only image files are allowed for SAC meetings.');
-                        e.target.value = ''; // Reset input
-                        return;
-                    }
-                }
-
-                const newFiles = Array.from(files);
-                const processedPhotos: any[] = [];
-                let processedCount = 0;
-
-                newFiles.forEach((file) => {
-                    const reader = new FileReader();
-                    reader.onload = (event) => {
-                        const img = new Image();
-                        img.onload = () => {
-                            // COMPRESS IMAGE: Max width/height 1280px
-                            const canvas = document.createElement('canvas');
-                            let width = img.width;
-                            let height = img.height;
-                            const MAX_SIZE = 1280;
-                            
-                            if (width > height && width > MAX_SIZE) {
-                                height *= MAX_SIZE / width;
-                                width = MAX_SIZE;
-                            } else if (height > MAX_SIZE) {
-                                width *= MAX_SIZE / height;
-                                height = MAX_SIZE;
-                            }
-                            
-                            canvas.width = width;
-                            canvas.height = height;
-                            const ctx = canvas.getContext('2d');
-                            ctx?.drawImage(img, 0, 0, width, height);
-                            
-                            // Convert to JPEG at 0.7 quality
-                            const compressedBase64 = canvas.toDataURL('image/jpeg', 0.7);
-                            
-                            processedPhotos.push({
-                                file: null, // No need for raw File anymore
-                                preview: compressedBase64,
-                                image: compressedBase64,
-                                caption: ''
-                            });
-
-                            processedCount++;
-                            if (processedCount === newFiles.length) {
-                                const existingPhotos = Array.isArray(formData[field]) ? formData[field] : [];
-                                setFormData({
-                                    ...formData,
-                                    [field]: [...existingPhotos, ...processedPhotos]
-                                });
-                            }
-                        };
-                        img.src = event.target?.result as string;
-                    };
-                    reader.readAsDataURL(file);
-                });
-            }
-        },
-        [formData, setFormData, entityType]
+    const formDataRef = React.useRef(formData)
+    React.useEffect(() => {
+        formDataRef.current = formData
+    })
+    const handleAttachmentIds = useCallback(
+        (ids: number[]) => setFormData({ ...formDataRef.current, attachmentIds: ids }),
+        [setFormData],
     )
 
-    const removePhoto = (field: string, index: number) => {
-        const existingPhotos = Array.isArray(formData[field]) ? [...formData[field]] : [];
-        existingPhotos.splice(index, 1);
-        setFormData({
-            ...formData,
-            [field]: existingPhotos
-        });
-    };
+    const recordId = formData?.sacMeetingId ?? formData?.id ?? null
+    const kvkId = formData?.kvkId ?? null
 
-    const updateCaption = (field: string, index: number, caption: string) => {
-        const existingPhotos = Array.isArray(formData[field]) ? [...formData[field]] : [];
-        if (existingPhotos[index]) {
-            existingPhotos[index] = { ...existingPhotos[index], caption };
-            setFormData({
-                ...formData,
-                [field]: existingPhotos
-            });
-        }
-    };
-
-    const renderPhotoFields = (field: string) => (
-        <FormSection title="Photographs" className="col-span-1 mt-2" noGrid={true}>
-            <FormInput
-                label=""
-                required={!Array.isArray(formData[field]) || formData[field].length === 0}
-                type="file"
-                multiple
-                accept="image/*"
-                onChange={handleFileChange(field)}
-                helperText="Only images allowed. Uploading new files will be added to the list. Only the first image uploaded will appear in the table. (Max 5MB per file)"
-            />
-
-            {Array.isArray(formData[field]) && formData[field].length > 0 && (
-                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mt-4">
-                    {formData[field].map((item: any, idx: number) => {
-                        const src = item.preview || (typeof item.image === 'string' ? (item.image.startsWith('data:') || item.image.startsWith('http') ? item.image : `${import.meta.env.VITE_API_URL || ''}${item.image.startsWith('/') ? '' : '/'}${item.image}`) : '');
-                        return (
-                            <div key={idx} className="relative bg-white border border-gray-200 rounded-xl p-2 shadow-sm flex flex-col group">
-                                <div className="relative aspect-square mb-2 overflow-hidden rounded-lg border border-gray-50">
-                                    <img
-                                        src={src}
-                                        className="w-full h-full object-cover transition-transform group-hover:scale-105"
-                                        alt={`P ${idx + 1}`}
-                                    />
-                                    <button
-                                        type="button"
-                                        onClick={() => removePhoto(field, idx)}
-                                        className="absolute top-1 right-1 p-1 bg-red-500 text-white rounded-full shadow-lg hover:bg-red-600 transition-colors z-10 scale-90"
-                                    >
-                                        <X className="w-3 h-3 stroke-[2.5]" />
-                                    </button>
-                                </div>
-                                <div className="space-y-1 mt-auto">
-                                    <textarea
-                                        placeholder="Caption..."
-                                        className="w-full text-[11px] font-bold bg-transparent border-none focus:ring-0 px-1 py-0 outline-none transition-all placeholder:text-gray-300 text-gray-700 min-h-[2.5rem] resize-none"
-                                        value={item.caption || ''}
-                                        onChange={(e) => updateCaption(field, idx, e.target.value)}
-                                        rows={2}
-                                    />
-                                </div>
-                            </div>
-                        );
-                    })}
-                </div>
-            )}
-        </FormSection>
-    );
-
-    // Normalize incoming photographs data when editing
-    React.useEffect(() => {
-        // SAC Meetings use sacMeetingId
-        if (!formData.id && !formData.sacMeetingId) return;
-
-        const photoFields = ['uploadedFile'];
-        let hasChanges = false;
-        const newData = { ...formData };
-
-        photoFields.forEach(field => {
-            const rawValue = formData[field];
-            if (rawValue && typeof rawValue === 'string') {
-                if (rawValue.startsWith('[') || rawValue.startsWith('{')) {
-                    try {
-                        const parsed = JSON.parse(rawValue);
-                        const arrayToMap = Array.isArray(parsed) ? parsed : [parsed];
-                        newData[field] = arrayToMap
-                            .filter((item: any) => item && (typeof item === 'string' || item.image || item.preview || item.url || item.file))
-                            .map((item: any) => {
-                                if (typeof item === 'string') return { preview: item, image: item, caption: '' };
-                                const url = item.image || item.file || item.url || item.path || item.preview || '';
-                                return { preview: url, image: url, caption: item.caption || '' };
-                            });
-                        hasChanges = true;
-                    } catch (e) {
-                        console.error('Photo parsing error:', e);
-                    }
-                } else if (rawValue.trim() !== '') {
-                    const values = rawValue.includes(',') ? rawValue.split(',') : [rawValue];
-                    newData[field] = values
-                        .filter((v: string) => v && v.trim() !== '')
-                        .map((s: string) => ({
-                            preview: s.trim(),
-                            image: s.trim(),
-                            caption: ''
-                        }));
-                    hasChanges = true;
-                }
-            }
-        });
-
-        if (hasChanges) {
-            setFormData(newData);
-        }
-    }, [formData.id, formData.sacMeetingId, formData.entityType, setFormData]);
+    const renderPhotoFields = () => (
+        <FormAttachmentSection
+            title="Photographs"
+            formCode={SAC_FORM_CODE}
+            kind="PHOTO"
+            kvkId={kvkId}
+            recordId={recordId}
+            showCaption
+            initialAttachments={formData?.photos}
+            onAttachmentIdsChange={handleAttachmentIds}
+        />
+    )
 
     if (!entityType) return null
 
@@ -335,7 +177,7 @@ export const MeetingForms: React.FC<MeetingFormsProps> = ({
                                 placeholder="Select"
                             />
 
-                            {renderPhotoFields('uploadedFile')}
+                            {renderPhotoFields()}
                         </div>
                     </div>
                 </div>

--- a/frontend/src/services/formAttachmentsApi.ts
+++ b/frontend/src/services/formAttachmentsApi.ts
@@ -6,7 +6,7 @@ export interface FormAttachmentRow {
     attachmentId: number
     kvkId: number
     formCode: string
-    recordId: number | null
+    recordId: string | null
     kind: FormAttachmentKind
     s3Key: string
     fileName: string | null
@@ -35,7 +35,7 @@ export interface ConfirmUploadInput {
     s3Key: string
     formCode: string
     kind: FormAttachmentKind
-    recordId?: number | null
+    recordId?: string | number | null
     kvkId: number
     fileName: string
     mimeType: string
@@ -88,10 +88,10 @@ export const formAttachmentsApi = {
     confirm: (body: ConfirmUploadInput) =>
         apiClient.post<FormAttachmentRow>(`${BASE}/confirm`, body),
 
-    attach: (body: { attachmentIds: number[]; formCode: string; recordId: number; kvkId: number }) =>
+    attach: (body: { attachmentIds: number[]; formCode: string; recordId: string | number; kvkId: number }) =>
         apiClient.post<{ count: number }>(`${BASE}/attach`, body),
 
-    listByRecord: (params: { formCode: string; recordId?: number | null; kvkId?: number; kind?: FormAttachmentKind }) => {
+    listByRecord: (params: { formCode: string; recordId?: string | number | null; kvkId?: number; kind?: FormAttachmentKind }) => {
         const qs = new URLSearchParams()
         Object.entries(params).forEach(([k, v]) => {
             if (v !== undefined && v !== null && v !== '') qs.set(k, String(v))


### PR DESCRIPTION
**Stacked on PR #149.** Will retarget to \`dev\` once PR-A merges.

## Summary
Three more forms moved off base64. Adds the reusable backend binding helper so each future form is only ~6 lines of plumbing. Widens \`form_attachments.record_id\` to \`TEXT\` so UUID-keyed forms (FarmerAward, SuccessStory) work too.

### Reusable backend helper
- \`backend/services/forms/formAttachmentBinding.js\` exports \`createAttachmentBinding({ formCode, primaryKey })\` returning \`{ strip, attach, decorate, decorateMany, cleanup }\`.
- \`oftService\`, \`aryaCurrentYearService\`, \`raweFetService\` refactored onto the binding (same behaviour, less code).

### Schema migration
- \`20260428100000_form_attachment_record_id_to_text\` — \`ALTER COLUMN record_id TYPE TEXT USING ::text\`. Idempotent for replay.
- Frontend types (\`recordId\`) widened to \`string | number | null\` across api / hook / section / uploader.

### Forms migrated in PR-B
| Form | Form code | Kind | Frontend | Backend service |
|---|---|---|---|---|
| SAC Meetings | \`sac_meeting\` | PHOTO | meetings/MeetingForms.tsx | meetingsService.sac.* |
| Award Recognition (Farmer) | \`farmer_award\` | PHOTO | AwardRecognitionForms.tsx | farmerAwardService |
| KVK Staff Photos | \`kvk_staff\` | PHOTO | AboutKvkForms.tsx | aboutKvkService (kvk-employees / kvk-staff-transferred) |

### Inventory progress
- ✅ OFT Result, ARYA Current Year, RAWE FET (PR-A)
- ✅ SAC Meetings, Farmer Award, KVK Staff (PR-B — this)
- 🔜 NICRA × 6 (PR-C)
- 🔜 CFLD + Natural Farming × 4 (PR-D)
- 🔜 PPV FRA + Success Stories (PR-E)

## Test plan
- [ ] DB push: confirm \`form_attachments.record_id\` is now \`text\`. Existing rows with \`recordId='1'\` etc. still readable.
- [ ] SAC Meeting: create with 3 photos → saved with \`form_code='sac_meeting'\`, recordId = \`sacMeetingId\` (string).
- [ ] Farmer Award: edit, upload 2 photos → linked with \`form_code='farmer_award'\`, recordId = farmerAward UUID.
- [ ] KVK Staff (Employees): add a staff member with photo → \`kvk_staff\` rows with \`recordId = kvkStaffId\` (string).
- [ ] Delete each — its FormAttachment rows + S3 objects clean up.
- [ ] OFT, ARYA, RAWE flows still work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)