### PR TITLE
fix(gallery, forms): polish, rename, hide, robustness

### DIFF
--- a/backend/repositories/formAttachmentRepository.js
+++ b/backend/repositories/formAttachmentRepository.js
@@ -56,11 +56,16 @@ async function listForGallery({
     limit = 50,
     kvkId,
     formCode,
-    kind = 'PHOTO',
     reportingYear,
     search,
 }) {
-    const where = { kind, AND: [] };
+    // Gallery only shows image-typed rows regardless of stored `kind`. RAWE FET
+    // and other DOCUMENT-kind forms upload mixed content (PDF, video, image);
+    // we want the images to appear here while non-image files don't pollute it.
+    const where = {
+        mimeType: { startsWith: 'image/' },
+        AND: [],
+    };
     if (kvkId) where.kvkId = Number(kvkId);
     if (formCode) where.formCode = formCode;
     if (reportingYear) {
@@ -146,8 +151,9 @@ async function attachToRecord({ attachmentIds, formCode, recordId, kvkId }) {
     });
 }
 
-async function distinctFormCodes({ kvkId, kind = 'PHOTO' }) {
-    const where = { kind };
+async function distinctFormCodes({ kvkId }) {
+    // Image-typed rows only — same filter the gallery list uses.
+    const where = { mimeType: { startsWith: 'image/' } };
     if (kvkId) where.kvkId = Number(kvkId);
     const rows = await prisma.formAttachment.groupBy({
         by: ['formCode'],
@@ -158,10 +164,10 @@ async function distinctFormCodes({ kvkId, kind = 'PHOTO' }) {
     return rows.map((r) => ({ formCode: r.formCode, count: r._count._all }));
 }
 
-async function distinctKvks({ kind = 'PHOTO' }) {
+async function distinctKvks() {
     const rows = await prisma.formAttachment.groupBy({
         by: ['kvkId'],
-        where: { kind },
+        where: { mimeType: { startsWith: 'image/' } },
         _count: { _all: true },
     });
     if (rows.length === 0) return [];

--- a/backend/repositories/forms/farmerAwardRepository.js
+++ b/backend/repositories/forms/farmerAwardRepository.js
@@ -174,7 +174,9 @@ const farmerAwardRepository = {
             const amount = _parseInteger(data.amount, 'Amount', false);
             const achievement = _normalizeString(data.achievement, 'Achievement', false);
             const conferringAuthority = _normalizeString(data.conferringAuthority, 'Conferring Authority', false);
-            const image = _normalizeString(data.image, 'Image', false);
+            // Legacy `image` column kept for backward read but no longer
+            // required — photos now live in form_attachments via attachmentIds.
+            const image = _normalizeString(data.image, 'Image', true);
 
             // Prepare create data
             const createData = {

--- a/backend/services/formAttachmentService.js
+++ b/backend/services/formAttachmentService.js
@@ -4,6 +4,37 @@ const { ValidationError, NotFoundError, UnauthorizedError } = require('../utils/
 
 const KIND = { PHOTO: 'PHOTO', DATASHEET: 'DATASHEET', DOCUMENT: 'DOCUMENT' };
 
+// Form codes that *can* hold image-bearing attachments. Always surfaced in the
+// gallery sidebar even when their count is currently 0 — users still need to
+// be able to click into them to upload via the linked record's form.
+const KNOWN_GALLERY_FORM_CODES = [
+    'oft_result',
+    'arya_current_year',
+    'rawe_fet',
+    'sac_meeting',
+    'farmer_award',
+    'nicra_details',
+    'nicra_farm_implement',
+    'nicra_vcrmc',
+    'nicra_soil_health',
+    'nicra_convergence',
+    'nicra_dignitaries',
+    'cfld_technical_training',
+    'cfld_technical_action',
+    'natural_farming_physical',
+    'natural_farming_demo',
+    'ppv_fra',
+    'success_story',
+];
+
+// Form codes that should NEVER appear in the gallery sidebar even if rows
+// exist in the DB (e.g. KVK staff photos are admin-internal, not gallery
+// content; Natural Farming Farmers Practicing is excluded by request).
+const HIDDEN_GALLERY_FORM_CODES = new Set([
+    'kvk_staff',
+    'natural_farming_farmers',
+]);
+
 const MAX_BYTES = {
     PHOTO: 5 * 1024 * 1024,
     DATASHEET: 5 * 1024 * 1024,
@@ -180,25 +211,43 @@ async function deleteManyByRecord({ formCode, recordId, kvkId }, user) {
 
 async function listForGallery(params, user) {
     if (!user) throw new UnauthorizedError();
-    const filters = { ...params, kind: 'PHOTO' };
+    const filters = { ...params };
     if (user.kvkId) filters.kvkId = user.kvkId;
     const result = await formAttachmentRepository.listForGallery(filters);
-    const data = await Promise.all(result.data.map(decorate));
-    return { data, meta: result.meta };
+    // Drop rows whose formCode is hidden from the gallery (kvk_staff, etc.)
+    const visibleRows = result.data.filter((r) => !HIDDEN_GALLERY_FORM_CODES.has(r.formCode));
+    const data = await Promise.all(visibleRows.map(decorate));
+    return {
+        data,
+        meta: { ...result.meta, total: visibleRows.length === result.data.length ? result.meta.total : visibleRows.length },
+    };
 }
 
 async function listForms(user) {
     if (!user) throw new UnauthorizedError();
-    return formAttachmentRepository.distinctFormCodes({ kvkId: user.kvkId, kind: 'PHOTO' });
+    const dbRows = await formAttachmentRepository.distinctFormCodes({ kvkId: user.kvkId });
+    const counts = new Map(dbRows.map((r) => [r.formCode, r.count]));
+    const known = KNOWN_GALLERY_FORM_CODES.map((formCode) => ({
+        formCode,
+        count: counts.get(formCode) || 0,
+    }));
+    // Append any formCode the DB knows about but our static list missed.
+    for (const r of dbRows) {
+        if (!KNOWN_GALLERY_FORM_CODES.includes(r.formCode)) {
+            known.push(r);
+        }
+    }
+    // Exclude codes that should never surface in the gallery sidebar.
+    return known.filter((r) => !HIDDEN_GALLERY_FORM_CODES.has(r.formCode));
 }
 
 async function listKvks(user) {
     if (!user) throw new UnauthorizedError();
     if (user.kvkId) {
-        return formAttachmentRepository.distinctKvks({ kind: 'PHOTO' })
+        return formAttachmentRepository.distinctKvks()
             .then((all) => all.filter((k) => k.kvkId === user.kvkId));
     }
-    return formAttachmentRepository.distinctKvks({ kind: 'PHOTO' });
+    return formAttachmentRepository.distinctKvks();
 }
 
 async function decorate(row) {

--- a/backend/services/forms/aboutKvkService.js
+++ b/backend/services/forms/aboutKvkService.js
@@ -3,19 +3,9 @@ const prisma = require('../../config/prisma.js');
 const { ValidationError } = require('../../utils/errorHandler.js');
 const { parseReportingYearDate, ensureNotFutureDate } = require('../../utils/reportingYearUtils.js');
 const { sanitizeDate, sanitizeString } = require('../../utils/dataSanitizer.js');
-const { createAttachmentBinding } = require('./formAttachmentBinding.js');
 
 /** Roles scoped to a specific KVK */
 const KVK_ROLES = ['kvk_admin', 'kvk_user'];
-
-const STAFF_ATTACHMENTS = createAttachmentBinding({
-    formCode: 'kvk_staff',
-    primaryKey: 'kvkStaffId',
-});
-
-function entityHasAttachments(entityName) {
-    return entityName === 'kvk-employees' || entityName === 'kvk-staff-transferred';
-}
 
 /**
  * About KVK Service
@@ -103,9 +93,6 @@ class AboutKvkService {
             }
         }
 
-        if (entityHasAttachments(entityName)) {
-            return STAFF_ATTACHMENTS.decorate(entity, user);
-        }
         return entity;
     }
 
@@ -173,24 +160,13 @@ class AboutKvkService {
             }
         }
 
-        // Strip attachmentIds before passing to repo (only kvk-staff carries them).
-        const hasAttachments = entityHasAttachments(entityName);
-        const { payload: rawWithoutAtt, attachmentIds } = hasAttachments
-            ? STAFF_ATTACHMENTS.strip(data)
-            : { payload: data, attachmentIds: [] };
-
         // Sanitize optional enum fields: convert empty strings to null
-        const sanitizedData = this.sanitizeEnumFields(entityName, rawWithoutAtt);
+        const sanitizedData = this.sanitizeEnumFields(entityName, data);
 
         // Convert numeric fields
         const finalData = this.sanitizeNumericFields(entityName, sanitizedData);
 
-        const created = await aboutKvkRepository.create(entityName, finalData);
-        if (hasAttachments) {
-            await STAFF_ATTACHMENTS.attach(created, attachmentIds, user);
-            return STAFF_ATTACHMENTS.decorate(created, user);
-        }
-        return created;
+        return await aboutKvkRepository.create(entityName, finalData);
     }
 
     async update(entityName, id, data, user = null) {
@@ -213,14 +189,8 @@ class AboutKvkService {
             throw new Error('Cannot change kvkId');
         }
 
-        // Strip attachmentIds before passing to repo (only kvk-staff carries them).
-        const hasAttachments = entityHasAttachments(entityName);
-        const { payload: rawWithoutAtt, attachmentIds } = hasAttachments
-            ? STAFF_ATTACHMENTS.strip(data)
-            : { payload: data, attachmentIds: [] };
-
         // Sanitize data: remove read-only fields and nested objects
-        const sanitizedData = this.sanitizeUpdateData(entityName, rawWithoutAtt);
+        const sanitizedData = this.sanitizeUpdateData(entityName, data);
 
         // Sanitize optional enum fields: convert empty strings to null
         const enumSanitized = this.sanitizeEnumFields(entityName, sanitizedData);
@@ -228,12 +198,7 @@ class AboutKvkService {
         // Convert numeric fields
         const finalData = this.sanitizeNumericFields(entityName, enumSanitized);
 
-        const updated = await aboutKvkRepository.update(entityName, id, finalData);
-        if (hasAttachments) {
-            await STAFF_ATTACHMENTS.attach(updated ?? currentEntity, attachmentIds, user);
-            return STAFF_ATTACHMENTS.decorate(updated, user);
-        }
-        return updated;
+        return await aboutKvkRepository.update(entityName, id, finalData);
     }
 
     async delete(entityName, id, user = null) {
@@ -256,11 +221,7 @@ class AboutKvkService {
             }
         }
 
-        const deleted = await aboutKvkRepository.deleteEntity(entityName, id);
-        if (entityHasAttachments(entityName)) {
-            await STAFF_ATTACHMENTS.cleanup(currentEntity, user);
-        }
-        return deleted;
+        return await aboutKvkRepository.deleteEntity(entityName, id);
     }
 
     /**

--- a/backend/services/forms/naturalFarmingService.js
+++ b/backend/services/forms/naturalFarmingService.js
@@ -27,11 +27,27 @@ const demoCrud = createAttachmentAwareCrud({
     onWrite: invalidate('naturalFarmingDemonstration'),
 });
 
-const farmersPracticingCrud = createAttachmentAwareCrud({
-    repo: farmersPracticingRepository,
-    binding: createAttachmentBinding({ formCode: 'natural_farming_farmers', primaryKey: 'farmersPracticingId' }),
-    onWrite: invalidate('naturalFarmingFarmersPracticing'),
-});
+// Farmers Practicing has no attachments — pass through to the repo directly.
+const farmersPracticingCrud = {
+    findAll: (filters, user) => farmersPracticingRepository.findAll(filters, user),
+    findById: (id, user) => farmersPracticingRepository.findById(id, user),
+    create: async (data, user) => {
+        const result = await farmersPracticingRepository.create(data, user);
+        await invalidate('naturalFarmingFarmersPracticing')(result, user);
+        return result;
+    },
+    update: async (id, data, user) => {
+        const result = await farmersPracticingRepository.update(id, data, user);
+        await invalidate('naturalFarmingFarmersPracticing')(result, user);
+        return result;
+    },
+    delete: async (id, user) => {
+        const existing = await farmersPracticingRepository.findById(id, user);
+        const result = await farmersPracticingRepository.delete(id, user);
+        await invalidate('naturalFarmingFarmersPracticing')(existing, user);
+        return result;
+    },
+};
 
 const naturalFarmingService = {
     // Geographical Info (no attachments)

--- a/frontend/src/components/common/FormAttachmentSection.tsx
+++ b/frontend/src/components/common/FormAttachmentSection.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FormSection } from '@/pages/dashboard/shared/forms/shared/FormComponents'
 import { MultiAttachmentUploader } from './MultiAttachmentUploader'
 import { useFormAttachmentsField } from '@/hooks/useFormAttachmentsField'
+import { useAuth } from '@/contexts/AuthContext'
 import type { FormAttachmentKind, FormAttachmentRow } from '@/services/formAttachmentsApi'
 
 export interface FormAttachmentSectionProps {
@@ -58,24 +59,44 @@ export const FormAttachmentSection: React.FC<FormAttachmentSectionProps> = ({
     maxBytes,
     reportingYearDate,
 }) => {
+    // Fall back to the logged-in user's kvkId when the form hasn't pushed it
+    // into formData yet (kvk-scoped users like kvk_admin / kvk_user / kvk_staff).
+    const { user } = useAuth()
+    const effectiveKvkId = kvkId ?? user?.kvkId ?? null
+
     const { attachments, setAttachments, pendingAttachmentIds } = useFormAttachmentsField({
         formCode,
         kind,
-        kvkId,
+        kvkId: effectiveKvkId,
         recordId,
         initialAttachments,
     })
 
-    const idsKey = pendingAttachmentIds.join(',')
+    // Keep the latest onChange handler in a ref so we don't refire the effect
+    // when the parent re-renders with a new inline callback.
     const onChangeRef = React.useRef(onAttachmentIdsChange)
     React.useEffect(() => {
         onChangeRef.current = onAttachmentIdsChange
     })
-    React.useEffect(() => {
-        onChangeRef.current?.(pendingAttachmentIds)
-    }, [idsKey, pendingAttachmentIds])
 
-    if (!kvkId) {
+    // Only notify the parent when the actual id list content changes. Skip the
+    // initial mount to avoid clobbering parent state with attachmentIds:[]
+    // before the user has done anything.
+    const idsKey = pendingAttachmentIds.join(',')
+    const lastNotifiedKeyRef = React.useRef<string | null>(null)
+    React.useEffect(() => {
+        if (lastNotifiedKeyRef.current === idsKey) return
+        // Skip the very first render — initial empty list isn't worth pushing.
+        if (lastNotifiedKeyRef.current === null && pendingAttachmentIds.length === 0) {
+            lastNotifiedKeyRef.current = idsKey
+            return
+        }
+        lastNotifiedKeyRef.current = idsKey
+        onChangeRef.current?.(pendingAttachmentIds)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [idsKey])
+
+    if (!effectiveKvkId) {
         return (
             <FormSection title={title}>
                 <div className="text-sm text-amber-600 bg-amber-50 border border-amber-200 rounded-lg p-3">
@@ -90,7 +111,7 @@ export const FormAttachmentSection: React.FC<FormAttachmentSectionProps> = ({
             <MultiAttachmentUploader
                 formCode={formCode}
                 kind={kind}
-                kvkId={kvkId}
+                kvkId={effectiveKvkId}
                 recordId={recordId ?? null}
                 attachments={attachments}
                 showCaption={showCaption}

--- a/frontend/src/components/common/MultiAttachmentUploader.tsx
+++ b/frontend/src/components/common/MultiAttachmentUploader.tsx
@@ -206,7 +206,7 @@ export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = (
 
     return (
         <div className="space-y-2">
-            <div className="rounded-xl border border-[#E0E0E0] overflow-hidden">
+            <div className="rounded-xl border border-[#E0E0E0] overflow-hidden w-full lg:max-w-md">
                 <input
                     ref={fileInputRef}
                     type="file"
@@ -229,7 +229,7 @@ export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = (
             {error && <div className="text-xs text-red-600 break-words">{error}</div>}
 
             {sorted.length > 0 && (
-                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mt-2">
+                <div className="grid gap-3 mt-2 grid-cols-[repeat(auto-fill,minmax(140px,160px))]">
                     {sorted.map((att) => (
                         <AttachmentTile
                             key={att.attachmentId}

--- a/frontend/src/hooks/useGallerySource.ts
+++ b/frontend/src/hooks/useGallerySource.ts
@@ -35,16 +35,54 @@ interface UseGallerySourceResult {
     total: number
     isLoading: boolean
     isError: boolean
+    /**
+     * Counts per categoryId (moduleId for module-images; synthetic id for form
+     * attachments) — sourced from unfiltered queries so the sidebar shows
+     * stable counts regardless of which category is currently selected.
+     */
+    categoryCounts: Map<number, number>
 }
 
 const FORM_LABEL_OVERRIDES: Record<string, string> = {
     oft_result: 'OFT Result',
+    nicra_farm_implement: 'NICRA Custom Hiring',
+    rawe_fet: 'RAWE/FET',
+    ppv_fra: 'PPV FRA',
+    cfld_technical_training: 'CFLD Training Photos',
+    cfld_technical_action: 'CFLD Action Photos',
+    nicra_details: 'NICRA Details',
+    nicra_vcrmc: 'NICRA VCRMC',
+    nicra_soil_health: 'NICRA Soil Health',
+    nicra_convergence: 'NICRA Convergence',
+    nicra_dignitaries: 'NICRA Dignitaries',
+    natural_farming_demo: 'Natural Farming Demonstration',
+    natural_farming_physical: 'Natural Farming Physical',
+    sac_meeting: 'SAC Meeting',
+    farmer_award: 'Farmer Award',
+    arya_current_year: 'ARYA Current Year',
+    success_story: 'Success Story',
 }
 
 // Maps a formCode to the sidebar group it should appear under. Falls back to
 // "Form Attachments" so unknown forms still show up.
 const FORM_MENU_BY_CODE: Record<string, string> = {
     oft_result: 'Achievements',
+    farmer_award: 'Achievements',
+    arya_current_year: 'Projects',
+    nicra_details: 'Projects',
+    nicra_farm_implement: 'Projects',
+    nicra_vcrmc: 'Projects',
+    nicra_soil_health: 'Projects',
+    nicra_convergence: 'Projects',
+    nicra_dignitaries: 'Projects',
+    cfld_technical_training: 'Projects',
+    cfld_technical_action: 'Projects',
+    natural_farming_physical: 'Projects',
+    natural_farming_demo: 'Projects',
+    sac_meeting: 'Meetings',
+    rawe_fet: 'Miscellaneous',
+    ppv_fra: 'Miscellaneous',
+    success_story: 'Performance Indicators',
 }
 
 const DEFAULT_FORMS_MENU_NAME = 'Form Attachments'
@@ -113,6 +151,13 @@ export function useGallerySource(
     }
 
     const moduleImagesQuery = useModuleImages(moduleImageFilters as any)
+    // Second module-image query without moduleId so the sidebar counts stay
+    // stable when a single module is selected (the filtered query above
+    // returns only one module's rows; that's not a count of the others).
+    const moduleImagesUnfilteredQuery = useModuleImages({
+        ...filters,
+        moduleId: undefined,
+    } as any)
     const moduleCategoriesQuery = useModuleImageCategories()
     const moduleKvksQuery = useModuleImageKvks(showKvkFilter)
 
@@ -151,7 +196,22 @@ export function useGallerySource(
             })
         }
 
-        const moduleCategories = moduleCategoriesQuery.data ?? []
+        // Build per-category counts from the unfiltered queries so the sidebar
+        // numbers stay stable when one category is selected.
+        const unfilteredModuleRows = moduleImagesUnfilteredQuery.data?.data ?? []
+        const moduleIdsWithImages = new Set(unfilteredModuleRows.map((r) => r.moduleId))
+        const categoryCounts = new Map<number, number>()
+        for (const r of unfilteredModuleRows) {
+            categoryCounts.set(r.moduleId, (categoryCounts.get(r.moduleId) ?? 0) + 1)
+        }
+        for (const f of formsListQuery.data ?? []) {
+            const id = formCodeToId.get(f.formCode) ?? FORM_ID_OFFSET
+            categoryCounts.set(id, f.count)
+        }
+
+        const moduleCategories = (moduleCategoriesQuery.data ?? []).filter((c) =>
+            moduleIdsWithImages.has(c.moduleId),
+        )
         const formCategories: ModuleImageCategory[] = (formsListQuery.data ?? []).map((f) => ({
             moduleId: formCodeToId.get(f.formCode) ?? FORM_ID_OFFSET,
             moduleCode: f.formCode,
@@ -178,6 +238,7 @@ export function useGallerySource(
             total,
             isLoading: moduleImagesQuery.isLoading || formsQuery.isLoading,
             isError: Boolean(moduleImagesQuery.error || formsQuery.error),
+            categoryCounts,
         }
     }, [
         formCodeToId,
@@ -189,6 +250,7 @@ export function useGallerySource(
         moduleImagesQuery.data,
         moduleImagesQuery.isLoading,
         moduleImagesQuery.error,
+        moduleImagesUnfilteredQuery.data,
         moduleCategoriesQuery.data,
         moduleKvksQuery.data,
         filters.moduleId,

--- a/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
@@ -16,7 +16,6 @@ import {
     AccountTypeEnum
 } from '@/hooks/forms/useAboutKvkData'
 import { useStaffCategories, usePayLevels, usePayScales, useDisciplines, useFundingSources, useAssetFundingSources, useEquipmentTypes, useEquipmentMasters } from '@/hooks/useOtherMastersData'
-import { FormAttachmentSection } from '@/components/common/FormAttachmentSection'
 import { DependentDropdown } from '@/components/common/DependentDropdown'
 import { masterDataApi } from '@/services/masterDataApi'
 import { useUniversityHostFields } from '@/hooks/useUniversityHostFields'
@@ -366,18 +365,6 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 placeholder="Resume link"
                             />
                         </div>
-                        <FormAttachmentSection
-                            title="Staff Photos"
-                            formCode="kvk_staff"
-                            kind="PHOTO"
-                            kvkId={formData.kvkId ?? null}
-                            recordId={formData.kvkStaffId ?? formData.id ?? null}
-                            showCaption
-                            initialAttachments={formData?.photos}
-                            onAttachmentIdsChange={(ids) =>
-                                setFormData((prev: any) => ({ ...prev, attachmentIds: ids }))
-                            }
-                        />
                     </FormSection>
 
                     <FormSection title="Job Details">

--- a/frontend/src/pages/dashboard/shared/forms/meetings/MeetingForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/meetings/MeetingForms.tsx
@@ -64,12 +64,8 @@ export const MeetingForms: React.FC<MeetingFormsProps> = ({
         [formData, setFormData]
     )
 
-    const formDataRef = React.useRef(formData)
-    React.useEffect(() => {
-        formDataRef.current = formData
-    })
     const handleAttachmentIds = useCallback(
-        (ids: number[]) => setFormData({ ...formDataRef.current, attachmentIds: ids }),
+        (ids: number[]) => setFormData((prev: any) => ({ ...prev, attachmentIds: ids })),
         [setFormData],
     )
 

--- a/frontend/src/pages/dashboard/shared/forms/miscellaneous/PPVFRASensitizationForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/miscellaneous/PPVFRASensitizationForms.tsx
@@ -2,11 +2,11 @@ import React, { useCallback, useMemo } from 'react'
 import { ENTITY_TYPES } from '@/constants/entityConstants'
 import { ExtendedEntityType } from '@/utils/masterUtils'
 import { FormInput, FormSection } from '../shared/FormComponents'
-import { useFileHandling } from '@/hooks/useFileHandling'
 import { useYears, usePpvFraTrainingTypes } from '@/hooks/useOtherMastersData'
 import { MasterDataDropdown } from '@/components/common/MasterDataDropdown'
 import { createMasterDataOptions } from '@/utils/formHelpers'
 import { cleanIndianMobileInput } from '@/utils/indianPhone'
+import { FormAttachmentSection } from '@/components/common/FormAttachmentSection'
 
 interface PPVFRASensitizationFormsProps {
     entityType: ExtendedEntityType | null
@@ -19,7 +19,6 @@ export const PPVFRASensitizationForms: React.FC<PPVFRASensitizationFormsProps> =
     formData,
     setFormData,
 }) => {
-    const { handleFileChange } = useFileHandling(formData, setFormData)
     const { data: years = [], isLoading: isLoadingYears } = useYears()
     const { data: trainingTypes = [], isLoading: isLoadingTypes } = usePpvFraTrainingTypes()
 
@@ -62,22 +61,9 @@ export const PPVFRASensitizationForms: React.FC<PPVFRASensitizationFormsProps> =
     )
 
 
-    const handleFileChangeLocal = useCallback(
-        (field: string, multiple: boolean = false) => (e: React.ChangeEvent<HTMLInputElement>) => {
-            handleFileChange(field, multiple)(e)
-            // If the field is 'image', also update the 'image' property which is used in the repository
-            if (field === 'images') {
-                const file = e.target.files?.[0];
-                if (file) {
-                    const reader = new FileReader();
-                    reader.onloadend = () => {
-                        setFormData({ ...formData, image: reader.result as string });
-                    };
-                    reader.readAsDataURL(file);
-                }
-            }
-        },
-        [handleFileChange, formData, setFormData]
+    const handleAttachmentIds = useCallback(
+        (ids: number[]) => setFormData((prev: any) => ({ ...prev, attachmentIds: ids })),
+        [setFormData],
     )
 
     if (!entityType) return null
@@ -301,63 +287,16 @@ export const PPVFRASensitizationForms: React.FC<PPVFRASensitizationFormsProps> =
                         placeholder="Enter characteristics"
                     />
 
-                    <div className="space-y-4">
-                        <label className="block text-sm font-semibold text-gray-700">
-                            Images
-                        </label>
-
-                        {(formData.image || formData.images) && (
-                            <div className="flex flex-wrap gap-3 mb-4 p-4 border border-dashed border-[#487749]/30 rounded-2xl bg-[#487749]/5">
-                                {(() => {
-                                    try {
-                                        const imageData = formData.image || formData.images;
-                                        const images = typeof imageData === 'string'
-                                            ? (imageData.startsWith('[') ? JSON.parse(imageData) : [imageData])
-                                            : [];
-                                        return images.map((img: string, idx: number) => (
-                                            <div key={idx} className="relative group">
-                                                <img
-                                                    src={img}
-                                                    className="h-24 w-auto object-cover rounded-xl shadow-md border-2 border-white hover:scale-105 transition-transform duration-300"
-                                                    alt={`Preview ${idx + 1}`}
-                                                />
-                                                <button
-                                                    type="button"
-                                                    onClick={() => {
-                                                        const newImages = images.filter((_: any, i: number) => i !== idx);
-                                                        const newValue = newImages.length === 0 ? null : (newImages.length === 1 ? newImages[0] : JSON.stringify(newImages));
-                                                        setFormData({
-                                                            ...formData,
-                                                            image: newValue,
-                                                            images: null // Clear the file objects
-                                                        });
-                                                    }}
-                                                    className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
-                                                >
-                                                    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                                    </svg>
-                                                </button>
-                                            </div>
-                                        ));
-                                    } catch { return null; }
-                                })()}
-                            </div>
-                        )}
-
-                        <div className="relative group">
-                            <input
-                                type="file"
-                                multiple
-                                accept="image/*"
-                                onChange={handleFileChangeLocal('images', true)}
-                                className="block w-full text-sm text-gray-500 file:mr-4 file:py-2.5 file:px-5 file:rounded-xl file:border-0 file:text-xs file:font-semibold file:bg-[#487749] file:text-white hover:file:bg-[#3d633e] transition-all border-2 border-dashed border-[#E0E0E0] group-hover:border-[#487749]/50 rounded-2xl p-2 bg-gray-50/50"
-                            />
-                            <p className="mt-2 text-[10px] text-gray-500">
-                                Max 2MB per file. (Optional)
-                            </p>
-                        </div>
-                    </div>
+                    <FormAttachmentSection
+                        title="Images"
+                        formCode="ppv_fra"
+                        kind="PHOTO"
+                        kvkId={formData.kvkId ?? null}
+                        recordId={formData.ppvFraPlantVarietiesID ?? formData.id ?? null}
+                        showCaption
+                        initialAttachments={formData?.photos}
+                        onAttachmentIdsChange={handleAttachmentIds}
+                    />
                 </div>
             )}
         </div>

--- a/frontend/src/pages/dashboard/shared/forms/miscellaneous/PpvFraForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/miscellaneous/PpvFraForms.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FormInput, FormSelect, FormTextArea } from '../shared/FormComponents'
+import { FormInput, FormSelect, FormTextArea, FormSection } from '../shared/FormComponents'
 import { ENTITY_TYPES } from '../../../../../constants/entityConstants'
 import { ExtendedEntityType } from '../../../../../utils/masterUtils'
 import { useMasterData } from '../../../../../hooks/useMasterData'
@@ -156,66 +156,69 @@ const PpvFraPlantVarietiesForm: React.FC<PpvFraPlantVarietiesFormProps> = ({ for
 
     return (
         <div className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <FormSelect
-                    label="Reporting Year"
-                    required
-                    options={[{ value: '', label: 'Select' }, ...yearOptions]}
-                    value={formData.reportingYear ?? ''}
-                    onChange={(e) => setFormData({ ...formData, reportingYear: e.target.value })}
-                />
-                <FormInput
-                    label="Name of Crop Registered"
-                    required
-                    value={formData.cropName ?? ''}
-                    onChange={(e) => setFormData({ ...formData, cropName: e.target.value })}
-                />
-                <FormInput
-                    label="Farmer Name"
-                    required
-                    value={formData.farmerName ?? ''}
-                    onChange={(e) => setFormData({ ...formData, farmerName: e.target.value })}
-                />
-                <FormInput
-                    label="Mobile No."
-                    required
-                    value={formData.mobile ?? ''}
-                    onChange={(e) =>
-                        setFormData({ ...formData, mobile: cleanIndianMobileInput(e.target.value) })
-                    }
-                    placeholder="10-digit mobile"
-                    inputMode="numeric"
-                    autoComplete="tel"
-                />
-                <FormInput
-                    label="Village"
-                    required
-                    value={formData.village ?? ''}
-                    onChange={(e) => setFormData({ ...formData, village: e.target.value })}
-                />
-                <FormInput
-                    label="Block"
-                    required
-                    value={formData.block ?? ''}
-                    onChange={(e) => setFormData({ ...formData, block: e.target.value })}
-                />
-                <FormSelect
-                    label="District"
-                    required
-                    options={districtOptions}
-                    value={formData.district ?? ''}
-                    onChange={(e) => setFormData({ ...formData, district: e.target.value })}
-                    placeholder={districtsLoading ? 'Loading districts...' : 'Select District'}
-                />
-            </div>
-
-            <FormTextArea
-                label="Characteristics"
-                required
-                rows={4}
-                value={formData.characteristics ?? ''}
-                onChange={(e) => setFormData({ ...formData, characteristics: e.target.value })}
-            />
+            <FormSection title="Plant Variety Details" noGrid>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <FormSelect
+                        label="Reporting Year"
+                        required
+                        options={[{ value: '', label: 'Select' }, ...yearOptions]}
+                        value={formData.reportingYear ?? ''}
+                        onChange={(e) => setFormData({ ...formData, reportingYear: e.target.value })}
+                    />
+                    <FormInput
+                        label="Name of Crop Registered"
+                        required
+                        value={formData.cropName ?? ''}
+                        onChange={(e) => setFormData({ ...formData, cropName: e.target.value })}
+                    />
+                    <FormInput
+                        label="Farmer Name"
+                        required
+                        value={formData.farmerName ?? ''}
+                        onChange={(e) => setFormData({ ...formData, farmerName: e.target.value })}
+                    />
+                    <FormInput
+                        label="Mobile No."
+                        required
+                        value={formData.mobile ?? ''}
+                        onChange={(e) =>
+                            setFormData({ ...formData, mobile: cleanIndianMobileInput(e.target.value) })
+                        }
+                        placeholder="10-digit mobile"
+                        inputMode="numeric"
+                        autoComplete="tel"
+                    />
+                    <FormInput
+                        label="Village"
+                        required
+                        value={formData.village ?? ''}
+                        onChange={(e) => setFormData({ ...formData, village: e.target.value })}
+                    />
+                    <FormInput
+                        label="Block"
+                        required
+                        value={formData.block ?? ''}
+                        onChange={(e) => setFormData({ ...formData, block: e.target.value })}
+                    />
+                    <FormSelect
+                        label="District"
+                        required
+                        options={districtOptions}
+                        value={formData.district ?? ''}
+                        onChange={(e) => setFormData({ ...formData, district: e.target.value })}
+                        placeholder={districtsLoading ? 'Loading districts...' : 'Select District'}
+                    />
+                </div>
+                <div className="mt-6">
+                    <FormTextArea
+                        label="Characteristics"
+                        required
+                        rows={4}
+                        value={formData.characteristics ?? ''}
+                        onChange={(e) => setFormData({ ...formData, characteristics: e.target.value })}
+                    />
+                </div>
+            </FormSection>
 
             <FormAttachmentSection
                 title="Images"
@@ -226,7 +229,7 @@ const PpvFraPlantVarietiesForm: React.FC<PpvFraPlantVarietiesFormProps> = ({ for
                 showCaption
                 initialAttachments={formData?.photos}
                 onAttachmentIdsChange={(ids) =>
-                    setFormData({ ...formData, attachmentIds: ids })
+                    setFormData((prev: any) => ({ ...prev, attachmentIds: ids }))
                 }
             />
         </div>

--- a/frontend/src/pages/dashboard/shared/forms/miscellaneous/RAWEFETProgrammeForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/miscellaneous/RAWEFETProgrammeForms.tsx
@@ -41,12 +41,8 @@ export const RAWEFETProgrammeForms: React.FC<RAWEFETProgrammeFormsProps> = ({
         [formData, setFormData]
     )
 
-    const formDataRef = React.useRef(formData)
-    React.useEffect(() => {
-        formDataRef.current = formData
-    })
     const handleAttachmentIds = useCallback(
-        (ids: number[]) => setFormData({ ...formDataRef.current, attachmentIds: ids }),
+        (ids: number[]) => setFormData((prev: any) => ({ ...prev, attachmentIds: ids })),
         [setFormData],
     )
 

--- a/frontend/src/pages/dashboard/shared/forms/miscellaneous/RaweFetForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/miscellaneous/RaweFetForms.tsx
@@ -10,12 +10,8 @@ interface RaweFetFormsProps {
 }
 
 export const RaweFetForms: React.FC<RaweFetFormsProps> = ({ formData, setFormData }) => {
-    const formDataRef = React.useRef(formData)
-    React.useEffect(() => {
-        formDataRef.current = formData
-    })
     const handleAttachmentIds = React.useCallback(
-        (ids: number[]) => setFormData({ ...formDataRef.current, attachmentIds: ids }),
+        (ids: number[]) => setFormData((prev: any) => ({ ...prev, attachmentIds: ids })),
         [setFormData],
     )
 

--- a/frontend/src/pages/dashboard/shared/forms/projects/NaturalFarmingForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/projects/NaturalFarmingForms.tsx
@@ -9,7 +9,6 @@ import { FormAttachmentSection } from '@/components/common/FormAttachmentSection
 const NF_ATTACHMENT_MAP: Record<string, { formCode: string; pk: string }> = {
     [ENTITY_TYPES.PROJECT_NATURAL_FARMING_PHYSICAL]: { formCode: 'natural_farming_physical', pk: 'physicalInfoId' },
     [ENTITY_TYPES.PROJECT_NATURAL_FARMING_DEMO]: { formCode: 'natural_farming_demo', pk: 'demonstrationInfoId' },
-    [ENTITY_TYPES.PROJECT_NATURAL_FARMING_FARMERS]: { formCode: 'natural_farming_farmers', pk: 'farmersPracticingId' },
 }
 
 interface NaturalFarmingFormsProps {
@@ -38,8 +37,7 @@ export const NaturalFarmingForms: React.FC<NaturalFarmingFormsProps> = ({
         (activity: any) => String(activity.naturalFarmingActivityId) === String(formData.activityId || '')
     )
     const handleAttachmentIds = React.useCallback(
-        (ids: number[]) => setFormData({ ...formData, attachmentIds: ids }),
-        // eslint-disable-next-line react-hooks/exhaustive-deps
+        (ids: number[]) => setFormData((prev: any) => ({ ...prev, attachmentIds: ids })),
         [setFormData],
     )
 

--- a/frontend/src/pages/features/Gallery.tsx
+++ b/frontend/src/pages/features/Gallery.tsx
@@ -16,6 +16,7 @@ import {
   PanelLeftOpen,
   Filter,
   FolderOpen,
+  Trash2,
 } from 'lucide-react'
 import { Breadcrumbs } from '../../components/common/Breadcrumbs'
 import { Card, CardContent } from '../../components/ui/Card'
@@ -23,7 +24,9 @@ import { getBreadcrumbsForPath, getRouteConfig } from '../../config/route'
 import { useAuth } from '@/contexts/AuthContext'
 import type { ModuleImageRow } from '@/services/moduleImagesApi'
 import { API_BASE_URL } from '@/config/api'
-import { useGallerySource } from '@/hooks/useGallerySource'
+import { useGallerySource, type GalleryItem } from '@/hooks/useGallerySource'
+import { useQueryClient } from '@tanstack/react-query'
+import { formAttachmentsApi } from '@/services/formAttachmentsApi'
 
 type ViewMode = 'grid' | 'compact'
 
@@ -125,7 +128,7 @@ export const Gallery: React.FC = () => {
   )
 
   const sourceResult = useGallerySource(filters, showKvkFilter)
-  const images = sourceResult.images as unknown as ModuleImageRow[]
+  const images: GalleryItem[] = sourceResult.images
   const total = sourceResult.total
   const categoriesQuery = { data: sourceResult.categories } as { data: typeof sourceResult.categories }
   const kvksQuery = { data: sourceResult.kvks } as { data: typeof sourceResult.kvks }
@@ -137,11 +140,10 @@ export const Gallery: React.FC = () => {
     return arr
   }, [currentYear])
 
-  const moduleCounts = useMemo(() => {
-    const counts = new Map<number, number>()
-    for (const img of images) counts.set(img.moduleId, (counts.get(img.moduleId) ?? 0) + 1)
-    return counts
-  }, [images])
+  // Counts come from unfiltered queries inside useGallerySource so the sidebar
+  // numbers stay stable when one category is selected (otherwise the filtered
+  // images list shrinks to one module and other modules would all read 0).
+  const moduleCounts = sourceResult.categoryCounts
 
   const groupedCategories = useMemo(() => {
     const cats = categoriesQuery.data ?? []
@@ -203,7 +205,7 @@ export const Gallery: React.FC = () => {
   const recent = useMemo(() => images.filter(i => isRecent(i.imageDate || i.createdAt)), [images])
 
   const groupedByMonth = useMemo(() => {
-    const map = new Map<string, ModuleImageRow[]>()
+    const map = new Map<string, GalleryItem[]>()
     for (const img of images) {
       const key = formatMonthKey(img.imageDate || img.createdAt)
       if (!map.has(key)) map.set(key, [])
@@ -216,8 +218,8 @@ export const Gallery: React.FC = () => {
     })
   }, [images])
 
-  const flatOrder: ModuleImageRow[] = useMemo(() => {
-    const list: ModuleImageRow[] = []
+  const flatOrder: GalleryItem[] = useMemo(() => {
+    const list: GalleryItem[] = []
     if (recent.length) list.push(...recent)
     for (const [, arr] of groupedByMonth) list.push(...arr)
     const seen = new Set<number>()
@@ -229,7 +231,7 @@ export const Gallery: React.FC = () => {
   }, [recent, groupedByMonth])
 
   const openLightbox = useCallback(
-    (img: ModuleImageRow) => {
+    (img: GalleryItem) => {
       const idx = flatOrder.findIndex(i => i.imageId === img.imageId)
       setLightboxIdx(idx >= 0 ? idx : 0)
     },
@@ -247,6 +249,37 @@ export const Gallery: React.FC = () => {
         idx === null ? null : (idx - 1 + flatOrder.length) % flatOrder.length
       ),
     [flatOrder.length]
+  )
+
+  // FORM_ID_OFFSET in useGallerySource is 1_000_000; subtract to recover the
+  // original attachmentId from the synthetic galleryItem.imageId.
+  const FORM_ID_OFFSET = 1_000_000
+  const qc = useQueryClient()
+  const handleDelete = useCallback(
+    async (img: ModuleImageRow & { source?: 'module' | 'form' }) => {
+      if (img.source !== 'form') {
+        alert('Module images can only be deleted from the Module Images admin page.')
+        return
+      }
+      const attachmentId = img.imageId - FORM_ID_OFFSET
+      if (!confirm('Delete this image? This cannot be undone.')) return
+      try {
+        await formAttachmentsApi.remove(attachmentId)
+        qc.invalidateQueries({ queryKey: ['form-attachments'] })
+        qc.invalidateQueries({ queryKey: ['form-attachments-gallery'] })
+        qc.invalidateQueries({ queryKey: ['form-attachments-gallery-forms'] })
+        qc.invalidateQueries({ queryKey: ['form-attachments-gallery-kvks'] })
+        // Advance or close depending on remaining length.
+        setLightboxIdx((idx) => {
+          if (idx === null) return null
+          if (flatOrder.length <= 1) return null
+          return idx >= flatOrder.length - 1 ? Math.max(0, idx - 1) : idx
+        })
+      } catch (e) {
+        alert(e instanceof Error ? e.message : 'Delete failed')
+      }
+    },
+    [qc, flatOrder.length],
   )
 
   useEffect(() => {
@@ -606,6 +639,7 @@ export const Gallery: React.FC = () => {
           onClose={closeLightbox}
           onNext={nextLightbox}
           onPrev={prevLightbox}
+          onDelete={handleDelete}
         />
       )}
     </div>
@@ -631,8 +665,8 @@ const Section: React.FC<{
 )
 
 const HorizontalStrip: React.FC<{
-  images: ModuleImageRow[]
-  onOpen: (img: ModuleImageRow) => void
+  images: GalleryItem[]
+  onOpen: (img: GalleryItem) => void
 }> = ({ images, onOpen }) => (
   <div className="flex gap-3 overflow-x-auto pb-2 -mx-1 px-1 scrollbar-thin">
     {images.map(img => (
@@ -656,8 +690,8 @@ const HorizontalStrip: React.FC<{
 )
 
 const Masonry: React.FC<{
-  images: ModuleImageRow[]
-  onOpen: (img: ModuleImageRow) => void
+  images: GalleryItem[]
+  onOpen: (img: GalleryItem) => void
   mode: ViewMode
 }> = ({ images, onOpen, mode }) => {
   const cols =
@@ -672,8 +706,8 @@ const Masonry: React.FC<{
 }
 
 const Tile: React.FC<{
-  img: ModuleImageRow
-  onOpen: (img: ModuleImageRow) => void
+  img: GalleryItem
+  onOpen: (img: GalleryItem) => void
   compact?: boolean
 }> = ({ img, onOpen, compact }) => {
   return (
@@ -744,13 +778,14 @@ const EmptyState: React.FC<{ activeChips: number; onClearAll: () => void }> = ({
 )
 
 const Lightbox: React.FC<{
-  img: ModuleImageRow
+  img: GalleryItem
   index: number
   total: number
   onClose: () => void
   onNext: () => void
   onPrev: () => void
-}> = ({ img, index, total, onClose, onNext, onPrev }) => {
+  onDelete?: (img: GalleryItem) => void
+}> = ({ img, index, total, onClose, onNext, onPrev, onDelete }) => {
   const [showInfo, setShowInfo] = useState(true)
   const overlayRef = useRef<HTMLDivElement>(null)
 
@@ -790,6 +825,16 @@ const Lightbox: React.FC<{
           >
             <Download className="w-4 h-4" />
           </button>
+          {onDelete && img.source === 'form' && (
+            <button
+              onClick={() => onDelete(img)}
+              className="p-2 rounded-lg text-red-300 hover:text-white hover:bg-red-500/40"
+              title="Delete"
+              aria-label="Delete"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          )}
           <button
             onClick={onClose}
             className="p-2 rounded-lg hover:bg-white/10"


### PR DESCRIPTION
## Summary
Bundle of fixes on top of the S3 migration based on user feedback.

### UI / sizing
- \`MultiAttachmentUploader\`: input is \`lg:max-w-md\` (half-width on lg+); tile grid \`grid-cols-[repeat(auto-fill,minmax(140px,160px))]\` so tiles stay uniformly small regardless of parent width.
- Lightbox gets a **Trash** action for form-attachment items (calls \`formAttachmentsApi.remove\`, advances/closes after).
- Active \`PPVFRASensitizationForms\` migrated onto \`FormAttachmentSection\` (the legacy \`PpvFraForms.tsx\` was the wrong variant).

### Gallery groups + labels
- All 17 form codes mapped to proper sidebar groups (Achievements, Projects, Meetings, Miscellaneous, Performance Indicators).
- \`FORM_LABEL_OVERRIDES\` gives correct acronyms (e.g. \`nicra_farm_implement\` → "NICRA Custom Hiring", \`rawe_fet\` → "RAWE/FET").
- Backend always surfaces all known forms in the sidebar (\`KNOWN_GALLERY_FORM_CODES\`); \`HIDDEN_GALLERY_FORM_CODES\` filters \`kvk_staff\` and \`natural_farming_farmers\` from both \`listForms\` and \`listForGallery\`.
- Gallery filters by \`mimeType startsWith 'image/'\` (was \`kind=PHOTO\`) so RAWE/FET image uploads with \`kind=DOCUMENT\` show up.
- Sidebar counts come from an unfiltered second query so other categories don't read 0 when one is selected.
- Empty module-image categories hidden from the sidebar.

### KVK Staff + Natural Farming Farmers — removed entirely
- Frontend: \`<FormAttachmentSection>\` removed from \`AboutKvkForms\`; \`PROJECT_NATURAL_FARMING_FARMERS\` removed from \`NF_ATTACHMENT_MAP\`.
- Backend: \`STAFF_ATTACHMENTS\` binding stripped from \`aboutKvkService\`; \`farmersPracticingCrud\` reverted to plain repo passthrough — no \`form_attachments\` rows ever created for these entities.

### \`FormAttachmentSection\` robustness
- Falls back to \`useAuth().user.kvkId\` when prop \`kvkId\` is missing (covers RAWE/FET, PPV, etc. that don't auto-sync \`formData.kvkId\`).
- Effect only fires on actual \`idsKey\` content change; skips initial empty-mount fire so \`attachmentIds:[]\` doesn't clobber other fields on render.

### Form data wipe — fixed
- Every form attachment handler now uses functional \`setFormData((prev) => ({ ...prev, attachmentIds }))\`. Previously several used \`setFormData({ ...formData, attachmentIds })\` with stale closure → upload/delete wiped recent field edits (most visible on Natural Farming Demo, RAWE FET, Meetings, PPV FRA).

### Backend
- \`farmerAwardRepository\`: dropped "Image is required" check; legacy \`image\` column kept nullable for backward read.
- \`formAttachmentRepository.listForGallery\` / \`distinctFormCodes\` / \`distinctKvks\` no longer pin to \`kind=PHOTO\`.

## Test plan
- [ ] Open any image form, type fields, upload a photo, type more fields → no field wipe.
- [ ] Delete a tile → form fields preserved.
- [ ] Gallery sidebar: KVK Staff / Natural Farming Farmers absent. RAWE/FET, PPV FRA, NICRA Custom Hiring labels correct.
- [ ] Gallery: pick a form → sidebar counts on other forms still correct (not 0).
- [ ] Lightbox: Trash icon visible for form attachments; deletes and advances.
- [ ] Farmer Award create with attachmentIds → no "Image is required" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)