### PR TITLE
feat(s3-migration) PR-E: PPV FRA + Success Stories — final batch

### DIFF
--- a/backend/services/forms/ppvFraService.js
+++ b/backend/services/forms/ppvFraService.js
@@ -1,8 +1,17 @@
 const ppvFraTrainingRepository = require('../../repositories/forms/ppvFraTrainingRepository');
 const ppvFraPlantVarietiesRepository = require('../../repositories/forms/ppvFraPlantVarietiesRepository');
+const { createAttachmentBinding, createAttachmentAwareCrud } = require('./formAttachmentBinding.js');
+
+const plantVarietyCrud = createAttachmentAwareCrud({
+    repo: ppvFraPlantVarietiesRepository,
+    binding: createAttachmentBinding({
+        formCode: 'ppv_fra',
+        primaryKey: 'ppvFraPlantVarietiesID',
+    }),
+});
 
 const ppvFraService = {
-    // Training
+    // Training (no attachments today)
     createTraining: async (data, user) => ppvFraTrainingRepository.create(data, user),
     findAllTrainings: async (filters, user) => ppvFraTrainingRepository.findAll(filters, user),
     findTrainingById: async (id, user) => {
@@ -13,16 +22,16 @@ const ppvFraService = {
     updateTraining: async (id, data, user) => ppvFraTrainingRepository.update(id, data, user),
     deleteTraining: async (id, user) => ppvFraTrainingRepository.delete(id, user),
 
-    // Plant Varieties
-    createPlantVariety: async (data, user) => ppvFraPlantVarietiesRepository.create(data, user),
-    findAllPlantVarieties: async (filters, user) => ppvFraPlantVarietiesRepository.findAll(filters, user),
+    // Plant Varieties — uses FormAttachment for photos
+    createPlantVariety: plantVarietyCrud.create,
+    findAllPlantVarieties: plantVarietyCrud.findAll,
     findPlantVarietyById: async (id, user) => {
-        const record = await ppvFraPlantVarietiesRepository.findById(id, user);
+        const record = await plantVarietyCrud.findById(id, user);
         if (!record) throw new Error('Record not found');
         return record;
     },
-    updatePlantVariety: async (id, data, user) => ppvFraPlantVarietiesRepository.update(id, data, user),
-    deletePlantVariety: async (id, user) => ppvFraPlantVarietiesRepository.delete(id, user),
+    updatePlantVariety: plantVarietyCrud.update,
+    deletePlantVariety: plantVarietyCrud.delete,
 };
 
 module.exports = ppvFraService;

--- a/backend/services/forms/successStoryService.js
+++ b/backend/services/forms/successStoryService.js
@@ -1,38 +1,26 @@
 const successStoryRepository = require('../../repositories/forms/successStoryRepository');
 const reportCacheInvalidationService = require('../reports/reportCacheInvalidationService.js');
+const { createAttachmentBinding, createAttachmentAwareCrud } = require('./formAttachmentBinding.js');
+
+const crud = createAttachmentAwareCrud({
+    repo: successStoryRepository,
+    binding: createAttachmentBinding({
+        formCode: 'success_story',
+        primaryKey: 'successStoryId',
+    }),
+    onWrite: (record, user) =>
+        reportCacheInvalidationService.invalidateDataSourceForKvk(
+            'successStory',
+            record?.kvkId || user?.kvkId,
+        ),
+});
 
 const successStoryService = {
-    getAll: (filters, user) => successStoryRepository.findAll(filters, user),
-    
-    getById: (id, user) => successStoryRepository.findById(id, user),
-    
-    create: async (data, user) => {
-        const result = await successStoryRepository.create(data, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk(
-            'successStory',
-            result?.kvkId || user?.kvkId,
-        );
-        return result;
-    },
-    
-    update: async (id, data, user) => {
-        const result = await successStoryRepository.update(id, data, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk(
-            'successStory',
-            result?.kvkId || user?.kvkId,
-        );
-        return result;
-    },
-    
-    delete: async (id, user) => {
-        const existing = await successStoryRepository.findById(id, user);
-        const result = await successStoryRepository.delete(id, user);
-        await reportCacheInvalidationService.invalidateDataSourceForKvk(
-            'successStory',
-            existing?.kvkId || user?.kvkId,
-        );
-        return result;
-    },
+    getAll: crud.findAll,
+    getById: crud.findById,
+    create: crud.create,
+    update: crud.update,
+    delete: crud.delete,
 };
 
 module.exports = successStoryService;

--- a/frontend/src/pages/dashboard/shared/forms/miscellaneous/PpvFraForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/miscellaneous/PpvFraForms.tsx
@@ -4,6 +4,7 @@ import { ENTITY_TYPES } from '../../../../../constants/entityConstants'
 import { ExtendedEntityType } from '../../../../../utils/masterUtils'
 import { useMasterData } from '../../../../../hooks/useMasterData'
 import { cleanIndianMobileInput } from '@/utils/indianPhone'
+import { FormAttachmentSection } from '@/components/common/FormAttachmentSection'
 
 interface PpvFraTrainingFormProps {
     formData: any
@@ -216,26 +217,17 @@ const PpvFraPlantVarietiesForm: React.FC<PpvFraPlantVarietiesFormProps> = ({ for
                 onChange={(e) => setFormData({ ...formData, characteristics: e.target.value })}
             />
 
-            <FormInput
-                label="Images"
-                type="file"
-                // Assuming standard file upload component handling here
-                onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) {
-                        const reader = new FileReader();
-                        reader.onloadend = () => {
-                            setFormData({
-                                ...formData,
-                                file, // Keep for UI if needed
-                                image: reader.result as string
-                            });
-                        };
-                        reader.readAsDataURL(file);
-                    } else {
-                        setFormData({ ...formData, file: null, image: null });
-                    }
-                }}
+            <FormAttachmentSection
+                title="Images"
+                formCode="ppv_fra"
+                kind="PHOTO"
+                kvkId={formData.kvkId ?? null}
+                recordId={formData.ppvFraPlantVarietiesID ?? formData.id ?? null}
+                showCaption
+                initialAttachments={formData?.photos}
+                onAttachmentIdsChange={(ids) =>
+                    setFormData({ ...formData, attachmentIds: ids })
+                }
             />
         </div>
     )

--- a/frontend/src/pages/dashboard/shared/forms/performance-indicators/ImpactForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/performance-indicators/ImpactForms.tsx
@@ -5,8 +5,8 @@ import { FormInput, FormTextArea, FormSection } from '../shared/FormComponents'
 import { useYears, useImpactSpecificAreas, useEnterpriseTypes } from '@/hooks/useOtherMastersData'
 import { MasterDataDropdown } from '@/components/common/MasterDataDropdown'
 import { createMasterDataOptions } from '@/utils/formHelpers'
-import { X } from 'lucide-react'
 import { parseBoundedCountInput, parseEstablishmentYearInput } from '@/utils/formNumericGuards'
+import { FormAttachmentSection } from '@/components/common/FormAttachmentSection'
 
 interface ImpactFormsProps {
     entityType: ExtendedEntityType | null
@@ -19,16 +19,6 @@ export const ImpactForms: React.FC<ImpactFormsProps> = ({
     formData,
     setFormData,
 }) => {
-    // Local helper for file to base64 conversion
-    const convertToBase64 = (file: File): Promise<string> => {
-        return new Promise((resolve, reject) => {
-            const reader = new FileReader()
-            reader.readAsDataURL(file)
-            reader.onload = () => resolve(reader.result as string)
-            reader.onerror = error => reject(error)
-        })
-    }
-
     const { data: years = [], isLoading: isLoadingYears } = useYears()
     const { data: specificAreas = [], isLoading: isLoadingAreas } = useImpactSpecificAreas()
     const { data: enterpriseTypes = [], isLoading: isLoadingEnterpriseTypes } = useEnterpriseTypes()
@@ -89,36 +79,9 @@ export const ImpactForms: React.FC<ImpactFormsProps> = ({
         [formData, setFormData]
     )
 
-    const handleFileChange = useCallback(
-        (field: string, multiple: boolean = false) => async (e: React.ChangeEvent<HTMLInputElement>) => {
-            const files = e.target.files
-            if (!files || files.length === 0) return
-
-            try {
-                if (multiple) {
-                    const base64Files = await Promise.all(Array.from(files).map(convertToBase64))
-                    const newPhotos = base64Files.map(base64 => ({
-                        preview: base64,
-                        image: base64,
-                        caption: ''
-                    }))
-
-                    setFormData((prev: any) => {
-                        const existingPhotos = Array.isArray(prev[field]) ? [...prev[field]] : []
-                        return { 
-                            ...prev, 
-                            [field]: [...existingPhotos, ...newPhotos] 
-                        }
-                    })
-                } else {
-                    const base64 = await convertToBase64(files[0])
-                    setFormData((prev: any) => ({ ...prev, [field]: base64 }))
-                }
-            } catch (error) {
-                console.error("Error converting files to base64:", error)
-            }
-        },
-        [setFormData] // formData is no longer a dependency thanks to functional update
+    const handleAttachmentIds = useCallback(
+        (ids: number[]) => setFormData((prev: any) => ({ ...prev, attachmentIds: ids })),
+        [setFormData],
     )
 
     const handleDateChange = useCallback(
@@ -132,121 +95,18 @@ export const ImpactForms: React.FC<ImpactFormsProps> = ({
         [formData, setFormData]
     )
 
-    const removePhoto = (field: string, index: number) => {
-        const existingPhotos = Array.isArray(formData[field]) ? [...formData[field]] : [];
-        existingPhotos.splice(index, 1);
-        setFormData({
-            ...formData,
-            [field]: existingPhotos
-        });
-    };
-
-    const updateCaption = (field: string, index: number, caption: string) => {
-        const existingPhotos = Array.isArray(formData[field]) ? [...formData[field]] : [];
-        if (existingPhotos[index]) {
-            existingPhotos[index] = { ...existingPhotos[index], caption };
-            setFormData({
-                ...formData,
-                [field]: existingPhotos
-            });
-        }
-    };
-
-    const renderPhotoFields = (field: string) => (
-        <div className="space-y-4">
-            <FormInput
-                label="Supporting Images"
-                type="file"
-                multiple
-                accept="image/*"
-                onChange={handleFileChange(field, true)}
-                helperText="Only images allowed. Uploading new files will be added to the list."
-            />
-
-            {Array.isArray(formData[field]) && formData[field].length > 0 && (
-                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mt-4">
-                    {formData[field].map((item: any, idx: number) => {
-                        const src = item.preview || (typeof item.image === 'string' ? (item.image.startsWith('data:') || item.image.startsWith('http') ? item.image : `${import.meta.env.VITE_API_URL || ''}${item.image.startsWith('/') ? '' : '/'}${item.image}`) : '');
-                        return (
-                            <div key={idx} className="relative bg-white border border-gray-200 rounded-xl p-2 shadow-sm flex flex-col group">
-                                <div className="relative aspect-square mb-2 overflow-hidden rounded-lg border border-gray-50">
-                                    <img
-                                        src={src}
-                                        className="w-full h-full object-cover transition-transform group-hover:scale-105"
-                                        alt={`P ${idx + 1}`}
-                                    />
-                                    <button
-                                        type="button"
-                                        onClick={() => removePhoto(field, idx)}
-                                        className="absolute top-1 right-1 p-1 bg-red-500 text-white rounded-full shadow-lg hover:bg-red-600 transition-colors z-10 scale-90"
-                                    >
-                                        <X className="w-3 h-3 stroke-[2.5]" />
-                                    </button>
-                                </div>
-                                <div className="space-y-1 mt-auto">
-                                    <textarea
-                                        placeholder="Caption..."
-                                        className="w-full text-[12px] font-medium bg-gray-50/50 border border-gray-100 rounded-md focus:bg-white focus:ring-1 focus:ring-green-200 px-2 py-1.5 outline-none transition-all placeholder:text-gray-400 text-gray-700 min-h-[3.5rem] resize-none"
-                                        value={item.caption || ''}
-                                        onChange={(e) => updateCaption(field, idx, e.target.value)}
-                                        rows={3}
-                                    />
-                                </div>
-                            </div>
-                        );
-                    })}
-                </div>
-            )}
-        </div>
-    );
-
-    // Normalize incoming photographs data when editing
-    React.useEffect(() => {
-        // Only normalize if we are editing an existing record and have an ID
-        // Success Stories uses successStoryId, others use generic id or specific mapping
-        const hasId = formData.id || formData.successStoryId || formData.kvkActivityImpactId || formData.entrepreneurshipDevelopmentId;
-        if (!hasId) return;
-
-        const photoFields = ['supportingImages'];
-        let hasChanges = false;
-        const newData = { ...formData };
-
-        photoFields.forEach(field => {
-            const rawValue = formData[field];
-            if (rawValue && typeof rawValue === 'string') {
-                if (rawValue.startsWith('[') || rawValue.startsWith('{')) {
-                    try {
-                        const parsed = JSON.parse(rawValue);
-                        const arrayToMap = Array.isArray(parsed) ? parsed : [parsed];
-                        newData[field] = arrayToMap
-                            .filter((item: any) => item && (typeof item === 'string' || item.image || item.preview || item.url))
-                            .map((item: any) => {
-                                if (typeof item === 'string') return { preview: item, image: item, caption: '' };
-                                const url = item.image || item.url || item.path || item.preview || '';
-                                return { preview: url, image: url, caption: item.caption || '' };
-                            });
-                        hasChanges = true;
-                    } catch (e) {
-                        console.error('Photo parsing error:', e);
-                    }
-                } else if (rawValue.trim() !== '' && !rawValue.includes('object Object')) {
-                    const values = rawValue.includes(',') ? rawValue.split(',') : [rawValue];
-                    newData[field] = values
-                        .filter((v: string) => v && v.trim() !== '')
-                        .map((s: string) => ({
-                            preview: s.trim(),
-                            image: s.trim(),
-                            caption: ''
-                        }));
-                    hasChanges = true;
-                }
-            }
-        });
-
-        if (hasChanges) {
-            setFormData(newData);
-        }
-    }, [formData.id, formData.entityType, setFormData]);
+    const renderSupportingImages = () => (
+        <FormAttachmentSection
+            title="Supporting Images"
+            formCode="success_story"
+            kind="PHOTO"
+            kvkId={formData.kvkId ?? null}
+            recordId={formData.successStoryId ?? formData.id ?? null}
+            showCaption
+            initialAttachments={formData?.photos}
+            onAttachmentIdsChange={handleAttachmentIds}
+        />
+    )
 
     if (!entityType) return null
 
@@ -621,7 +481,7 @@ export const ImpactForms: React.FC<ImpactFormsProps> = ({
                                 />
 
                                 <div className="space-y-4">
-                                     {renderPhotoFields('supportingImages')}
+                                     {renderSupportingImages()}
                                 </div>
                             </div>
 


### PR DESCRIPTION
**Stacked on PR #152 → #151 → #150 → #149 → dev.** Final batch — once merged in order, every form upload in the app is on S3.

## Forms migrated in PR-E
| Form | Form code | Prisma model | PK |
|---|---|---|---|
| PPV FRA Plant Varieties | \`ppv_fra\` | PpvFraPlantVarieties | Int |
| Success Stories / Impact | \`success_story\` | SuccessStory | UUID |

## Final inventory — every file-upload form now on S3
- ✅ OFT Result (PR-A)
- ✅ ARYA Current Year (PR-A)
- ✅ RAWE FET Programme (PR-A)
- ✅ SAC Meetings (PR-B)
- ✅ Farmer Award (PR-B)
- ✅ KVK Staff Photos (PR-B)
- ✅ NICRA Details (PR-C)
- ✅ NICRA Custom Hiring / Farm Implement (PR-C)
- ✅ NICRA VCRMC (PR-C)
- ✅ NICRA Soil Health (PR-C)
- ✅ NICRA Convergence (PR-C)
- ✅ NICRA Dignitaries (PR-C)
- ✅ CFLD Technical — Training + Action (PR-D)
- ✅ Natural Farming Physical Info (PR-D)
- ✅ Natural Farming Demonstration (PR-D)
- ✅ Natural Farming Farmers Practicing (PR-D)
- ✅ PPV FRA Plant Varieties (PR-E — this)
- ✅ Success Stories (PR-E — this)

**No base64 anywhere on the upload path. No \`Bytes\` columns in the new schema. Every upload: presign → browser→S3 PUT → confirm → \`form_attachments\` row.**

## Test plan
- [ ] PPV FRA Plant Varieties: upload images on a record, save → \`form_code='ppv_fra'\`, \`record_id=ppvFraPlantVarietiesID\`.
- [ ] Success Stories: upload images on a story, save → \`form_code='success_story'\`, \`record_id\` = UUID string.
- [ ] Gallery sidebar shows both forms under "Form Attachments" group; filtering works.
- [ ] Delete each — S3 + DB cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)