### PR TITLE
feat(about-kvk): KVK staff photo upload via form attachments

### DIFF
--- a/backend/services/formAttachmentService.js
+++ b/backend/services/formAttachmentService.js
@@ -25,13 +25,12 @@ const KNOWN_GALLERY_FORM_CODES = [
     'natural_farming_demo',
     'ppv_fra',
     'success_story',
+    'kvk_staff',
 ];
 
 // Form codes that should NEVER appear in the gallery sidebar even if rows
-// exist in the DB (e.g. KVK staff photos are admin-internal, not gallery
-// content; Natural Farming Farmers Practicing is excluded by request).
+// exist in the DB (Natural Farming Farmers Practicing is excluded by request).
 const HIDDEN_GALLERY_FORM_CODES = new Set([
-    'kvk_staff',
     'natural_farming_farmers',
 ]);
 

--- a/backend/services/forms/aboutKvkService.js
+++ b/backend/services/forms/aboutKvkService.js
@@ -3,9 +3,16 @@ const prisma = require('../../config/prisma.js');
 const { ValidationError } = require('../../utils/errorHandler.js');
 const { parseReportingYearDate, ensureNotFutureDate } = require('../../utils/reportingYearUtils.js');
 const { sanitizeDate, sanitizeString } = require('../../utils/dataSanitizer.js');
+const { createAttachmentBinding } = require('./formAttachmentBinding.js');
 
 /** Roles scoped to a specific KVK */
 const KVK_ROLES = ['kvk_admin', 'kvk_user'];
+
+const STAFF_ATTACHMENT_ENTITIES = new Set(['kvk-employees', 'kvk-staff-transferred']);
+const staffAttachmentBinding = createAttachmentBinding({
+    formCode: 'kvk_staff',
+    primaryKey: 'kvkStaffId',
+});
 
 /**
  * About KVK Service
@@ -52,6 +59,9 @@ class AboutKvkService {
         }
 
         const result = await aboutKvkRepository.findAll(entityName, options, user);
+        if (STAFF_ATTACHMENT_ENTITIES.has(entityName) && Array.isArray(result?.data)) {
+            result.data = await staffAttachmentBinding.decorateMany(result.data, user);
+        }
         return {
             ...result,
             page: options.page || 1,
@@ -76,7 +86,7 @@ class AboutKvkService {
                     : (typeof entity.sourceKvkIds === 'string' ? JSON.parse(entity.sourceKvkIds) : []);
                 if (Array.isArray(sourceIds) && sourceIds.includes(user.kvkId)) {
                     // Allow view access for source KVK
-                    return entity;
+                    return staffAttachmentBinding.decorate(entity, user);
                 }
             }
             throw new Error('Access denied: You can only access your own KVK data');
@@ -93,10 +103,22 @@ class AboutKvkService {
             }
         }
 
+        if (STAFF_ATTACHMENT_ENTITIES.has(entityName)) {
+            return staffAttachmentBinding.decorate(entity, user);
+        }
+
         return entity;
     }
 
     async create(entityName, data, user = null) {
+        const useStaffAttachments = STAFF_ATTACHMENT_ENTITIES.has(entityName);
+        let attachmentIds = [];
+        if (useStaffAttachments) {
+            const stripped = staffAttachmentBinding.strip(data);
+            data = stripped.payload;
+            attachmentIds = stripped.attachmentIds;
+        }
+
         // Authorization checks
         if (entityName === 'kvks') {
             // Only super_admin can create KVKs
@@ -166,10 +188,23 @@ class AboutKvkService {
         // Convert numeric fields
         const finalData = this.sanitizeNumericFields(entityName, sanitizedData);
 
-        return await aboutKvkRepository.create(entityName, finalData);
+        const created = await aboutKvkRepository.create(entityName, finalData);
+        if (useStaffAttachments) {
+            await staffAttachmentBinding.attach(created, attachmentIds, user);
+            return staffAttachmentBinding.decorate(created, user);
+        }
+        return created;
     }
 
     async update(entityName, id, data, user = null) {
+        const useStaffAttachments = STAFF_ATTACHMENT_ENTITIES.has(entityName);
+        let attachmentIds = [];
+        if (useStaffAttachments) {
+            const stripped = staffAttachmentBinding.strip(data);
+            data = stripped.payload;
+            attachmentIds = stripped.attachmentIds;
+        }
+
         // Ensure entity exists and user has access (getById enforces geographic scope)
         const currentEntity = await this.getById(entityName, id, user);
 
@@ -198,7 +233,12 @@ class AboutKvkService {
         // Convert numeric fields
         const finalData = this.sanitizeNumericFields(entityName, enumSanitized);
 
-        return await aboutKvkRepository.update(entityName, id, finalData);
+        const updated = await aboutKvkRepository.update(entityName, id, finalData);
+        if (useStaffAttachments) {
+            await staffAttachmentBinding.attach(updated ?? currentEntity, attachmentIds, user);
+            return staffAttachmentBinding.decorate(updated, user);
+        }
+        return updated;
     }
 
     async delete(entityName, id, user = null) {
@@ -221,7 +261,11 @@ class AboutKvkService {
             }
         }
 
-        return await aboutKvkRepository.deleteEntity(entityName, id);
+        const result = await aboutKvkRepository.deleteEntity(entityName, id);
+        if (STAFF_ATTACHMENT_ENTITIES.has(entityName)) {
+            await staffAttachmentBinding.cleanup(currentEntity, user);
+        }
+        return result;
     }
 
     /**

--- a/frontend/src/components/common/DataTable/TableCell.tsx
+++ b/frontend/src/components/common/DataTable/TableCell.tsx
@@ -25,7 +25,12 @@ export const TableCell: React.FC<TableCellProps> = ({ field, value, item }) => {
     // Photo/Attachment field
     const isImageValue = typeof value === 'string' && value.startsWith('data:image/') && value.includes('base64,');
     const isImageField = field === 'photo' || field === 'photoPath' || field === 'attachment' || field === 'attachmentPath' || field === 'file' || field === 'uploadedFile';
-    const imagePath = isImageValue ? value : (item[field] || item.photoPath || item.photo || item.attachmentPath || item.attachment || item.uploadedFile || item.file);
+    const photoFromAttachments = Array.isArray(item.photos) && item.photos.length > 0
+        ? (item.photos[0].fileUrl || item.photos[0].downloadUrl || null)
+        : null;
+    const imagePath = isImageValue
+        ? value
+        : (item[field] || item.photoPath || item.photo || item.attachmentPath || item.attachment || item.uploadedFile || item.file || photoFromAttachments);
     const isTransferStatusField = field === 'transferStatus' || field === 'transfer_status'
     const isOftStatusField = field === 'ongoingCompleted' || field === 'status'
     const isAccountTypeField = field === 'accountType' || field === 'account_type'

--- a/frontend/src/components/common/FormAttachmentSection.tsx
+++ b/frontend/src/components/common/FormAttachmentSection.tsx
@@ -22,6 +22,7 @@ export interface FormAttachmentSectionProps {
     disabled?: boolean
     accept?: string
     maxBytes?: number
+    maxCount?: number
     reportingYearDate?: string | null
 }
 
@@ -57,6 +58,7 @@ export const FormAttachmentSection: React.FC<FormAttachmentSectionProps> = ({
     disabled,
     accept,
     maxBytes,
+    maxCount,
     reportingYearDate,
 }) => {
     // Fall back to the logged-in user's kvkId when the form hasn't pushed it
@@ -119,6 +121,7 @@ export const FormAttachmentSection: React.FC<FormAttachmentSectionProps> = ({
                 disabled={disabled}
                 accept={accept}
                 maxBytes={maxBytes}
+                maxCount={maxCount}
                 reportingYearDate={reportingYearDate}
                 onChange={recordId ? undefined : setAttachments}
             />

--- a/frontend/src/components/common/MultiAttachmentUploader.tsx
+++ b/frontend/src/components/common/MultiAttachmentUploader.tsx
@@ -35,6 +35,7 @@ export interface MultiAttachmentUploaderProps {
     disabled?: boolean
     helperText?: string
     reportingYearDate?: string | null
+    maxCount?: number
     onChange?: (rows: FormAttachmentRow[]) => void
 }
 
@@ -93,8 +94,10 @@ export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = (
     disabled = false,
     helperText,
     reportingYearDate = null,
+    maxCount,
     onChange,
 }) => {
+    const isSingle = maxCount === 1
     const fileInputRef = useRef<HTMLInputElement>(null)
     const qc = useQueryClient()
     const updateMut = useUpdateAttachment()
@@ -107,9 +110,11 @@ export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = (
     const acceptAttr = accept ?? (kind === 'PHOTO' ? PHOTO_ACCEPT : DATASHEET_ACCEPT)
     const helper =
         helperText ??
-        (kind === 'PHOTO'
-            ? `Only images allowed. Hold Ctrl/Cmd in the file picker to select multiple. (Max ${(maxBytes / (1024 * 1024)).toFixed(0)} MB per file)`
-            : `PDF / Image / Excel / Word allowed. Hold Ctrl/Cmd to select multiple. (Max ${(maxBytes / (1024 * 1024)).toFixed(0)} MB per file)`)
+        (isSingle
+            ? `Only one image allowed. (Max ${(maxBytes / (1024 * 1024)).toFixed(0)} MB)`
+            : kind === 'PHOTO'
+                ? `Only images allowed. Hold Ctrl/Cmd in the file picker to select multiple. (Max ${(maxBytes / (1024 * 1024)).toFixed(0)} MB per file)`
+                : `PDF / Image / Excel / Word allowed. Hold Ctrl/Cmd to select multiple. (Max ${(maxBytes / (1024 * 1024)).toFixed(0)} MB per file)`)
 
     const sorted = useMemo(
         () => [...attachments].sort((a, b) => a.sortOrder - b.sortOrder || a.attachmentId - b.attachmentId),
@@ -120,7 +125,18 @@ export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = (
         async (files: FileList | null) => {
             if (!files || files.length === 0) return
             setError(null)
-            const list = Array.from(files)
+            let list = Array.from(files)
+            if (typeof maxCount === 'number' && maxCount > 0) {
+                const remaining = Math.max(0, maxCount - sorted.length)
+                if (remaining === 0) {
+                    setError(`Limit reached: only ${maxCount} file${maxCount === 1 ? '' : 's'} allowed. Remove the existing file to replace.`)
+                    if (fileInputRef.current) fileInputRef.current.value = ''
+                    return
+                }
+                if (list.length > remaining) {
+                    list = list.slice(0, remaining)
+                }
+            }
             const oversized = list.find((f) => f.size > maxBytes)
             if (oversized) {
                 setError(`"${oversized.name}" exceeds max size ${(maxBytes / (1024 * 1024)).toFixed(0)} MB`)
@@ -170,8 +186,10 @@ export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = (
             setProgress(null)
             if (fileInputRef.current) fileInputRef.current.value = ''
         },
-        [formCode, kind, kvkId, recordId, sorted, onChange, maxBytes, reportingYearDate, qc],
+        [formCode, kind, kvkId, recordId, sorted, onChange, maxBytes, maxCount, reportingYearDate, qc],
     )
+
+    const atLimit = typeof maxCount === 'number' && maxCount > 0 && sorted.length >= maxCount
 
     const handleRemove = useCallback(
         async (att: FormAttachmentRow) => {
@@ -211,8 +229,8 @@ export const MultiAttachmentUploader: React.FC<MultiAttachmentUploaderProps> = (
                     ref={fileInputRef}
                     type="file"
                     accept={acceptAttr}
-                    multiple
-                    disabled={disabled || uploading}
+                    multiple={!isSingle}
+                    disabled={disabled || uploading || atLimit}
                     onChange={(e) => handleFiles(e.target.files)}
                     className="block w-full text-sm bg-white px-3 py-2 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-[#487749] file:text-white hover:file:bg-[#3d6540] cursor-pointer disabled:opacity-60"
                 />

--- a/frontend/src/hooks/useGallerySource.ts
+++ b/frontend/src/hooks/useGallerySource.ts
@@ -61,6 +61,7 @@ const FORM_LABEL_OVERRIDES: Record<string, string> = {
     farmer_award: 'Farmer Award',
     arya_current_year: 'ARYA Current Year',
     success_story: 'Success Story',
+    kvk_staff: 'KVK Staff Photos',
 }
 
 // Maps a formCode to the sidebar group it should appear under. Falls back to
@@ -83,6 +84,7 @@ const FORM_MENU_BY_CODE: Record<string, string> = {
     rawe_fet: 'Miscellaneous',
     ppv_fra: 'Miscellaneous',
     success_story: 'Performance Indicators',
+    kvk_staff: 'About KVKs',
 }
 
 const DEFAULT_FORMS_MENU_NAME = 'Form Attachments'
@@ -136,7 +138,10 @@ export function useGallerySource(
     // Translate selected synthetic moduleId to formCode if it belongs to forms.
     // Module-image queries should not pass a synthetic id (out of range), so
     // strip moduleId when it's >= FORM_ID_OFFSET.
-    const isFormSelection = (filters.moduleId ?? 0) >= FORM_ID_OFFSET
+    // Also treat an explicit formCode filter as a form-only selection so module
+    // images don't bleed into the result list.
+    const isFormSelection =
+        (filters.moduleId ?? 0) >= FORM_ID_OFFSET || Boolean(filters.formCode)
     const moduleImageFilters = {
         ...filters,
         moduleId: isFormSelection ? undefined : filters.moduleId,

--- a/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
@@ -21,6 +21,9 @@ import { masterDataApi } from '@/services/masterDataApi'
 import { useUniversityHostFields } from '@/hooks/useUniversityHostFields'
 import { cleanIndianMobileInput } from '@/utils/indianPhone'
 import { toOptions, toFilteredOptions } from '@/utils/formOptions'
+import { FormAttachmentSection } from '@/components/common/FormAttachmentSection'
+
+const KVK_STAFF_FORM_CODE = 'kvk_staff'
 
 // Label resolvers — pure, hoisted outside the component so they keep stable
 // identity across renders and don't pull closures from props.
@@ -209,33 +212,10 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
         }
     }, [entityType, setFormData])
 
-    // Normalize incoming photoPath for KVK Employees/Staff
-    React.useEffect(() => {
-        if (entityType === ENTITY_TYPES.KVK_EMPLOYEES || entityType === ENTITY_TYPES.KVK_STAFF_TRANSFERRED) {
-            const field = 'photoPath';
-            if (formData[field] && typeof formData[field] === 'string') {
-                if (formData[field].startsWith('[') || formData[field].startsWith('{')) {
-                    try {
-                        const parsed = JSON.parse(formData[field]);
-                        const arrayToMap = Array.isArray(parsed) ? parsed : [parsed];
-                        const normalized = arrayToMap.map((item: any) => {
-                            if (typeof item === 'string') {
-                                return { preview: item, image: item, caption: '' };
-                            }
-                            const url = item.image || item.url || item.path || item.preview || '';
-                            return { preview: url, image: url, caption: item.caption || '' };
-                        });
-                        setFormData((prev: any) => ({ ...prev, [field]: normalized }));
-                    } catch (e) {
-                        console.error('Photo parsing error:', e);
-                    }
-                } else if (formData[field].trim() !== '') {
-                    const normalized = [{ preview: formData[field].trim(), image: formData[field].trim(), caption: '' }];
-                    setFormData((prev: any) => ({ ...prev, [field]: normalized }));
-                }
-            }
-        }
-    }, [formData.kvkStaffId, formData.id, entityType, setFormData]);
+    const handleStaffAttachmentIds = React.useCallback(
+        (ids: number[]) => setFormData((prev: any) => ({ ...prev, attachmentIds: ids })),
+        [setFormData],
+    )
     // Autofill host fields from selected University
     const selectedUniversityId = typeof formData.universityId === 'number' ? formData.universityId : undefined
     const { data: uniHost } = useUniversityHostFields(selectedUniversityId)
@@ -363,6 +343,18 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 value={formData.resumePath ?? ''}
                                 onChange={(e) => setFormData({ ...formData, resumePath: e.target.value })}
                                 placeholder="Resume link"
+                            />
+                        </div>
+                        <div className="mt-6">
+                            <FormAttachmentSection
+                                title="Photograph"
+                                formCode={KVK_STAFF_FORM_CODE}
+                                kind="PHOTO"
+                                kvkId={formData.kvkId ?? user?.kvkId ?? null}
+                                recordId={formData.kvkStaffId ?? formData.id ?? null}
+                                maxCount={1}
+                                initialAttachments={formData?.photos}
+                                onAttachmentIdsChange={handleStaffAttachmentIds}
                             />
                         </div>
                     </FormSection>

--- a/frontend/src/pages/features/Gallery.tsx
+++ b/frontend/src/pages/features/Gallery.tsx
@@ -935,6 +935,16 @@ const Lightbox: React.FC<{
               Open
             </a>
           </div>
+          {onDelete && img.source === 'form' && (
+            <div className="pt-3">
+              <button
+                onClick={() => onDelete(img)}
+                className="w-full inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-lg border border-red-200 text-red-600 hover:bg-red-50 transition-colors"
+              >
+                <Trash2 className="w-4 h-4" /> Delete image
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/services/aboutKvkApi.ts
+++ b/frontend/src/services/aboutKvkApi.ts
@@ -37,7 +37,7 @@ const STAFF_ALLOWED_KEYS = [
     'kvkId', 'staffName', 'email', 'mobile', 'dateOfBirth', 'photoPath', 'resumePath',
     'sanctionedPostId', 'positionOrder', 'disciplineId', 'payScaleId', 'dateOfJoining',
     'jobType', 'allowances', 'transferStatus', 'sourceKvkIds', 'originalKvkId',
-    'staffCategoryId', 'payLevelId',
+    'staffCategoryId', 'payLevelId', 'attachmentIds',
 ] as const;
 
 const INFRASTRUCTURE_ALLOWED_KEYS = [


### PR DESCRIPTION
## Summary
- Wire `kvk_staff` form-attachment binding into AboutKvk service so staff CRUD links/cleans up `FormAttachment` rows.
- Add single-image (`maxCount=1`) photo input to KVK Employee Details form; uploads via S3 presign and store in `form_attachments`.
- Surface `kvk_staff` in the Gallery sidebar under **About KVKs** with the **KVK Staff Photos** label.
- Fix gallery filter cross-bleed: a `formCode` filter no longer shows unrelated module-image rows.
- Add Delete action to the lightbox details panel for form-source images.
- DataTable photo column falls back to `photos[0].fileUrl` so the staff list renders the uploaded photo.

## Test plan
- [ ] Create a new staff record with a photo → verify S3 upload, row appears on edit, photo renders in table.
- [ ] Upload a second image → input is disabled at 1; remove existing then re-upload to replace.
- [ ] Open Gallery → confirm `KVK Staff Photos` appears under **About KVKs**, count matches.
- [ ] Filter by Farmer Award (or any other form) → only that form's images appear (no module-image leakage).
- [ ] Open a form-source image in lightbox → click **Delete image** in details panel → confirm removal.
- [ ] Delete staff record → verify attachment cleanup (rows + S3 keys removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)