### PR TITLE
feat(dashboard): chart views + per-KVK status segments

### DIFF
--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -4,6 +4,8 @@
     "": {
       "name": "backend",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1037.0",
+        "@aws-sdk/s3-request-presigner": "^3.1037.0",
         "@prisma/adapter-pg": "^7.2.0",
         "@prisma/client": "^7.2.0",
         "@sparticuz/chromium": "^133.0.0",
@@ -28,6 +30,90 @@
     },
   },
   "packages": {
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/crc32c": ["@aws-crypto/crc32c@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag=="],
+
+    "@aws-crypto/sha1-browser": ["@aws-crypto/sha1-browser@5.2.0", "", { "dependencies": { "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1040.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.7", "@aws-sdk/credential-provider-node": "^3.972.38", "@aws-sdk/middleware-bucket-endpoint": "^3.972.10", "@aws-sdk/middleware-expect-continue": "^3.972.10", "@aws-sdk/middleware-flexible-checksums": "^3.974.15", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-location-constraint": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-sdk-s3": "^3.972.36", "@aws-sdk/middleware-ssec": "^3.972.10", "@aws-sdk/middleware-user-agent": "^3.972.37", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/signature-v4-multi-region": "^3.996.24", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.23", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/eventstream-serde-browser": "^4.2.14", "@smithy/eventstream-serde-config-resolver": "^4.3.14", "@smithy/eventstream-serde-node": "^4.2.14", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-blob-browser": "^4.2.15", "@smithy/hash-node": "^4.2.14", "@smithy/hash-stream-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/md5-js": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "@smithy/util-waiter": "^4.3.0", "tslib": "^2.6.2" } }, "sha512-Ldfby1xDrlZwNY2NxP9pwdVrf8sqHbGBKP1UkoG/oWcePGlGhjY8iVwy8hRy9f1EQfHVFWIFunwHaPQxhYTnWQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.7", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/xml-builder": "^3.972.22", "@smithy/core": "^3.23.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-YhRC90ofz5oolTJZlA8voU/oUrCB2azi8Usx51k8hhB5LpWbYQMMXKUqSqkoL0Cru+RQJgWTHpAfEDDIwfUhJw=="],
+
+    "@aws-sdk/crc64-nvme": ["@aws-sdk/crc64-nvme@3.972.7", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.33", "", { "dependencies": { "@aws-sdk/core": "^3.974.7", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.35", "", { "dependencies": { "@aws-sdk/core": "^3.974.7", "@aws-sdk/types": "^3.973.8", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.6.1", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-stream": "^4.5.25", "tslib": "^2.6.2" } }, "sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.37", "", { "dependencies": { "@aws-sdk/core": "^3.974.7", "@aws-sdk/credential-provider-env": "^3.972.33", "@aws-sdk/credential-provider-http": "^3.972.35", "@aws-sdk/credential-provider-login": "^3.972.37", "@aws-sdk/credential-provider-process": "^3.972.33", "@aws-sdk/credential-provider-sso": "^3.972.37", "@aws-sdk/credential-provider-web-identity": "^3.972.37", "@aws-sdk/nested-clients": "^3.997.5", "@aws-sdk/types": "^3.973.8", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.37", "", { "dependencies": { "@aws-sdk/core": "^3.974.7", "@aws-sdk/nested-clients": "^3.997.5", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.38", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.33", "@aws-sdk/credential-provider-http": "^3.972.35", "@aws-sdk/credential-provider-ini": "^3.972.37", "@aws-sdk/credential-provider-process": "^3.972.33", "@aws-sdk/credential-provider-sso": "^3.972.37", "@aws-sdk/credential-provider-web-identity": "^3.972.37", "@aws-sdk/types": "^3.973.8", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.33", "", { "dependencies": { "@aws-sdk/core": "^3.974.7", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.37", "", { "dependencies": { "@aws-sdk/core": "^3.974.7", "@aws-sdk/nested-clients": "^3.997.5", "@aws-sdk/token-providers": "3.1039.0", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.37", "", { "dependencies": { "@aws-sdk/core": "^3.974.7", "@aws-sdk/nested-clients": "^3.997.5", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw=="],
+
+    "@aws-sdk/middleware-bucket-endpoint": ["@aws-sdk/middleware-bucket-endpoint@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA=="],
+
+    "@aws-sdk/middleware-expect-continue": ["@aws-sdk/middleware-expect-continue@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ=="],
+
+    "@aws-sdk/middleware-flexible-checksums": ["@aws-sdk/middleware-flexible-checksums@3.974.15", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@aws-crypto/crc32c": "5.2.0", "@aws-crypto/util": "5.2.0", "@aws-sdk/core": "^3.974.7", "@aws-sdk/crc64-nvme": "^3.972.7", "@aws-sdk/types": "^3.973.8", "@smithy/is-array-buffer": "^4.2.2", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-j4Zp7rA1HfhDTteICnx/tPax4N/v5wmytgguXExUGyEwQ8Ug4EBA4kjp9puFAN1UZoBVpxoiXMiuTFvjaHjeEw=="],
+
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg=="],
+
+    "@aws-sdk/middleware-location-constraint": ["@aws-sdk/middleware-location-constraint@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ=="],
+
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ=="],
+
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.974.7", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/core": "^3.23.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-YhPix+0x/MdQrb1Ug1GDKeS5fqylIy+naz800asX8II4jqfTk2KY2KhmmYCwZcky8YWtRQQwWCGdoqeAnip8Uw=="],
+
+    "@aws-sdk/middleware-ssec": ["@aws-sdk/middleware-ssec@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw=="],
+
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.37", "", { "dependencies": { "@aws-sdk/core": "^3.974.7", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@smithy/core": "^3.23.17", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-retry": "^4.3.6", "tslib": "^2.6.2" } }, "sha512-N1oNpdiLoVAWYD3WFBnUi3LlfoDA06ZHo4ozyjbsJNLvILzvt//0CnR8N+CZ0NWeYgVB/5V59ivixHCWCx2ALw=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.5", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.7", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.37", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/signature-v4-multi-region": "^3.996.24", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.23", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg=="],
+
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/config-resolver": "^4.4.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A=="],
+
+    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1040.0", "", { "dependencies": { "@aws-sdk/signature-v4-multi-region": "^3.996.24", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-format-url": "^3.972.10", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-AmesZGG/B5sDIiWahyY11fOkXSsuHc7LciE88YFURehMVSdEORo2Vzz1d2kBgmJG9oar5Vmmwf9X/w7mqb7ytg=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.24", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.36", "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1039.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.7", "@aws-sdk/nested-clients": "^3.997.5", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
+
+    "@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.972.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA=="],
+
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-endpoints": "^3.4.2", "tslib": "^2.6.2" } }, "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g=="],
+
+    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g=="],
+
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.23", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.37", "@aws-sdk/types": "^3.973.8", "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-gGwq8L2Euw0aNG6Ey4EktiAo3fSCVoDy1CaBIthd+oeaKHPXUrNaApMewQ6La5Hv0lcznOtECZaNvYyc5LXXfA=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.22", "", { "dependencies": { "@nodable/entities": "2.1.0", "@smithy/types": "^4.14.1", "fast-xml-parser": "5.7.2", "tslib": "^2.6.2" } }, "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
@@ -56,6 +142,8 @@
 
     "@mrleebo/prisma-ast": ["@mrleebo/prisma-ast@0.12.1", "", { "dependencies": { "chevrotain": "^10.5.0", "lilconfig": "^2.1.0" } }, "sha512-JwqeCQ1U3fvccttHZq7Tk0m/TMC6WcFAQZdukypW3AzlJYKYTGNVd1ANU2GuhKnv4UQuOFj3oAl0LLG/gxFN1w=="],
 
+    "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
+
     "@prisma/adapter-pg": ["@prisma/adapter-pg@7.2.0", "", { "dependencies": { "@prisma/driver-adapter-utils": "7.2.0", "pg": "^8.16.3", "postgres-array": "3.0.4" } }, "sha512-euIdQ13cRB2wZ3jPsnDnFhINquo1PYFPCg6yVL8b2rp3EdinQHsX9EDdCtRr489D5uhphcRk463OdQAFlsCr0w=="],
 
     "@prisma/client": ["@prisma/client@7.2.0", "", { "dependencies": { "@prisma/client-runtime-utils": "7.2.0" }, "peerDependencies": { "prisma": "*", "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-JdLF8lWZ+LjKGKpBqyAlenxd/kXjd1Abf/xK+6vUA7R7L2Suo6AFTHFRpPSdAKCan9wzdFApsUpSa/F6+t1AtA=="],
@@ -83,6 +171,106 @@
     "@prisma/studio-core": ["@prisma/studio-core@0.9.0", "", { "peerDependencies": { "@types/react": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-xA2zoR/ADu/NCSQuriBKTh6Ps4XjU0bErkEcgMfnSGh346K1VI7iWKnoq1l2DoxUqiddPHIEWwtxJ6xCHG6W7g=="],
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.12.0", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.3", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-Xuq42yxcQJ54ti8ZHNzF5snFvtpgXzNToJ1bXUGQRaiO8t+B6UM8sTUJfvV+AJnqtkJU/7hdy6nbKyA12aHtRw=="],
+
+    "@smithy/chunked-blob-reader": ["@smithy/chunked-blob-reader@5.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw=="],
+
+    "@smithy/chunked-blob-reader-native": ["@smithy/chunked-blob-reader-native@4.2.3", "", { "dependencies": { "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw=="],
+
+    "@smithy/config-resolver": ["@smithy/config-resolver@4.4.17", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ=="],
+
+    "@smithy/core": ["@smithy/core@3.23.17", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.2.14", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg=="],
+
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.14", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw=="],
+
+    "@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.2.14", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ=="],
+
+    "@smithy/eventstream-serde-config-resolver": ["@smithy/eventstream-serde-config-resolver@4.3.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA=="],
+
+    "@smithy/eventstream-serde-node": ["@smithy/eventstream-serde-node@4.2.14", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw=="],
+
+    "@smithy/eventstream-serde-universal": ["@smithy/eventstream-serde-universal@4.2.14", "", { "dependencies": { "@smithy/eventstream-codec": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.17", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw=="],
+
+    "@smithy/hash-blob-browser": ["@smithy/hash-blob-browser@4.2.15", "", { "dependencies": { "@smithy/chunked-blob-reader": "^5.2.2", "@smithy/chunked-blob-reader-native": "^4.2.3", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA=="],
+
+    "@smithy/hash-node": ["@smithy/hash-node@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g=="],
+
+    "@smithy/hash-stream-node": ["@smithy/hash-stream-node@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ=="],
+
+    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@smithy/md5-js": ["@smithy/md5-js@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA=="],
+
+    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.2.14", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw=="],
+
+    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.4.32", "", { "dependencies": { "@smithy/core": "^3.23.17", "@smithy/middleware-serde": "^4.2.20", "@smithy/node-config-provider": "^4.3.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-middleware": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q=="],
+
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.5.7", "", { "dependencies": { "@smithy/core": "^3.23.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/service-error-classification": "^4.3.1", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg=="],
+
+    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.2.20", "", { "dependencies": { "@smithy/core": "^3.23.17", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ=="],
+
+    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA=="],
+
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.3.14", "", { "dependencies": { "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.6.1", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg=="],
+
+    "@smithy/property-provider": ["@smithy/property-provider@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ=="],
+
+    "@smithy/protocol-http": ["@smithy/protocol-http@5.3.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ=="],
+
+    "@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A=="],
+
+    "@smithy/querystring-parser": ["@smithy/querystring-parser@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw=="],
+
+    "@smithy/service-error-classification": ["@smithy/service-error-classification@4.3.1", "", { "dependencies": { "@smithy/types": "^4.14.1" } }, "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw=="],
+
+    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.9", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.3.14", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-uri-escape": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA=="],
+
+    "@smithy/smithy-client": ["@smithy/smithy-client@4.12.13", "", { "dependencies": { "@smithy/core": "^3.23.17", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-stack": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-stream": "^4.5.25", "tslib": "^2.6.2" } }, "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA=="],
+
+    "@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@smithy/url-parser": ["@smithy/url-parser@4.2.14", "", { "dependencies": { "@smithy/querystring-parser": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ=="],
+
+    "@smithy/util-base64": ["@smithy/util-base64@4.3.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ=="],
+
+    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ=="],
+
+    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.2.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.2", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q=="],
+
+    "@smithy/util-config-provider": ["@smithy/util-config-provider@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ=="],
+
+    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.3.49", "", { "dependencies": { "@smithy/property-provider": "^4.2.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw=="],
+
+    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.2.54", "", { "dependencies": { "@smithy/config-resolver": "^4.4.17", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw=="],
+
+    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.4.2", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg=="],
+
+    "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg=="],
+
+    "@smithy/util-middleware": ["@smithy/util-middleware@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw=="],
+
+    "@smithy/util-retry": ["@smithy/util-retry@4.3.6", "", { "dependencies": { "@smithy/service-error-classification": "^4.3.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew=="],
+
+    "@smithy/util-stream": ["@smithy/util-stream@4.5.25", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.6.1", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA=="],
+
+    "@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
+
+    "@smithy/util-waiter": ["@smithy/util-waiter@4.3.0", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA=="],
+
+    "@smithy/uuid": ["@smithy/uuid@1.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g=="],
 
     "@sparticuz/chromium": ["@sparticuz/chromium@133.0.0", "", { "dependencies": { "follow-redirects": "^1.15.9", "tar-fs": "^3.0.8" } }, "sha512-wioNxMtSxRI+Y6ymc/UFPX9lY7A1SDgBezjFITH6arwe5CONfWosNDGpgflUGYajxxGktb1k3kjJ83jWzbccBw=="],
 
@@ -147,6 +335,8 @@
     "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -303,6 +493,10 @@
     "fast-csv": ["fast-csv@4.3.6", "", { "dependencies": { "@fast-csv/format": "4.3.5", "@fast-csv/parse": "4.3.6" } }, "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.1.5", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
 
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
@@ -530,6 +724,8 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -692,6 +888,8 @@
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
+
     "tar-fs": ["tar-fs@3.1.1", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg=="],
 
     "tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
@@ -760,6 +958,12 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
     "@fast-csv/format/@types/node": ["@types/node@14.18.63", "", {}, "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="],
 
     "@fast-csv/parse/@types/node": ["@types/node@14.18.63", "", {}, "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="],
@@ -796,6 +1000,12 @@
 
     "zip-stream/archiver-utils": ["archiver-utils@3.0.4", "", { "dependencies": { "glob": "^7.2.3", "graceful-fs": "^4.2.0", "lazystream": "^1.0.0", "lodash.defaults": "^4.2.0", "lodash.difference": "^4.5.0", "lodash.flatten": "^4.4.0", "lodash.isplainobject": "^4.0.6", "lodash.union": "^4.6.0", "normalize-path": "^3.0.0", "readable-stream": "^3.6.0" } }, "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw=="],
 
+    "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
     "archiver-utils/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "archiver-utils/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
@@ -817,5 +1027,11 @@
     "unzipper/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "unzipper/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
   }
 }

--- a/backend/services/dashboardService.js
+++ b/backend/services/dashboardService.js
@@ -132,6 +132,8 @@ const dashboardService = {
     const trainingWhere = { ...achKvk, ...trainingDateClause(yearMode) };
     const extensionWhere = { ...achKvk, ...extensionDateClause(yearMode) };
 
+    const now = new Date();
+
     const currentYear = new Date().getFullYear();
     const yearOptions = Array.from({ length: 20 }, (_, i) => currentYear - i);
 
@@ -149,12 +151,14 @@ const dashboardService = {
       trainingTotal,
       extensionSum,
       staffTotal,
-      oftGroup,
+      oftStatusGroup,
       oftCompletedGroup,
-      fldGroup,
+      fldStatusGroup,
       fldCompletedGroup,
       trainingGroup,
       extensionGroup,
+      trainingCompletedGroup,
+      extensionCompletedGroup,
       staffPostGroups,
       recentLogs,
     ] = await Promise.all([
@@ -175,7 +179,7 @@ const dashboardService = {
         where: buildStaffWhere(listWhere),
       }),
       prisma.kvkoft.groupBy({
-        by: ['kvkId'],
+        by: ['kvkId', 'status'],
         where: oftWhere,
         _count: { _all: true },
       }),
@@ -185,7 +189,7 @@ const dashboardService = {
         _count: { _all: true },
       }),
       prisma.kvkFldIntroduction.groupBy({
-        by: ['kvkId'],
+        by: ['kvkId', 'ongoingCompleted'],
         where: fldWhere,
         _count: { _all: true },
       }),
@@ -202,6 +206,16 @@ const dashboardService = {
       prisma.kvkExtensionActivity.groupBy({
         by: ['kvkId'],
         where: extensionWhere,
+        _sum: { numberOfActivities: true },
+      }),
+      prisma.trainingAchievement.groupBy({
+        by: ['kvkId'],
+        where: { ...trainingWhere, endDate: { lt: now } },
+        _count: { _all: true },
+      }),
+      prisma.kvkExtensionActivity.groupBy({
+        by: ['kvkId'],
+        where: { ...extensionWhere, endDate: { lt: now } },
         _sum: { numberOfActivities: true },
       }),
       prisma.kvkStaff.groupBy({
@@ -229,21 +243,69 @@ const dashboardService = {
       orderBy: [{ kvkName: 'asc' }, { kvkId: 'asc' }],
     });
 
-    const oftCreatedByKvk = countMapFromGroup(oftGroup);
     const oftCompletedByKvk = countMapFromGroup(oftCompletedGroup);
-    const fldCreatedByKvk = countMapFromGroup(fldGroup);
     const fldCompletedByKvk = countMapFromGroup(fldCompletedGroup);
     const trainAch = new Map(trainingGroup.map((g) => [g.kvkId, g._count._all]));
     const extAch = new Map(extensionGroup.map((g) => [g.kvkId, toNumber(g._sum?.numberOfActivities)]));
 
+    function buildStatusMap(rows, statusKey, mapping) {
+      const m = new Map();
+      for (const r of rows) {
+        const slot = mapping[r[statusKey]];
+        if (!slot) continue;
+        const cur = m.get(r.kvkId) || { ongoing: 0, completed: 0, notStarted: 0 };
+        cur[slot] += toNumber(r._count?._all);
+        m.set(r.kvkId, cur);
+      }
+      return m;
+    }
+
+    const oftStatusByKvk = buildStatusMap(oftStatusGroup, 'status', {
+      ONGOING: 'ongoing',
+      COMPLETED: 'completed',
+      TRANSFERRED_TO_NEXT_YEAR: 'ongoing',
+    });
+    const fldStatusByKvk = buildStatusMap(fldStatusGroup, 'ongoingCompleted', {
+      ONGOING: 'ongoing',
+      COMPLETED: 'completed',
+      TRANSFERRED_TO_NEXT_YEAR: 'ongoing',
+    });
+
+    const trainingCompletedByKvk = new Map(
+      trainingCompletedGroup.map((g) => [g.kvkId, toNumber(g._count?._all)])
+    );
+    const extensionCompletedByKvk = new Map(
+      extensionCompletedGroup.map((g) => [g.kvkId, toNumber(g._sum?.numberOfActivities)])
+    );
+
+    function emptySegments() {
+      return { ongoing: 0, completed: 0, notStarted: 0 };
+    }
+
     const perKvk = kvkRows.map((k) => {
       const oid = k.kvkId;
-      const oftCreated = toNumber(oftCreatedByKvk.get(oid));
+      const oftSegRaw = oftStatusByKvk.get(oid) || emptySegments();
+      const oftCreated = oftSegRaw.ongoing + oftSegRaw.completed;
       const oftCompleted = toNumber(oftCompletedByKvk.get(oid));
-      const fldCreated = toNumber(fldCreatedByKvk.get(oid));
+      const oftSeg = {
+        ongoing: oftSegRaw.ongoing,
+        completed: oftSegRaw.completed,
+        notStarted: oftCreated === 0 ? 1 : 0,
+      };
+      const fldSegRaw = fldStatusByKvk.get(oid) || emptySegments();
+      const fldCreated = fldSegRaw.ongoing + fldSegRaw.completed;
       const fldCompleted = toNumber(fldCompletedByKvk.get(oid));
+      const fldSeg = {
+        ongoing: fldSegRaw.ongoing,
+        completed: fldSegRaw.completed,
+        notStarted: fldCreated === 0 ? 1 : 0,
+      };
       const trainC = toNumber(trainAch.get(oid));
       const extC = toNumber(extAch.get(oid));
+      const trainCompleted = toNumber(trainingCompletedByKvk.get(oid));
+      const trainOngoing = Math.max(trainC - trainCompleted, 0);
+      const extCompleted = toNumber(extensionCompletedByKvk.get(oid));
+      const extOngoing = Math.max(extC - extCompleted, 0);
 
       return {
         kvkId: oid,
@@ -252,19 +314,31 @@ const dashboardService = {
           completed: oftCompleted,
           created: oftCreated,
           status: computeOftFldStatus(oftCompleted, oftCreated),
+          segments: oftSeg,
         },
         fld: {
           completed: fldCompleted,
           created: fldCreated,
           status: computeOftFldStatus(fldCompleted, fldCreated),
+          segments: fldSeg,
         },
         training: {
           count: trainC,
           status: trainC > 0 ? 'active' : 'pending',
+          segments: {
+            ongoing: trainOngoing,
+            completed: trainCompleted,
+            notStarted: trainC === 0 ? 1 : 0,
+          },
         },
         extension: {
           count: extC,
           status: extC > 0 ? 'active' : 'pending',
+          segments: {
+            ongoing: extOngoing,
+            completed: extCompleted,
+            notStarted: extC === 0 ? 1 : 0,
+          },
         },
       };
     });

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -18,6 +18,7 @@
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.12.0",
+        "recharts": "^3.8.1",
         "shadcn": "^4.1.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
@@ -291,6 +292,8 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.55.1", "", { "os": "android", "cpu": "arm" }, "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg=="],
@@ -347,6 +350,10 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
     "@tabby_ai/hijri-converter": ["@tabby_ai/hijri-converter@1.0.5", "", {}, "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
@@ -397,6 +404,24 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -412,6 +437,8 @@
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
@@ -543,6 +570,28 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
@@ -550,6 +599,8 @@
     "date-fns-jalali": ["date-fns-jalali@4.1.0-0", "", {}, "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
 
@@ -599,6 +650,8 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
+
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": "bin/esbuild" }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
@@ -632,6 +685,8 @@
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
@@ -747,11 +802,15 @@
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "iobuffer": ["iobuffer@5.4.0", "", {}, "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA=="],
 
@@ -993,6 +1052,10 @@
 
     "react-dom": ["react-dom@19.2.3", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg=="],
 
+    "react-is": ["react-is@19.2.5", "", {}, "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ=="],
+
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
@@ -1006,6 +1069,12 @@
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "regenerator-runtime": ["regenerator-runtime@0.13.11", "", {}, "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="],
 
@@ -1165,6 +1234,8 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
@@ -1248,6 +1319,8 @@
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@ts-morph/common/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.12.0",
+        "recharts": "^3.8.1",
         "shadcn": "^4.1.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",

--- a/frontend/src/pages/dashboard/KVKDashboard.tsx
+++ b/frontend/src/pages/dashboard/KVKDashboard.tsx
@@ -23,6 +23,7 @@ import {
     DashboardKpiSkeleton,
     DashboardPanelsSkeleton,
 } from './shared/DashboardSkeletons'
+import { StatChartPanel } from './shared/StatChartPanel'
 
 const getProgressColor = (status: string) => {
     switch (status) {
@@ -40,22 +41,6 @@ const getProgressColor = (status: string) => {
     }
 }
 
-const getBadgeColor = (status: string) => {
-    switch (status) {
-        case 'complete':
-        case 'active':
-            return 'bg-[#E8F5E9] text-[#487749] border border-[#C8E6C9]'
-        case 'in-progress':
-            return 'bg-[#F1F8E9] text-[#487749] border border-[#DCEDC8]'
-        case 'over':
-            return 'bg-[#FFF3E0] text-[#F57C00] border border-[#FFE0B2]'
-        case 'pending':
-            return 'bg-[#F5F5F5] text-[#757575] border border-[#E0E0E0]'
-        default:
-            return 'bg-[#F5F5F5] text-[#757575] border border-[#E0E0E0]'
-    }
-}
-
 function formatLogTime(iso: string) {
     try {
         const d = new Date(iso)
@@ -66,11 +51,6 @@ function formatLogTime(iso: string) {
     } catch {
         return iso
     }
-}
-
-function progressCompletedOverCreated(completed: number, created: number) {
-    if (created <= 0) return 0
-    return Math.min((completed / created) * 100, 100)
 }
 
 export const KVKDashboard: React.FC = () => {
@@ -243,187 +223,64 @@ export const KVKDashboard: React.FC = () => {
                     <div
                         className={`grid grid-cols-1 lg:grid-cols-2 gap-3 transition-opacity ${isFetching ? 'opacity-70' : ''}`}
                     >
-                        <Card className="border-[#E0E0E0] shadow-none">
-                            <CardContent className="p-0">
-                                <div className="border-b border-[#E0E0E0] bg-[#FAF9F6]">
-                                    <h3 className="text-xs font-bold text-[#487749] uppercase tracking-wider">
-                                        OFT
-                                    </h3>
-                                    <p className="text-[10px] text-[#757575] mt-0.5 mb-1">
-                                        Completed / created
-                                    </p>
-                                </div>
-                                <div className="mt-2 space-y-3">
-                                    {data.perKvk.map(row => {
-                                        const progress =
-                                            progressCompletedOverCreated(
-                                                row.oft.completed,
-                                                row.oft.created
-                                            )
-                                        return (
-                                            <div
-                                                key={row.kvkId}
-                                                className="space-y-1"
-                                            >
-                                                <div className="flex items-start justify-between gap-2">
-                                                    <span className="text-xs font-bold text-[#212121] line-clamp-2">
-                                                        {row.kvkName}
-                                                    </span>
-                                                    <div className="text-right shrink-0">
-                                                        <span
-                                                            className={`inline-block px-2 py-0.5 rounded-md text-[11px] font-bold ${getBadgeColor(row.oft.status)}`}
-                                                        >
-                                                            {row.oft.completed}{' '}
-                                                            / {row.oft.created}
-                                                        </span>
-                                                        <p className="text-[9px] text-[#757575] mt-0.5">
-                                                            completed / created
-                                                        </p>
-                                                    </div>
-                                                </div>
-                                                <div className="w-full bg-[#F5F5F5] rounded-full h-1.5 border border-[#E0E0E0]/50">
-                                                    <div
-                                                        className={`h-1.5 rounded-full ${getProgressColor(row.oft.status)} transition-all duration-700`}
-                                                        style={{
-                                                            width: `${progress}%`,
-                                                        }}
-                                                    />
-                                                </div>
-                                            </div>
-                                        )
-                                    })}
-                                </div>
-                            </CardContent>
-                        </Card>
-
-                        <Card className="border-[#E0E0E0] shadow-none">
-                            <CardContent className="p-0">
-                                <div className="border-b border-[#E0E0E0] bg-[#FAF9F6]">
-                                    <h3 className="text-xs font-bold text-[#487749] uppercase tracking-wider">
-                                        FLD
-                                    </h3>
-                                    <p className="text-[10px] text-[#757575] mt-0.5 mb-1">
-                                        Completed / created
-                                    </p>
-                                </div>
-                                <div className="mt-2 space-y-3">
-                                    {data.perKvk.map(row => {
-                                        const progress =
-                                            progressCompletedOverCreated(
-                                                row.fld.completed,
-                                                row.fld.created
-                                            )
-                                        return (
-                                            <div
-                                                key={row.kvkId}
-                                                className="space-y-1"
-                                            >
-                                                <div className="flex items-start justify-between gap-2">
-                                                    <span className="text-xs font-bold text-[#212121] line-clamp-2">
-                                                        {row.kvkName}
-                                                    </span>
-                                                    <div className="text-right shrink-0">
-                                                        <span
-                                                            className={`inline-block px-2 py-0.5 rounded-md text-[11px] font-bold ${getBadgeColor(row.fld.status)}`}
-                                                        >
-                                                            {row.fld.completed}{' '}
-                                                            / {row.fld.created}
-                                                        </span>
-                                                        <p className="text-[9px] text-[#757575] mt-0.5">
-                                                            completed / created
-                                                        </p>
-                                                    </div>
-                                                </div>
-                                                <div className="w-full bg-[#F5F5F5] rounded-full h-1.5 border border-[#E0E0E0]/50">
-                                                    <div
-                                                        className={`h-1.5 rounded-full ${getProgressColor(row.fld.status)} transition-all duration-700`}
-                                                        style={{
-                                                            width: `${progress}%`,
-                                                        }}
-                                                    />
-                                                </div>
-                                            </div>
-                                        )
-                                    })}
-                                </div>
-                            </CardContent>
-                        </Card>
-
-                        <Card className="border-[#E0E0E0] shadow-none">
-                            <CardContent className="p-0">
-                                <div className="border-b border-[#E0E0E0] bg-[#FAF9F6]">
-                                    <h3 className="text-xs font-bold text-[#487749] uppercase tracking-wider">
-                                        Training
-                                    </h3>
-                                    <p className="text-[10px] text-[#757575] mt-0.5 mb-1">
-                                        Count
-                                    </p>
-                                </div>
-                                <div className="mt-2 space-y-3">
-                                    {data.perKvk.map(row => (
-                                        <div
-                                            key={row.kvkId}
-                                            className="space-y-1"
-                                        >
-                                            <div className="flex items-center justify-between gap-2">
-                                                <span className="text-xs font-bold text-[#212121] line-clamp-2">
-                                                    {row.kvkName}
-                                                </span>
-                                                <span
-                                                    className={`px-2 py-0.5 rounded-md text-[11px] font-bold shrink-0 ${getBadgeColor(row.training.status)}`}
-                                                >
-                                                    {row.training.count}
-                                                </span>
-                                            </div>
-                                            <div className="w-full bg-[#F5F5F5] rounded-full h-1.5 border border-[#E0E0E0]/50">
-                                                <div
-                                                    className={`h-1.5 rounded-full ${getProgressColor(row.training.status)} transition-all duration-700`}
-                                                    style={{ width: '100%' }}
-                                                />
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            </CardContent>
-                        </Card>
-
-                        <Card className="border-[#E0E0E0] shadow-none">
-                            <CardContent className="p-0">
-                                <div className="border-b border-[#E0E0E0] bg-[#FAF9F6]">
-                                    <h3 className="text-xs font-bold text-[#487749] uppercase tracking-wider">
-                                        Extension activity
-                                    </h3>
-                                    <p className="text-[10px] text-[#757575] mt-0.5 mb-1">
-                                        Count
-                                    </p>
-                                </div>
-                                <div className="mt-2 space-y-3">
-                                    {data.perKvk.map(row => (
-                                        <div
-                                            key={row.kvkId}
-                                            className="space-y-1"
-                                        >
-                                            <div className="flex items-center justify-between gap-2">
-                                                <span className="text-xs font-bold text-[#212121] line-clamp-2">
-                                                    {row.kvkName}
-                                                </span>
-                                                <span
-                                                    className={`px-2 py-0.5 rounded-md text-[11px] font-bold shrink-0 ${getBadgeColor(row.extension.status)}`}
-                                                >
-                                                    {row.extension.count}
-                                                </span>
-                                            </div>
-                                            <div className="w-full bg-[#F5F5F5] rounded-full h-1.5 border border-[#E0E0E0]/50">
-                                                <div
-                                                    className={`h-1.5 rounded-full ${getProgressColor(row.extension.status)} transition-all duration-700`}
-                                                    style={{ width: '100%' }}
-                                                />
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            </CardContent>
-                        </Card>
+                        <StatChartPanel
+                            title="OFT"
+                            subtitle="Ongoing, completed; not started = no entries yet"
+                            mode="pair"
+                            primaryLabel="completed"
+                            secondaryLabel="created"
+                            rows={data.perKvk.map(r => ({
+                                id: r.kvkId,
+                                name: r.kvkName,
+                                status: r.oft.status,
+                                primary: r.oft.completed,
+                                secondary: r.oft.created,
+                                segments: r.oft.segments,
+                            }))}
+                        />
+                        <StatChartPanel
+                            title="FLD"
+                            subtitle="Ongoing, completed; not started = no entries yet"
+                            mode="pair"
+                            primaryLabel="completed"
+                            secondaryLabel="created"
+                            rows={data.perKvk.map(r => ({
+                                id: r.kvkId,
+                                name: r.kvkName,
+                                status: r.fld.status,
+                                primary: r.fld.completed,
+                                secondary: r.fld.created,
+                                segments: r.fld.segments,
+                            }))}
+                        />
+                        <StatChartPanel
+                            title="Training"
+                            subtitle="Ongoing, completed; not started = no entries yet"
+                            mode="count"
+                            primaryLabel="sessions"
+                            unit="sessions"
+                            rows={data.perKvk.map(r => ({
+                                id: r.kvkId,
+                                name: r.kvkName,
+                                status: r.training.status,
+                                primary: r.training.count,
+                                segments: r.training.segments,
+                            }))}
+                        />
+                        <StatChartPanel
+                            title="Extension activity"
+                            subtitle="Ongoing, completed; not started = no entries yet"
+                            mode="count"
+                            primaryLabel="activities"
+                            unit="activities"
+                            rows={data.perKvk.map(r => ({
+                                id: r.kvkId,
+                                name: r.kvkName,
+                                status: r.extension.status,
+                                primary: r.extension.count,
+                                segments: r.extension.segments,
+                            }))}
+                        />
                     </div>
 
                     <div

--- a/frontend/src/pages/dashboard/SuperAdminDashboard.tsx
+++ b/frontend/src/pages/dashboard/SuperAdminDashboard.tsx
@@ -21,6 +21,7 @@ import {
     DashboardKpiSkeleton,
     DashboardPanelsSkeleton,
 } from './shared/DashboardSkeletons'
+import { StatChartPanel } from './shared/StatChartPanel'
 
 const getProgressColor = (status: string) => {
     switch (status) {
@@ -38,22 +39,6 @@ const getProgressColor = (status: string) => {
     }
 }
 
-const getBadgeColor = (status: string) => {
-    switch (status) {
-        case 'complete':
-        case 'active':
-            return 'bg-[#E8F5E9] text-[#487749] border border-[#C8E6C9]'
-        case 'in-progress':
-            return 'bg-[#F1F8E9] text-[#487749] border border-[#DCEDC8]'
-        case 'over':
-            return 'bg-[#FFF3E0] text-[#F57C00] border border-[#FFE0B2]'
-        case 'pending':
-            return 'bg-[#F5F5F5] text-[#757575] border border-[#E0E0E0]'
-        default:
-            return 'bg-[#F5F5F5] text-[#757575] border border-[#E0E0E0]'
-    }
-}
-
 function formatLogTime(iso: string) {
     try {
         const d = new Date(iso)
@@ -64,11 +49,6 @@ function formatLogTime(iso: string) {
     } catch {
         return iso
     }
-}
-
-function progressCompletedOverCreated(completed: number, created: number) {
-    if (created <= 0) return 0
-    return Math.min((completed / created) * 100, 100)
 }
 
 export const SuperAdminDashboard: React.FC = () => {
@@ -278,190 +258,64 @@ export const SuperAdminDashboard: React.FC = () => {
                     <div
                         className={`grid grid-cols-1 lg:grid-cols-2 gap-3 transition-opacity ${isFetching ? 'opacity-70' : ''}`}
                     >
-                        <Card className="border-[#E0E0E0] shadow-none">
-                            <CardContent className="p-0">
-                                <div className="border-b border-[#E0E0E0] bg-[#FAF9F6]">
-                                    <h3 className="text-xs font-bold text-[#487749] uppercase tracking-wider">
-                                        OFT progress
-                                    </h3>
-                                    <p className="text-[10px] text-[#757575] mt-0.5 mb-1">
-                                        Completed OFTs vs total created (same
-                                        scope as filters)
-                                    </p>
-                                </div>
-                                <div className="space-y-3 max-h-[min(420px,50vh)] overflow-y-auto">
-                                    {data.perKvk.map(row => {
-                                        const progress =
-                                            progressCompletedOverCreated(
-                                                row.oft.completed,
-                                                row.oft.created
-                                            )
-                                        return (
-                                            <div
-                                                key={row.kvkId}
-                                                className="space-y-1"
-                                            >
-                                                <div className="flex items-start justify-between gap-2">
-                                                    <span className="text-xs font-bold text-[#212121] line-clamp-2">
-                                                        {row.kvkName}
-                                                    </span>
-                                                    <div className="text-right shrink-0">
-                                                        <span
-                                                            className={`inline-block px-2 py-0.5 rounded-md text-[11px] font-bold ${getBadgeColor(row.oft.status)}`}
-                                                        >
-                                                            {row.oft.completed}{' '}
-                                                            / {row.oft.created}
-                                                        </span>
-                                                        <p className="text-[9px] text-[#757575] mt-0.5 leading-tight">
-                                                            completed / created
-                                                        </p>
-                                                    </div>
-                                                </div>
-                                                <div className="w-full bg-[#F5F5F5] rounded-full h-1.5 border border-[#E0E0E0]/50">
-                                                    <div
-                                                        className={`h-1.5 rounded-full ${getProgressColor(row.oft.status)} transition-all duration-700 ease-out`}
-                                                        style={{
-                                                            width: `${progress}%`,
-                                                        }}
-                                                    />
-                                                </div>
-                                            </div>
-                                        )
-                                    })}
-                                </div>
-                            </CardContent>
-                        </Card>
-
-                        <Card className="border-[#E0E0E0] shadow-none">
-                            <CardContent className="p-0">
-                                <div className="border-b border-[#E0E0E0] bg-[#FAF9F6]">
-                                    <h3 className="text-xs font-bold text-[#487749] uppercase tracking-wider">
-                                        FLD progress
-                                    </h3>
-                                    <p className="text-[10px] text-[#757575] mt-0.5 mb-1">
-                                        Completed FLDs vs total created
-                                    </p>
-                                </div>
-                                <div className="space-y-3 max-h-[min(420px,50vh)] overflow-y-auto">
-                                    {data.perKvk.map(row => {
-                                        const progress =
-                                            progressCompletedOverCreated(
-                                                row.fld.completed,
-                                                row.fld.created
-                                            )
-                                        return (
-                                            <div
-                                                key={row.kvkId}
-                                                className="space-y-1"
-                                            >
-                                                <div className="flex items-start justify-between gap-2">
-                                                    <span className="text-xs font-bold text-[#212121] line-clamp-2">
-                                                        {row.kvkName}
-                                                    </span>
-                                                    <div className="text-right shrink-0">
-                                                        <span
-                                                            className={`inline-block px-2 py-0.5 rounded-md text-[11px] font-bold ${getBadgeColor(row.fld.status)}`}
-                                                        >
-                                                            {row.fld.completed}{' '}
-                                                            / {row.fld.created}
-                                                        </span>
-                                                        <p className="text-[9px] text-[#757575] mt-0.5 leading-tight">
-                                                            completed / created
-                                                        </p>
-                                                    </div>
-                                                </div>
-                                                <div className="w-full bg-[#F5F5F5] rounded-full h-1.5 border border-[#E0E0E0]/50">
-                                                    <div
-                                                        className={`h-1.5 rounded-full ${getProgressColor(row.fld.status)} transition-all duration-700 ease-out`}
-                                                        style={{
-                                                            width: `${progress}%`,
-                                                        }}
-                                                    />
-                                                </div>
-                                            </div>
-                                        )
-                                    })}
-                                </div>
-                            </CardContent>
-                        </Card>
-
-                        <Card className="border-[#E0E0E0] shadow-none">
-                            <CardContent className="p-0">
-                                <div className="border-b border-[#E0E0E0] bg-[#FAF9F6]">
-                                    <h3 className="text-xs font-bold text-[#487749] uppercase tracking-wider">
-                                        Training
-                                    </h3>
-                                    <p className="text-[10px] text-[#757575] mt-0.5 mb-1">
-                                        Count
-                                    </p>
-                                </div>
-                                <div className="space-y-3 max-h-[min(420px,50vh)] overflow-y-auto">
-                                    {data.perKvk.map(row => (
-                                        <div
-                                            key={row.kvkId}
-                                            className="space-y-1"
-                                        >
-                                            <div className="flex items-center justify-between gap-2">
-                                                <span className="text-xs font-bold text-[#212121] line-clamp-2">
-                                                    {row.kvkName}
-                                                </span>
-                                                <span
-                                                    className={`px-2 py-0.5 rounded-md text-[11px] font-bold shrink-0 ${getBadgeColor(row.training.status)}`}
-                                                >
-                                                    {row.training.count}{' '}
-                                                    sessions
-                                                </span>
-                                            </div>
-                                            <div className="w-full bg-[#F5F5F5] rounded-full h-1.5 border border-[#E0E0E0]/50">
-                                                <div
-                                                    className={`h-1.5 rounded-full ${getProgressColor(row.training.status)} transition-all duration-700`}
-                                                    style={{ width: '100%' }}
-                                                />
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            </CardContent>
-                        </Card>
-
-                        <Card className="border-[#E0E0E0] shadow-none">
-                            <CardContent className="p-0">
-                                <div className="border-b border-[#E0E0E0] bg-[#FAF9F6]">
-                                    <h3 className="text-xs font-bold text-[#487749] uppercase tracking-wider">
-                                        Extension activities
-                                    </h3>
-                                    <p className="text-[10px] text-[#757575] mt-0.5 mb-1">
-                                        Count
-                                    </p>
-                                </div>
-                                <div className="space-y-3 max-h-[min(420px,50vh)] overflow-y-auto">
-                                    {data.perKvk.map(row => (
-                                        <div
-                                            key={row.kvkId}
-                                            className="space-y-1"
-                                        >
-                                            <div className="flex items-center justify-between gap-2">
-                                                <span className="text-xs font-bold text-[#212121] line-clamp-2">
-                                                    {row.kvkName}
-                                                </span>
-                                                <span
-                                                    className={`px-2 py-0.5 rounded-md text-[11px] font-bold shrink-0 ${getBadgeColor(row.extension.status)}`}
-                                                >
-                                                    {row.extension.count}{' '}
-                                                    activities
-                                                </span>
-                                            </div>
-                                            <div className="w-full bg-[#F5F5F5] rounded-full h-1.5 border border-[#E0E0E0]/50">
-                                                <div
-                                                    className={`h-1.5 rounded-full ${getProgressColor(row.extension.status)} transition-all duration-700`}
-                                                    style={{ width: '100%' }}
-                                                />
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            </CardContent>
-                        </Card>
+                        <StatChartPanel
+                            title="OFT progress"
+                            subtitle="Ongoing, completed; not started = KVK with no entries"
+                            mode="pair"
+                            primaryLabel="completed"
+                            secondaryLabel="created"
+                            rows={data.perKvk.map(r => ({
+                                id: r.kvkId,
+                                name: r.kvkName,
+                                status: r.oft.status,
+                                primary: r.oft.completed,
+                                secondary: r.oft.created,
+                                segments: r.oft.segments,
+                            }))}
+                        />
+                        <StatChartPanel
+                            title="FLD progress"
+                            subtitle="Ongoing, completed; not started = KVK with no entries"
+                            mode="pair"
+                            primaryLabel="completed"
+                            secondaryLabel="created"
+                            rows={data.perKvk.map(r => ({
+                                id: r.kvkId,
+                                name: r.kvkName,
+                                status: r.fld.status,
+                                primary: r.fld.completed,
+                                secondary: r.fld.created,
+                                segments: r.fld.segments,
+                            }))}
+                        />
+                        <StatChartPanel
+                            title="Training"
+                            subtitle="Ongoing, completed; not started = KVK with no entries"
+                            mode="count"
+                            primaryLabel="sessions"
+                            unit="sessions"
+                            rows={data.perKvk.map(r => ({
+                                id: r.kvkId,
+                                name: r.kvkName,
+                                status: r.training.status,
+                                primary: r.training.count,
+                                segments: r.training.segments,
+                            }))}
+                        />
+                        <StatChartPanel
+                            title="Extension activities"
+                            subtitle="Ongoing, completed; not started = KVK with no entries"
+                            mode="count"
+                            primaryLabel="activities"
+                            unit="activities"
+                            rows={data.perKvk.map(r => ({
+                                id: r.kvkId,
+                                name: r.kvkName,
+                                status: r.extension.status,
+                                primary: r.extension.count,
+                                segments: r.extension.segments,
+                            }))}
+                        />
                     </div>
 
                     <div

--- a/frontend/src/pages/dashboard/shared/StatChartPanel.tsx
+++ b/frontend/src/pages/dashboard/shared/StatChartPanel.tsx
@@ -1,0 +1,636 @@
+import React, { useMemo, useState } from 'react'
+import {
+    Area,
+    AreaChart,
+    Bar,
+    BarChart,
+    CartesianGrid,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from 'recharts'
+import { BarChart3, LineChart as LineIcon, ListChecks } from 'lucide-react'
+import { Card, CardContent } from '../../../components/ui/Card'
+
+export type StatSegments = {
+    ongoing: number
+    completed: number
+    notStarted: number
+}
+
+export type StatRow = {
+    id: number | string
+    name: string
+    status: string
+    primary: number
+    secondary?: number
+    segments?: StatSegments
+}
+
+type Mode = 'pair' | 'count'
+type View = 'progress' | 'bar' | 'area'
+
+type Props = {
+    title: string
+    subtitle?: string
+    rows: StatRow[]
+    mode: Mode
+    primaryLabel: string
+    secondaryLabel?: string
+    unit?: string
+}
+
+const STATUS_BADGE: Record<string, string> = {
+    complete: 'bg-[#E8F5E9] text-[#487749] border border-[#C8E6C9]',
+    active: 'bg-[#E8F5E9] text-[#487749] border border-[#C8E6C9]',
+    'in-progress': 'bg-[#F1F8E9] text-[#487749] border border-[#DCEDC8]',
+    over: 'bg-[#FFF3E0] text-[#F57C00] border border-[#FFE0B2]',
+    pending: 'bg-[#F5F5F5] text-[#757575] border border-[#E0E0E0]',
+}
+
+const STATUS_BAR: Record<string, string> = {
+    complete: 'bg-[#487749]',
+    active: 'bg-[#487749]',
+    'in-progress': 'bg-[#5c9a5e]',
+    over: 'bg-amber-500',
+    pending: 'bg-gray-300',
+}
+
+const SEG_COLOR = {
+    completed: '#487749',
+    ongoing: '#F2A61F',
+    notStarted: '#BDBDBD',
+}
+
+const SEG_LABEL = {
+    completed: 'Completed',
+    ongoing: 'Ongoing',
+    notStarted: 'Not started',
+}
+
+const SEG_KEYS: Array<keyof StatSegments> = [
+    'ongoing',
+    'completed',
+    'notStarted',
+]
+
+const COLOR_GRID = '#E0E0E0'
+const COLOR_AXIS = '#757575'
+
+function pct(num: number, den: number) {
+    if (den <= 0) return 0
+    return Math.min((num / den) * 100, 100)
+}
+
+function truncate(s: string, n = 14) {
+    return s.length > n ? `${s.slice(0, n - 1)}…` : s
+}
+
+const ChartTooltip = ({
+    active,
+    payload,
+    unit,
+}: {
+    active?: boolean
+    payload?: Array<{
+        name: string
+        value: number
+        color: string
+        payload: { fullName?: string }
+    }>
+    unit?: string
+}) => {
+    if (!active || !payload || payload.length === 0) return null
+    const fullName = payload[0]?.payload?.fullName ?? ''
+    const total = payload.reduce((sum, p) => sum + (p.value || 0), 0)
+    const ordered = [...payload].reverse()
+    return (
+        <div className="rounded-lg border border-[#E0E0E0] bg-white px-3 py-2 shadow-lg min-w-[180px]">
+            <div className="text-[11px] font-bold text-[#212121] mb-1.5 line-clamp-2">
+                {fullName}
+            </div>
+            <div className="space-y-1">
+                {ordered.map(p => (
+                    <div
+                        key={p.name}
+                        className="flex items-center justify-between gap-3 text-[11px]"
+                    >
+                        <div className="flex items-center gap-1.5 min-w-0">
+                            <span
+                                className="w-2 h-2 rounded-full shrink-0"
+                                style={{ backgroundColor: p.color }}
+                            />
+                            <span className="text-[#757575] font-medium truncate">
+                                {SEG_LABEL[p.name as keyof typeof SEG_LABEL] ??
+                                    p.name}
+                            </span>
+                        </div>
+                        <span className="text-[#212121] font-bold shrink-0">
+                            {p.value.toLocaleString()}
+                            {unit ? ` ${unit}` : ''}
+                        </span>
+                    </div>
+                ))}
+                <div className="pt-1 mt-1 border-t border-[#E0E0E0] flex items-center justify-between text-[11px]">
+                    <span className="text-[#757575] font-medium">Total</span>
+                    <span className="text-[#487749] font-bold">
+                        {total.toLocaleString()}
+                        {unit ? ` ${unit}` : ''}
+                    </span>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const Legend: React.FC = () => (
+    <div className="flex items-center gap-3 flex-wrap">
+        {SEG_KEYS.map(k => (
+            <div key={k} className="flex items-center gap-1.5">
+                <span
+                    className="w-2.5 h-2.5 rounded-sm"
+                    style={{ backgroundColor: SEG_COLOR[k] }}
+                />
+                <span className="text-[10px] font-medium text-[#757575] uppercase tracking-wide">
+                    {SEG_LABEL[k]}
+                </span>
+            </div>
+        ))}
+    </div>
+)
+
+const ViewToggle: React.FC<{ view: View; onChange: (v: View) => void }> = ({
+    view,
+    onChange,
+}) => {
+    const items: Array<{ key: View; label: string; icon: React.ReactNode }> = [
+        {
+            key: 'progress',
+            label: 'List',
+            icon: <ListChecks className="w-3 h-3" />,
+        },
+        {
+            key: 'bar',
+            label: 'Bar',
+            icon: <BarChart3 className="w-3 h-3" />,
+        },
+        {
+            key: 'area',
+            label: 'Area',
+            icon: <LineIcon className="w-3 h-3" />,
+        },
+    ]
+    return (
+        <div
+            className="inline-flex items-center gap-0.5 rounded-md border border-[#E0E0E0] bg-white p-0.5"
+            role="tablist"
+        >
+            {items.map(item => {
+                const isActive = view === item.key
+                return (
+                    <button
+                        key={item.key}
+                        type="button"
+                        role="tab"
+                        aria-selected={isActive}
+                        onClick={() => onChange(item.key)}
+                        className={`flex items-center gap-1 px-2 py-1 rounded text-[10px] font-bold uppercase tracking-wide transition-colors ${
+                            isActive
+                                ? 'bg-[#487749] text-white'
+                                : 'text-[#757575] hover:text-[#487749]'
+                        }`}
+                    >
+                        {item.icon}
+                        <span>{item.label}</span>
+                    </button>
+                )
+            })}
+        </div>
+    )
+}
+
+export const StatChartPanel: React.FC<Props> = ({
+    title,
+    subtitle,
+    rows,
+    mode,
+    primaryLabel,
+    secondaryLabel,
+    unit,
+}) => {
+    const [view, setView] = useState<View>('progress')
+
+    const chartData = useMemo(
+        () =>
+            rows.map(r => ({
+                id: r.id,
+                name: truncate(r.name),
+                fullName: r.name,
+                primary: r.primary,
+                secondary: r.secondary ?? 0,
+                completed: r.segments?.completed ?? 0,
+                ongoing: r.segments?.ongoing ?? 0,
+                notStarted: r.segments?.notStarted ?? 0,
+                status: r.status,
+            })),
+        [rows]
+    )
+
+    const showStacked = chartData.some(
+        d => d.completed + d.ongoing + d.notStarted > 0
+    )
+
+    return (
+        <Card className="border-[#E0E0E0] shadow-none">
+            <CardContent className="p-0">
+                <div className="flex items-start justify-between gap-2 border-b border-[#E0E0E0] bg-[#FAF9F6] px-3 py-2">
+                    <div className="min-w-0">
+                        <h3 className="text-xs font-bold text-[#487749] uppercase tracking-wider">
+                            {title}
+                        </h3>
+                        {subtitle && (
+                            <p className="text-[10px] text-[#757575] mt-0.5">
+                                {subtitle}
+                            </p>
+                        )}
+                    </div>
+                    <ViewToggle view={view} onChange={setView} />
+                </div>
+
+                {view === 'progress' && (
+                    <div className="space-y-3 max-h-[min(420px,50vh)] overflow-y-auto p-3">
+                        {rows.map(row => {
+                            const total =
+                                (row.segments?.completed ?? 0) +
+                                (row.segments?.ongoing ?? 0) +
+                                (row.segments?.notStarted ?? 0)
+                            const useSegments = total > 0
+                            const fallbackProgress =
+                                mode === 'pair'
+                                    ? pct(row.primary, row.secondary ?? 0)
+                                    : 100
+                            return (
+                                <div key={row.id} className="space-y-1">
+                                    <div className="flex items-start justify-between gap-2">
+                                        <span className="text-xs font-bold text-[#212121] line-clamp-2">
+                                            {row.name}
+                                        </span>
+                                        <div className="text-right shrink-0">
+                                            {useSegments ? (
+                                                <div className="flex items-center gap-1.5">
+                                                    {SEG_KEYS.map(k => {
+                                                        const v =
+                                                            row.segments?.[k] ??
+                                                            0
+                                                        return (
+                                                            <span
+                                                                key={k}
+                                                                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-bold"
+                                                                style={{
+                                                                    backgroundColor: `${SEG_COLOR[k]}1A`,
+                                                                    color: SEG_COLOR[
+                                                                        k
+                                                                    ],
+                                                                }}
+                                                                title={`${SEG_LABEL[k]}: ${v}`}
+                                                            >
+                                                                <span
+                                                                    className="w-1.5 h-1.5 rounded-full"
+                                                                    style={{
+                                                                        backgroundColor:
+                                                                            SEG_COLOR[
+                                                                                k
+                                                                            ],
+                                                                    }}
+                                                                />
+                                                                {v}
+                                                            </span>
+                                                        )
+                                                    })}
+                                                    <span className="ml-1 inline-block px-1.5 py-0.5 rounded text-[10px] font-bold bg-[#F5F5F5] text-[#212121] border border-[#E0E0E0]">
+                                                        Σ {total}
+                                                    </span>
+                                                </div>
+                                            ) : (
+                                                <>
+                                                    <span
+                                                        className={`inline-block px-2 py-0.5 rounded-md text-[11px] font-bold ${STATUS_BADGE[row.status] ?? STATUS_BADGE.pending}`}
+                                                    >
+                                                        {mode === 'pair'
+                                                            ? `${row.primary} / ${row.secondary ?? 0}`
+                                                            : `${row.primary}${unit ? ` ${unit}` : ''}`}
+                                                    </span>
+                                                    {mode === 'pair' && (
+                                                        <p className="text-[9px] text-[#757575] mt-0.5 leading-tight">
+                                                            {primaryLabel} /{' '}
+                                                            {secondaryLabel}
+                                                        </p>
+                                                    )}
+                                                </>
+                                            )}
+                                        </div>
+                                    </div>
+                                    {useSegments ? (
+                                        <div className="w-full flex h-1.5 rounded-full overflow-hidden border border-[#E0E0E0]/50 bg-[#F5F5F5]">
+                                            {SEG_KEYS.map(k => {
+                                                const v = row.segments?.[k] ?? 0
+                                                if (v <= 0) return null
+                                                const w = (v / total) * 100
+                                                return (
+                                                    <div
+                                                        key={k}
+                                                        className="h-full transition-all duration-700 ease-out"
+                                                        style={{
+                                                            width: `${w}%`,
+                                                            backgroundColor:
+                                                                SEG_COLOR[k],
+                                                        }}
+                                                        title={`${SEG_LABEL[k]}: ${v}`}
+                                                    />
+                                                )
+                                            })}
+                                        </div>
+                                    ) : (
+                                        <div className="w-full bg-[#F5F5F5] rounded-full h-1.5 border border-[#E0E0E0]/50">
+                                            <div
+                                                className={`h-1.5 rounded-full ${STATUS_BAR[row.status] ?? STATUS_BAR.pending} transition-all duration-700 ease-out`}
+                                                style={{
+                                                    width: `${fallbackProgress}%`,
+                                                }}
+                                            />
+                                        </div>
+                                    )}
+                                </div>
+                            )
+                        })}
+                    </div>
+                )}
+
+                {view === 'bar' && (
+                    <div className="p-3">
+                        {showStacked && (
+                            <div className="mb-2 flex justify-end">
+                                <Legend />
+                            </div>
+                        )}
+                        <ResponsiveContainer width="100%" height={300}>
+                            <BarChart
+                                data={chartData}
+                                margin={{
+                                    top: 8,
+                                    right: 8,
+                                    left: -16,
+                                    bottom: 8,
+                                }}
+                                barCategoryGap={20}
+                            >
+                                <CartesianGrid
+                                    strokeDasharray="3 3"
+                                    stroke={COLOR_GRID}
+                                    vertical={false}
+                                />
+                                <XAxis
+                                    dataKey="name"
+                                    tick={{
+                                        fontSize: 10,
+                                        fill: COLOR_AXIS,
+                                    }}
+                                    tickLine={false}
+                                    axisLine={{ stroke: COLOR_GRID }}
+                                    interval={0}
+                                    angle={-25}
+                                    textAnchor="end"
+                                    height={50}
+                                />
+                                <YAxis
+                                    tick={{
+                                        fontSize: 10,
+                                        fill: COLOR_AXIS,
+                                    }}
+                                    tickLine={false}
+                                    axisLine={{ stroke: COLOR_GRID }}
+                                    allowDecimals={false}
+                                />
+                                <Tooltip
+                                    cursor={{
+                                        fill: '#487749',
+                                        fillOpacity: 0.06,
+                                    }}
+                                    content={<ChartTooltip unit={unit} />}
+                                />
+                                {showStacked ? (
+                                    <>
+                                        <Bar
+                                            dataKey="ongoing"
+                                            name="ongoing"
+                                            stackId="seg"
+                                            fill={SEG_COLOR.ongoing}
+                                            maxBarSize={36}
+                                        />
+                                        <Bar
+                                            dataKey="completed"
+                                            name="completed"
+                                            stackId="seg"
+                                            fill={SEG_COLOR.completed}
+                                            maxBarSize={36}
+                                        />
+                                        <Bar
+                                            dataKey="notStarted"
+                                            name="notStarted"
+                                            stackId="seg"
+                                            fill={SEG_COLOR.notStarted}
+                                            radius={[4, 4, 0, 0]}
+                                            maxBarSize={36}
+                                        />
+                                    </>
+                                ) : (
+                                    <Bar
+                                        dataKey="primary"
+                                        name="primary"
+                                        fill={SEG_COLOR.completed}
+                                        radius={[4, 4, 0, 0]}
+                                        maxBarSize={36}
+                                    />
+                                )}
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </div>
+                )}
+
+                {view === 'area' && (
+                    <div className="p-3">
+                        {showStacked && (
+                            <div className="mb-2 flex justify-end">
+                                <Legend />
+                            </div>
+                        )}
+                        <ResponsiveContainer width="100%" height={300}>
+                            <AreaChart
+                                data={chartData}
+                                margin={{
+                                    top: 8,
+                                    right: 8,
+                                    left: -16,
+                                    bottom: 8,
+                                }}
+                            >
+                                <defs>
+                                    <linearGradient
+                                        id="gradCompleted"
+                                        x1="0"
+                                        y1="0"
+                                        x2="0"
+                                        y2="1"
+                                    >
+                                        <stop
+                                            offset="0%"
+                                            stopColor={SEG_COLOR.completed}
+                                            stopOpacity={0.55}
+                                        />
+                                        <stop
+                                            offset="100%"
+                                            stopColor={SEG_COLOR.completed}
+                                            stopOpacity={0.05}
+                                        />
+                                    </linearGradient>
+                                    <linearGradient
+                                        id="gradOngoing"
+                                        x1="0"
+                                        y1="0"
+                                        x2="0"
+                                        y2="1"
+                                    >
+                                        <stop
+                                            offset="0%"
+                                            stopColor={SEG_COLOR.ongoing}
+                                            stopOpacity={0.5}
+                                        />
+                                        <stop
+                                            offset="100%"
+                                            stopColor={SEG_COLOR.ongoing}
+                                            stopOpacity={0.05}
+                                        />
+                                    </linearGradient>
+                                    <linearGradient
+                                        id="gradNotStarted"
+                                        x1="0"
+                                        y1="0"
+                                        x2="0"
+                                        y2="1"
+                                    >
+                                        <stop
+                                            offset="0%"
+                                            stopColor={SEG_COLOR.notStarted}
+                                            stopOpacity={0.5}
+                                        />
+                                        <stop
+                                            offset="100%"
+                                            stopColor={SEG_COLOR.notStarted}
+                                            stopOpacity={0.05}
+                                        />
+                                    </linearGradient>
+                                </defs>
+                                <CartesianGrid
+                                    strokeDasharray="3 3"
+                                    stroke={COLOR_GRID}
+                                    vertical={false}
+                                />
+                                <XAxis
+                                    dataKey="name"
+                                    tick={{
+                                        fontSize: 10,
+                                        fill: COLOR_AXIS,
+                                    }}
+                                    tickLine={false}
+                                    axisLine={{ stroke: COLOR_GRID }}
+                                    interval={0}
+                                    angle={-25}
+                                    textAnchor="end"
+                                    height={50}
+                                />
+                                <YAxis
+                                    tick={{
+                                        fontSize: 10,
+                                        fill: COLOR_AXIS,
+                                    }}
+                                    tickLine={false}
+                                    axisLine={{ stroke: COLOR_GRID }}
+                                    allowDecimals={false}
+                                />
+                                <Tooltip
+                                    cursor={{
+                                        stroke: '#487749',
+                                        strokeOpacity: 0.4,
+                                        strokeWidth: 1,
+                                    }}
+                                    content={<ChartTooltip unit={unit} />}
+                                />
+                                {showStacked ? (
+                                    <>
+                                        <Area
+                                            type="monotone"
+                                            dataKey="ongoing"
+                                            name="ongoing"
+                                            stackId="seg"
+                                            stroke={SEG_COLOR.ongoing}
+                                            strokeWidth={2}
+                                            fill="url(#gradOngoing)"
+                                            activeDot={{
+                                                r: 4,
+                                                stroke: '#fff',
+                                                strokeWidth: 2,
+                                            }}
+                                        />
+                                        <Area
+                                            type="monotone"
+                                            dataKey="completed"
+                                            name="completed"
+                                            stackId="seg"
+                                            stroke={SEG_COLOR.completed}
+                                            strokeWidth={2}
+                                            fill="url(#gradCompleted)"
+                                            activeDot={{
+                                                r: 4,
+                                                stroke: '#fff',
+                                                strokeWidth: 2,
+                                            }}
+                                        />
+                                        <Area
+                                            type="monotone"
+                                            dataKey="notStarted"
+                                            name="notStarted"
+                                            stackId="seg"
+                                            stroke={SEG_COLOR.notStarted}
+                                            strokeWidth={2}
+                                            fill="url(#gradNotStarted)"
+                                            activeDot={{
+                                                r: 4,
+                                                stroke: '#fff',
+                                                strokeWidth: 2,
+                                            }}
+                                        />
+                                    </>
+                                ) : (
+                                    <Area
+                                        type="monotone"
+                                        dataKey="primary"
+                                        name="primary"
+                                        stroke={SEG_COLOR.completed}
+                                        strokeWidth={2}
+                                        fill="url(#gradCompleted)"
+                                        activeDot={{
+                                            r: 4,
+                                            stroke: '#fff',
+                                            strokeWidth: 2,
+                                        }}
+                                    />
+                                )}
+                            </AreaChart>
+                        </ResponsiveContainer>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    )
+}

--- a/frontend/src/services/dashboardApi.ts
+++ b/frontend/src/services/dashboardApi.ts
@@ -5,13 +5,29 @@ export interface DashboardKvkOption {
   kvkName: string
 }
 
+export interface DashboardSegments {
+  ongoing: number
+  completed: number
+  notStarted: number
+}
+
 export interface DashboardPerKvkRow {
   kvkId: number
   kvkName: string
-  oft: { completed: number; created: number; status: string }
-  fld: { completed: number; created: number; status: string }
-  training: { count: number; status: string }
-  extension: { count: number; status: string }
+  oft: {
+    completed: number
+    created: number
+    status: string
+    segments: DashboardSegments
+  }
+  fld: {
+    completed: number
+    created: number
+    status: string
+    segments: DashboardSegments
+  }
+  training: { count: number; status: string; segments: DashboardSegments }
+  extension: { count: number; status: string; segments: DashboardSegments }
 }
 
 export interface DashboardStaffPost {


### PR DESCRIPTION
## Summary
- New reusable `StatChartPanel` with three views: List / Bar / Area. Each panel has a view toggle, custom hover tooltip, and theme-matched palette (green completed / amber ongoing / gray not-started).
- Wired OFT, FLD, Training, Extension into the panel on both Super-Admin and KVK dashboards.
- Backend `dashboardService` now returns `segments: { ongoing, completed, notStarted }` per module per KVK. **Not Started = KVK has no entries** for that module. OFT/FLD merge `TRANSFERRED_TO_NEXT_YEAR` into ongoing.
- Removed dead helpers (`getBadgeColor`, `progressCompletedOverCreated`) from dashboards.
- Added `recharts` to frontend dependencies.

## Test plan
- [ ] Open Super-Admin dashboard, verify OFT / FLD / Training / Extension panels render.
- [ ] Toggle List / Bar / Area on each panel — verify smooth switch and stacked segments.
- [ ] Hover bars/areas — tooltip shows KVK name + per-segment counts.
- [ ] KVK with no entries shows a "Not started" segment (gray) of height 1.
- [ ] KVK dashboard mirrors the same behavior.
- [ ] Year filter / KVK filter still updates panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)