### PR TITLE
feat(s3-migration) PR-D: CFLD Technical + Natural Farming × 3

### DIFF
--- a/backend/services/forms/cfldTechnicalParameterService.js
+++ b/backend/services/forms/cfldTechnicalParameterService.js
@@ -2,6 +2,53 @@ const cfldTechnicalParameterRepository = require('../../repositories/forms/cfldT
 const prisma = require('../../config/prisma.js');
 const { ValidationError, NotFoundError, UnauthorizedError } = require('../../utils/errorHandler.js');
 const reportCacheInvalidationService = require('../reports/reportCacheInvalidationService.js');
+const { createAttachmentBinding } = require('./formAttachmentBinding.js');
+
+const trainingAttachments = createAttachmentBinding({
+    formCode: 'cfld_technical_training',
+    primaryKey: 'cfldTechId',
+});
+const actionAttachments = createAttachmentBinding({
+    formCode: 'cfld_technical_action',
+    primaryKey: 'cfldTechId',
+});
+
+function stripBoth(data) {
+    if (!data || typeof data !== 'object') return { payload: data, training: [], action: [] };
+    const { trainingAttachmentIds, actionAttachmentIds, ...rest } = data;
+    return {
+        payload: rest,
+        training: Array.isArray(trainingAttachmentIds) ? trainingAttachmentIds : [],
+        action: Array.isArray(actionAttachmentIds) ? actionAttachmentIds : [],
+    };
+}
+
+async function attachBoth(record, training, action, user) {
+    if (!record) return;
+    await trainingAttachments.attach(record, training, user);
+    await actionAttachments.attach(record, action, user);
+}
+
+async function decorateBoth(record, user) {
+    if (!record) return record;
+    const withTraining = await trainingAttachments.decorate(record, user);
+    const withAction = await actionAttachments.decorate(withTraining, user);
+    // decorate() returns photos/datasheets/documents grouped by kind. Rename
+    // to keep training/action distinction in the response.
+    const trainingList = await trainingAttachments.decorate(record, user);
+    const actionList = await actionAttachments.decorate(record, user);
+    return {
+        ...withAction,
+        trainingPhotos: trainingList.photos || [],
+        actionPhotos: actionList.photos || [],
+    };
+}
+
+async function cleanupBoth(record, user) {
+    if (!record) return;
+    await trainingAttachments.cleanup(record, user);
+    await actionAttachments.cleanup(record, user);
+}
 
 const TRANSACTION_OPTIONS = {
     maxWait: 5000,
@@ -19,26 +66,37 @@ function assertKvkRecordAccess(record, user) {
 
 const cfldTechnicalParameterService = {
     create: async (data, user) => {
-        const result = await cfldTechnicalParameterRepository.create(data, {}, user);
+        const { payload, training, action } = stripBoth(data);
+        const result = await cfldTechnicalParameterRepository.create(payload, {}, user);
+        await attachBoth(result, training, action, user);
         await invalidateCfldReportCache(result?.kvkId);
-        return result;
+        return decorateBoth(result, user);
     },
 
     findAll: async (filters, user) => {
-        return await cfldTechnicalParameterRepository.findAll(filters, user);
+        const rows = await cfldTechnicalParameterRepository.findAll(filters, user);
+        if (rows && Array.isArray(rows.data)) {
+            rows.data = await Promise.all(rows.data.map((r) => decorateBoth(r, user)));
+            return rows;
+        }
+        if (Array.isArray(rows)) return Promise.all(rows.map((r) => decorateBoth(r, user)));
+        return rows;
     },
 
-    findById: async (id) => {
-        return await cfldTechnicalParameterRepository.findById(id);
+    findById: async (id, user) => {
+        const record = await cfldTechnicalParameterRepository.findById(id);
+        return decorateBoth(record, user);
     },
 
     update: async (id, data, user) => {
+        const { payload, training, action } = stripBoth(data);
         const existing = await cfldTechnicalParameterRepository.findById(id);
         if (!existing) throw new NotFoundError('CFLD technical parameter');
         assertKvkRecordAccess(existing, user);
-        const result = await cfldTechnicalParameterRepository.update(id, data);
+        const result = await cfldTechnicalParameterRepository.update(id, payload);
+        await attachBoth(result ?? existing, training, action, user);
         await invalidateCfldReportCache(existing.kvkId);
-        return result;
+        return decorateBoth(result, user);
     },
 
     transferToNextYear: async (id, user) => {
@@ -200,6 +258,7 @@ const cfldTechnicalParameterService = {
         if (!existing) throw new NotFoundError('CFLD technical parameter');
         assertKvkRecordAccess(existing, user);
         const deleted = await cfldTechnicalParameterRepository.delete(id);
+        await cleanupBoth(existing, user);
         await invalidateCfldReportCache(existing.kvkId);
         return deleted;
     }

--- a/backend/services/forms/naturalFarmingService.js
+++ b/backend/services/forms/naturalFarmingService.js
@@ -8,105 +8,104 @@ const {
 } = require('../../repositories/forms/naturalFarmingRepository');
 const { farmersPracticingRepository } = require('../../repositories/forms/farmersPracticingRepository');
 const reportCacheInvalidationService = require('../reports/reportCacheInvalidationService.js');
+const { createAttachmentBinding, createAttachmentAwareCrud } = require('./formAttachmentBinding.js');
+
+const invalidate = (dataSource) => async (record, user) =>
+    reportCacheInvalidationService.invalidateDataSourceForKvk(
+        dataSource,
+        record?.kvkId || user?.kvkId,
+    );
+
+const physicalCrud = createAttachmentAwareCrud({
+    repo: physicalInfoRepository,
+    binding: createAttachmentBinding({ formCode: 'natural_farming_physical', primaryKey: 'physicalInfoId' }),
+});
+
+const demoCrud = createAttachmentAwareCrud({
+    repo: demonstrationInfoRepository,
+    binding: createAttachmentBinding({ formCode: 'natural_farming_demo', primaryKey: 'demonstrationInfoId' }),
+    onWrite: invalidate('naturalFarmingDemonstration'),
+});
+
+const farmersPracticingCrud = createAttachmentAwareCrud({
+    repo: farmersPracticingRepository,
+    binding: createAttachmentBinding({ formCode: 'natural_farming_farmers', primaryKey: 'farmersPracticingId' }),
+    onWrite: invalidate('naturalFarmingFarmersPracticing'),
+});
 
 const naturalFarmingService = {
-    // Geographical Info
+    // Geographical Info (no attachments)
     getAllGeo: (filters, user) => geographicalInfoRepository.findAll(filters, user),
     getGeoById: (id, user) => geographicalInfoRepository.findById(id, user),
     createGeo: (data, user) => geographicalInfoRepository.create(data, user),
     updateGeo: (id, data, user) => geographicalInfoRepository.update(id, data, user),
     deleteGeo: (id, user) => geographicalInfoRepository.delete(id, user),
 
-    // Physical Info
-    getAllPhysical: (filters, user) => physicalInfoRepository.findAll(filters, user),
-    getPhysicalById: (id, user) => physicalInfoRepository.findById(id, user),
-    createPhysical: (data, user) => physicalInfoRepository.create(data, user),
-    updatePhysical: (id, data, user) => physicalInfoRepository.update(id, data, user),
-    deletePhysical: (id, user) => physicalInfoRepository.delete(id, user),
+    // Physical Info — uses FormAttachment for photos
+    getAllPhysical: physicalCrud.findAll,
+    getPhysicalById: physicalCrud.findById,
+    createPhysical: physicalCrud.create,
+    updatePhysical: physicalCrud.update,
+    deletePhysical: physicalCrud.delete,
 
-    // Demonstration Info
-    getAllDemo: (filters, user) => demonstrationInfoRepository.findAll(filters, user),
-    getDemoById: (id, user) => demonstrationInfoRepository.findById(id, user),
-    createDemo: async (data, user) => {
-        const result = await demonstrationInfoRepository.create(data, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingDemonstration', result?.kvkId || user?.kvkId);
-        return result;
-    },
-    updateDemo: async (id, data, user) => {
-        const result = await demonstrationInfoRepository.update(id, data, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingDemonstration', result?.kvkId || user?.kvkId);
-        return result;
-    },
-    deleteDemo: async (id, user) => {
-        const existing = await demonstrationInfoRepository.findById(id, user);
-        const result = await demonstrationInfoRepository.delete(id, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingDemonstration', existing?.kvkId || user?.kvkId);
-        return result;
-    },
+    // Demonstration Info — uses FormAttachment for photos
+    getAllDemo: demoCrud.findAll,
+    getDemoById: demoCrud.findById,
+    createDemo: demoCrud.create,
+    updateDemo: demoCrud.update,
+    deleteDemo: demoCrud.delete,
 
-    // Farmers already practicing Natural Farming
-    getAllFarmersPracticing: (filters, user) => farmersPracticingRepository.findAll(filters, user),
-    getFarmersPracticingById: (id, user) => farmersPracticingRepository.findById(id, user),
-    createFarmersPracticing: async (data, user) => {
-        const result = await farmersPracticingRepository.create(data, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingFarmersPracticing', result?.kvkId || user?.kvkId);
-        return result;
-    },
-    updateFarmersPracticing: async (id, data, user) => {
-        const result = await farmersPracticingRepository.update(id, data, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingFarmersPracticing', result?.kvkId || user?.kvkId);
-        return result;
-    },
-    deleteFarmersPracticing: async (id, user) => {
-        const existing = await farmersPracticingRepository.findById(id, user);
-        await farmersPracticingRepository.delete(id, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingFarmersPracticing', existing?.kvkId || user?.kvkId);
-    },
+    // Farmers Practicing Natural Farming — uses FormAttachment for photos (UUID PK)
+    getAllFarmersPracticing: farmersPracticingCrud.findAll,
+    getFarmersPracticingById: farmersPracticingCrud.findById,
+    createFarmersPracticing: farmersPracticingCrud.create,
+    updateFarmersPracticing: farmersPracticingCrud.update,
+    deleteFarmersPracticing: farmersPracticingCrud.delete,
 
-    // Beneficiaries
+    // Beneficiaries (no attachments)
     getAllBeneficiaries: (filters, user) => beneficiariesRepository.findAll(filters, user),
     getBeneficiariesById: (id, user) => beneficiariesRepository.findById(id, user),
     createBeneficiaries: (data, user) => beneficiariesRepository.create(data, user),
     updateBeneficiaries: (id, data, user) => beneficiariesRepository.update(id, data, user),
     deleteBeneficiaries: (id, user) => beneficiariesRepository.delete(id, user),
 
-    // Soil Data
+    // Soil Data (no attachments)
     getAllSoil: (filters, user) => soilDataRepository.findAll(filters, user),
     getSoilById: (id, user) => soilDataRepository.findById(id, user),
     createSoil: async (data, user) => {
         const result = await soilDataRepository.create(data, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingSoilData', result?.kvkId || user?.kvkId);
+        await invalidate('naturalFarmingSoilData')(result, user);
         return result;
     },
     updateSoil: async (id, data, user) => {
         const result = await soilDataRepository.update(id, data, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingSoilData', result?.kvkId || user?.kvkId);
+        await invalidate('naturalFarmingSoilData')(result, user);
         return result;
     },
     deleteSoil: async (id, user) => {
         const existing = await soilDataRepository.findById(id, user);
         const result = await soilDataRepository.delete(id, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingSoilData', existing?.kvkId || user?.kvkId);
+        await invalidate('naturalFarmingSoilData')(existing, user);
         return result;
     },
 
-    // Financial Info (Budget)
+    // Financial Info (Budget) (no attachments)
     getAllFinancial: (filters, user) => financialInfoRepository.findAll(filters, user),
     getFinancialById: (id, user) => financialInfoRepository.findById(id, user),
     createFinancial: async (data, user) => {
         const result = await financialInfoRepository.create(data, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingBudgetExpenditure', result?.kvkId || user?.kvkId);
+        await invalidate('naturalFarmingBudgetExpenditure')(result, user);
         return result;
     },
     updateFinancial: async (id, data, user) => {
         const result = await financialInfoRepository.update(id, data, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingBudgetExpenditure', result?.kvkId || user?.kvkId);
+        await invalidate('naturalFarmingBudgetExpenditure')(result, user);
         return result;
     },
     deleteFinancial: async (id, user) => {
         const existing = await financialInfoRepository.findById(id, user);
         const result = await financialInfoRepository.delete(id, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk('naturalFarmingBudgetExpenditure', existing?.kvkId || user?.kvkId);
+        await invalidate('naturalFarmingBudgetExpenditure')(existing, user);
         return result;
     },
 };

--- a/frontend/src/pages/dashboard/shared/forms/projects/CfldForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/projects/CfldForms.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ChevronDown, X } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import { ENTITY_TYPES } from '@/constants/entityConstants';
 import { MONTHS } from '@/constants/monthConstants';
 import { FormInput, FormSelect, FormSection } from '../shared/FormComponents';
@@ -8,6 +8,7 @@ import { DependentDropdown } from '@/components/common/DependentDropdown';
 import { createMasterDataOptions } from '@/utils/formHelpers';
 import { useSeasons, useCropTypes, useCfldExtensionActivityTypes, useBudgetItems } from '@/hooks/useOtherMastersData';
 import { useCfldCrops } from '@/hooks/useOftFldData';
+import { FormAttachmentSection } from '@/components/common/FormAttachmentSection';
 import { calculatePercentIncrease } from '@/utils/cfldCalculations';
 
 interface CfldFormsProps {
@@ -425,72 +426,6 @@ export const CfldForms: React.FC<CfldFormsProps> = ({
         [handleFieldChange]
     );
 
-    const removePhoto = (field: string, index: number) => {
-        setFormData((prev: any) => {
-            const existingPhotos = Array.isArray(prev[field]) ? [...prev[field]] : []
-            existingPhotos.splice(index, 1)
-            return { ...prev, [field]: existingPhotos }
-        })
-    }
-
-    const updatePhotoCaption = (field: string, index: number, caption: string) => {
-        setFormData((prev: any) => {
-            const existingPhotos = Array.isArray(prev[field]) ? [...prev[field]] : []
-            if (existingPhotos[index]) {
-                existingPhotos[index] = { ...existingPhotos[index], caption }
-            }
-            return { ...prev, [field]: existingPhotos }
-        })
-    }
-
-    const renderPhotoFields = (field: string, label: string) => (
-        <div className="space-y-4">
-            <FormInput
-                label={label}
-                type="file"
-                multiple
-                accept="image/*"
-                onChange={handleFileChange(field, true)}
-                helperText="Only images allowed. Multiple uploads supported."
-            />
-
-            {Array.isArray(formData[field]) && formData[field].length > 0 && (
-                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mt-4">
-                    {formData[field].map((item: any, idx: number) => {
-                        const src = item.preview || (typeof item.image === 'string' ? (item.image.startsWith('data:') || item.image.startsWith('http') ? item.image : `${import.meta.env.VITE_API_URL || ''}${item.image.startsWith('/') ? '' : '/'}${item.image}`) : '');
-                        return (
-                            <div key={idx} className="relative bg-white border border-gray-200 rounded-xl p-2 shadow-sm flex flex-col group">
-                                <div className="relative aspect-square mb-2 overflow-hidden rounded-lg border border-gray-50">
-                                    <img
-                                        src={src}
-                                        className="w-full h-full object-cover transition-transform group-hover:scale-105"
-                                        alt={`${label} ${idx + 1}`}
-                                    />
-                                    <button
-                                        type="button"
-                                        onClick={() => removePhoto(field, idx)}
-                                        className="absolute top-1 right-1 p-1 bg-red-500 text-white rounded-full shadow-lg hover:bg-red-600 transition-colors z-10 scale-90"
-                                    >
-                                        <X className="w-3 h-3 stroke-[2.5]" />
-                                    </button>
-                                </div>
-                                <div className="space-y-1 mt-auto">
-                                    <textarea
-                                        placeholder="Caption..."
-                                        className="w-full text-[12px] font-medium bg-gray-50/50 border border-gray-100 rounded-md focus:bg-white focus:ring-1 focus:ring-green-200 px-2 py-1.5 outline-none transition-all placeholder:text-gray-400 text-gray-700 min-h-[3.5rem] resize-none"
-                                        value={item.caption || ''}
-                                        onChange={(e) => updatePhotoCaption(field, idx, e.target.value)}
-                                        rows={3}
-                                    />
-                                </div>
-                            </div>
-                        );
-                    })}
-                </div>
-            )}
-        </div>
-    );
-
     const setActiveSection = useCallback(
         (next: CfldSection) => {
             setCfldSection(next)
@@ -501,48 +436,6 @@ export const CfldForms: React.FC<CfldFormsProps> = ({
         },
         [setFormData]
     )
-
-    // File upload handlers
-    const handleFileChange = useCallback(
-        (field: string, multiple: boolean = false) => async (e: React.ChangeEvent<HTMLInputElement>) => {
-            const files = e.target.files;
-            if (!files || files.length === 0) return;
-
-            const convertToBase64 = (file: File): Promise<string> => {
-                return new Promise((resolve, reject) => {
-                    const reader = new FileReader();
-                    reader.readAsDataURL(file);
-                    reader.onload = () => resolve(reader.result as string);
-                    reader.onerror = error => reject(error);
-                });
-            };
-
-            try {
-                if (multiple) {
-                    const base64Files = await Promise.all(Array.from(files).map(convertToBase64));
-                    const newPhotos = base64Files.map(base64 => ({
-                        preview: base64,
-                        image: base64,
-                        caption: ''
-                    }));
-
-                    setFormData((prev: any) => {
-                        const existingPhotos = Array.isArray(prev[field]) ? [...prev[field]] : [];
-                        return { 
-                            ...prev, 
-                            [field]: [...existingPhotos, ...newPhotos] 
-                        };
-                    });
-                } else {
-                    const base64 = await convertToBase64(files[0]);
-                    setFormData((prev: any) => ({ ...prev, [field]: base64 }));
-                }
-            } catch (error) {
-                console.error("Error converting files down to base64:", error);
-            }
-        },
-        [setFormData]
-    );
 
     const renderEconomicParametersForm = () => (
         <div className="space-y-8">
@@ -886,8 +779,30 @@ export const CfldForms: React.FC<CfldFormsProps> = ({
                     />
                 </div>
                 <div className="col-span-2 grid grid-cols-1 md:grid-cols-2 gap-6 mt-4">
-                    {renderPhotoFields('trainingPhotos', "Farmers' training photographs")}
-                    {renderPhotoFields('actionPhotos', "Quality Action Photographs of field visits/field days and technology demonstrated")}
+                    <FormAttachmentSection
+                        title="Farmers' Training Photographs"
+                        formCode="cfld_technical_training"
+                        kind="PHOTO"
+                        kvkId={formData.kvkId ?? null}
+                        recordId={formData.cfldTechId ?? formData.id ?? null}
+                        showCaption
+                        initialAttachments={formData?.trainingPhotos}
+                        onAttachmentIdsChange={(ids) =>
+                            setFormData((prev: any) => ({ ...prev, trainingAttachmentIds: ids }))
+                        }
+                    />
+                    <FormAttachmentSection
+                        title="Quality Action Photographs (field visits / technology demos)"
+                        formCode="cfld_technical_action"
+                        kind="PHOTO"
+                        kvkId={formData.kvkId ?? null}
+                        recordId={formData.cfldTechId ?? formData.id ?? null}
+                        showCaption
+                        initialAttachments={formData?.actionPhotos}
+                        onAttachmentIdsChange={(ids) =>
+                            setFormData((prev: any) => ({ ...prev, actionAttachmentIds: ids }))
+                        }
+                    />
                 </div>
                 <div className="col-span-2 grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
                     {formData.trainingPhotoPath ? (

--- a/frontend/src/pages/dashboard/shared/forms/projects/NaturalFarmingForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/projects/NaturalFarmingForms.tsx
@@ -1,10 +1,16 @@
 import React from 'react'
-import { X } from 'lucide-react'
 import { ENTITY_TYPES } from '@/constants/entityConstants'
-import { FormInput, FormSelect, FormSection } from '../shared/FormComponents'
+import { FormInput, FormSelect } from '../shared/FormComponents'
 import { MasterDataDropdown } from '@/components/common/MasterDataDropdown'
 import { createMasterDataOptions } from '@/utils/formHelpers'
 import { cleanIndianMobileInput } from '@/utils/indianPhone'
+import { FormAttachmentSection } from '@/components/common/FormAttachmentSection'
+
+const NF_ATTACHMENT_MAP: Record<string, { formCode: string; pk: string }> = {
+    [ENTITY_TYPES.PROJECT_NATURAL_FARMING_PHYSICAL]: { formCode: 'natural_farming_physical', pk: 'physicalInfoId' },
+    [ENTITY_TYPES.PROJECT_NATURAL_FARMING_DEMO]: { formCode: 'natural_farming_demo', pk: 'demonstrationInfoId' },
+    [ENTITY_TYPES.PROJECT_NATURAL_FARMING_FARMERS]: { formCode: 'natural_farming_farmers', pk: 'farmersPracticingId' },
+}
 
 interface NaturalFarmingFormsProps {
     entityType: string
@@ -31,147 +37,28 @@ export const NaturalFarmingForms: React.FC<NaturalFarmingFormsProps> = ({
     const selectedNaturalFarmingActivity = naturalFarmingActivities.find(
         (activity: any) => String(activity.naturalFarmingActivityId) === String(formData.activityId || '')
     )
-    const handleFileChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-        const files = e.target.files;
-        if (files && files.length > 0) {
-            const newFiles = Array.from(files);
-            const previews: string[] = [];
-            let count = 0;
+    const handleAttachmentIds = React.useCallback(
+        (ids: number[]) => setFormData({ ...formData, attachmentIds: ids }),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [setFormData],
+    )
 
-            newFiles.forEach((file, index) => {
-                const reader = new FileReader();
-                reader.onloadend = () => {
-                    previews[index] = reader.result as string;
-                    count++;
-                    if (count === newFiles.length) {
-                        const existingPhotos = Array.isArray(formData[field]) ? formData[field] : [];
-                        setFormData({
-                            ...formData,
-                            [field]: [
-                                ...existingPhotos,
-                                ...newFiles.map((f, i) => ({
-                                    file: f,
-                                    preview: previews[i],
-                                    image: previews[i],
-                                    caption: ''
-                                }))
-                            ]
-                        });
-                    }
-                };
-                reader.readAsDataURL(file);
-            });
-        }
-    };
+    const mapping = NF_ATTACHMENT_MAP[entityType]
+    const recordId = mapping ? (formData?.[mapping.pk] ?? formData?.id ?? null) : null
+    const kvkId = formData?.kvkId ?? null
 
-    const removePhoto = (field: string, index: number) => {
-        const photos = [...(Array.isArray(formData[field]) ? formData[field] : [])];
-        photos.splice(index, 1);
-        setFormData({ ...formData, [field]: photos });
-    };
-
-    const updateCaption = (field: string, index: number, caption: string) => {
-        const photos = [...(Array.isArray(formData[field]) ? formData[field] : [])];
-        if (photos[index]) {
-            photos[index] = { ...photos[index], caption };
-            setFormData({ ...formData, [field]: photos });
-        }
-    };
-
-    const renderPhotoFields = (field: string) => (
-        <FormSection title="Photographs" className="col-span-1 mt-2" noGrid={true}>
-            <FormInput
-                label=""
-                required={!Array.isArray(formData[field]) || formData[field].length === 0}
-                type="file"
-                multiple
-                accept="image/*"
-                onChange={handleFileChange(field)}
-                helperText="Only images allowed. Uploading new files will be added to the list. Only the first image uploaded will appear in the table. (Max 5MB per file)"
-            />
-
-            {Array.isArray(formData[field]) && formData[field].length > 0 && (
-                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mt-4">
-                    {formData[field].map((item: any, idx: number) => {
-                        const src = item.preview || (typeof item.image === 'string' ? (item.image.startsWith('data:') || item.image.startsWith('http') ? item.image : `${import.meta.env.VITE_API_URL || ''}${item.image.startsWith('/') ? '' : '/'}${item.image}`) : '');
-                        return (
-                            <div key={idx} className="relative bg-white border border-gray-200 rounded-xl p-2 shadow-sm flex flex-col group">
-                                <div className="relative aspect-square mb-2 overflow-hidden rounded-lg border border-gray-50">
-                                    <img
-                                        src={src}
-                                        className="w-full h-full object-cover transition-transform group-hover:scale-105"
-                                        alt={`P ${idx + 1}`}
-                                    />
-                                    <button
-                                        type="button"
-                                        onClick={() => removePhoto(field, idx)}
-                                        className="absolute top-1 right-1 p-1 bg-red-500 text-white rounded-full shadow-lg hover:bg-red-600 transition-colors z-10 scale-90"
-                                    >
-                                        <X className="w-3 h-3 stroke-[2.5]" />
-                                    </button>
-                                </div>
-                                <div className="space-y-1 mt-auto">
-                                    <textarea
-                                        placeholder="Caption..."
-                                        className="w-full text-[12px] font-medium bg-gray-50/50 border border-gray-100 rounded-md focus:bg-white focus:ring-1 focus:ring-green-200 px-2 py-1.5 outline-none transition-all placeholder:text-gray-400 text-gray-700 min-h-[3.5rem] resize-none"
-                                        value={item.caption || ''}
-                                        onChange={(e) => updateCaption(field, idx, e.target.value)}
-                                        rows={3}
-                                    />
-                                </div>
-                            </div>
-                        );
-                    })}
-                </div>
-            )}
-        </FormSection>
-    );
-
-    // Normalize incoming photographs data when editing
-    React.useEffect(() => {
-        // Only normalize if we are editing an existing record and have an ID
-        if (!formData.id) return;
-
-        const photoFields = ['images', 'photographs', 'demoImages'];
-        let hasChanges = false;
-        const newData = { ...formData };
-
-        photoFields.forEach(field => {
-            const rawValue = formData[field];
-            if (rawValue && typeof rawValue === 'string') {
-                if (rawValue.startsWith('[') || rawValue.startsWith('{')) {
-                    try {
-                        const parsed = JSON.parse(rawValue);
-                        const arrayToMap = Array.isArray(parsed) ? parsed : [parsed];
-                        newData[field] = arrayToMap
-                            .filter((item: any) => item && (typeof item === 'string' || item.image || item.preview || item.url))
-                            .map((item: any) => {
-                                if (typeof item === 'string') return { preview: item, image: item, caption: '' };
-                                const url = item.image || item.url || item.path || item.preview || '';
-                                return { preview: url, image: url, caption: item.caption || '' };
-                            });
-                        hasChanges = true;
-                    } catch (e) {
-                        console.error('Photo parsing error:', e);
-                    }
-                } else if (rawValue.trim() !== '' && !rawValue.includes('object Object')) {
-                    const values = rawValue.includes(',') ? rawValue.split(',') : [rawValue];
-                    newData[field] = values
-                        .filter((v: string) => v && v.trim() !== '')
-                        .map((s: string) => ({
-                            preview: s.trim(),
-                            image: s.trim(),
-                            caption: ''
-                        }));
-                    hasChanges = true;
-                }
-            }
-        });
-
-        if (hasChanges) {
-            setFormData(newData);
-        }
-    }, [formData.id, formData.entityType, setFormData]); // Only depend on identity change
+    const renderPhotos = () => mapping ? (
+        <FormAttachmentSection
+            title="Photographs"
+            formCode={mapping.formCode}
+            kind="PHOTO"
+            kvkId={kvkId}
+            recordId={recordId}
+            showCaption
+            initialAttachments={formData?.photos}
+            onAttachmentIdsChange={handleAttachmentIds}
+        />
+    ) : null
 
     const isOtherActivitySelected = String(selectedNaturalFarmingActivity?.activityName || '').trim().toLowerCase() === 'other activity'
 
@@ -355,7 +242,7 @@ export const NaturalFarmingForms: React.FC<NaturalFarmingFormsProps> = ({
                             onChange={(e) => setFormData({ ...formData, remarks: e.target.value })}
                         />
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mt-2">
-                             {renderPhotoFields('images')}
+                             {renderPhotos()}
                         </div>
                     </div>
                         </>
@@ -571,7 +458,7 @@ export const NaturalFarmingForms: React.FC<NaturalFarmingFormsProps> = ({
                             onChange={(e) => setFormData({ ...formData, farmersFeedback: e.target.value })}
                         />
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mt-2">
-                             {renderPhotoFields('images')}
+                             {renderPhotos()}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
**Stacked on PR #151 → #150 → #149 → dev.** Will retarget to \`dev\` once earlier PRs merge.

## Forms migrated in PR-D
| Form | Form code(s) | Prisma model | Kind |
|---|---|---|---|
| CFLD Technical Parameter | \`cfld_technical_training\` + \`cfld_technical_action\` | CfldTechnicalParameter | PHOTO × 2 |
| Natural Farming Physical Info | \`natural_farming_physical\` | PhysicalInfo | PHOTO |
| Natural Farming Demonstration | \`natural_farming_demo\` | DemonstrationInfo | PHOTO |
| Natural Farming Farmers Practicing | \`natural_farming_farmers\` | FarmersPracticingNaturalFarming (UUID PK) | PHOTO |

### CFLD's two photo collections
CFLD has both Farmers' Training photos and Quality Action photos on the same \`cfldTechId\`. Both go to S3 but need to stay distinguishable in Gallery + reads. Implemented via two formCodes pointing at the same \`cfldTechId\` — one binding per kind. Service has small \`stripBoth / attachBoth / decorateBoth / cleanupBoth\` helpers that wrap the two bindings, returning \`{ trainingPhotos, actionPhotos }\` arrays on read. Frontend posts \`trainingAttachmentIds\` + \`actionAttachmentIds\` separately.

### Inventory progress
- ✅ OFT Result, ARYA Current Year, RAWE FET (PR-A)
- ✅ SAC Meetings, Farmer Award, KVK Staff (PR-B)
- ✅ NICRA × 6 (PR-C)
- ✅ CFLD + Natural Farming × 3 (PR-D — this)
- 🔜 PPV FRA + Success Stories (PR-E)

## Test plan
- [ ] CFLD: open a record, upload 2 training photos and 2 action photos, save → DB has 4 \`form_attachments\` rows split between the two formCodes.
- [ ] Reload → both lists hydrate from \`trainingPhotos\` and \`actionPhotos\` arrays.
- [ ] Natural Farming Physical / Demo / Farmers: upload + save + reload → photos round-trip via FormAttachment.
- [ ] Farmers Practicing (UUID PK): \`record_id\` stored as text matching \`farmersPracticingId\`; gallery filter works.
- [ ] Delete each → S3 + DB rows clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)