### PR TITLE
feat(datatable): excel-style per-column filters across all form tables

### DIFF
--- a/backend/repositories/forms/aboutKvkRepository.js
+++ b/backend/repositories/forms/aboutKvkRepository.js
@@ -243,7 +243,7 @@ async function findAll(entityName, options = {}, user = null) {
     }
     const {
         page = 1,
-        limit = 100,
+        limit = 10000,
         search = '',
         sortBy,
         sortOrder = 'asc',
@@ -252,7 +252,7 @@ async function findAll(entityName, options = {}, user = null) {
 
     const actualSortBy = sortBy || config.idField;
     const skip = (page - 1) * limit;
-    const take = Math.min(limit, 100);
+    const take = Math.min(limit, 10000);
 
     let where = {};
 

--- a/backend/services/forms/aboutKvkService.js
+++ b/backend/services/forms/aboutKvkService.js
@@ -30,7 +30,7 @@ class AboutKvkService {
                 data: [],
                 total: 0,
                 page: options.page || 1,
-                limit: options.limit || 100,
+                limit: options.limit || 10000,
                 noKvkLinked: true,
             };
         }
@@ -65,7 +65,7 @@ class AboutKvkService {
         return {
             ...result,
             page: options.page || 1,
-            limit: options.limit || 100,
+            limit: options.limit || 10000,
         };
     }
 
@@ -617,7 +617,7 @@ class AboutKvkService {
         return {
             ...result,
             page: options.page || 1,
-            limit: options.limit || 100,
+            limit: options.limit || 10000,
         };
     }
 
@@ -639,7 +639,7 @@ class AboutKvkService {
         return {
             ...result,
             page: options.page || 1,
-            limit: options.limit || 100,
+            limit: options.limit || 10000,
         };
     }
 

--- a/frontend/src/components/common/DataTable/ColumnFilter.tsx
+++ b/frontend/src/components/common/DataTable/ColumnFilter.tsx
@@ -1,0 +1,288 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { ArrowUp, ArrowDown, Filter, Search, X } from 'lucide-react'
+
+export type SortDir = 'asc' | 'desc' | null
+
+export interface ColumnFilterState {
+    sort: SortDir
+    text: string
+    excluded: Set<string>
+}
+
+export const EMPTY_FILTER: ColumnFilterState = {
+    sort: null,
+    text: '',
+    excluded: new Set<string>(),
+}
+
+export function isFilterActive(state: ColumnFilterState | undefined): boolean {
+    if (!state) return false
+    return Boolean(state.sort) || state.text.trim() !== '' || state.excluded.size > 0
+}
+
+interface Props {
+    field: string
+    label: string
+    uniqueValues: string[]
+    state: ColumnFilterState
+    onChange: (next: ColumnFilterState) => void
+    onClear: () => void
+}
+
+const BLANK_TOKEN = '__blank__'
+const BLANK_LABEL = '(Blanks)'
+
+export const ColumnFilter: React.FC<Props> = ({
+    field: _field,
+    label,
+    uniqueValues,
+    state,
+    onChange,
+    onClear,
+}) => {
+    const [open, setOpen] = useState(false)
+    const [valueSearch, setValueSearch] = useState('')
+    const buttonRef = useRef<HTMLButtonElement | null>(null)
+    const popoverRef = useRef<HTMLDivElement | null>(null)
+    const [popoverPos, setPopoverPos] = useState<{ top: number; left: number } | null>(null)
+
+    const active = isFilterActive(state)
+
+    useEffect(() => {
+        if (!open) return
+        const handleClickOutside = (e: MouseEvent) => {
+            if (
+                popoverRef.current &&
+                !popoverRef.current.contains(e.target as Node) &&
+                buttonRef.current &&
+                !buttonRef.current.contains(e.target as Node)
+            ) {
+                setOpen(false)
+            }
+        }
+        const handleEsc = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setOpen(false)
+        }
+        document.addEventListener('mousedown', handleClickOutside)
+        document.addEventListener('keydown', handleEsc)
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside)
+            document.removeEventListener('keydown', handleEsc)
+        }
+    }, [open])
+
+    useEffect(() => {
+        if (!open || !buttonRef.current) return
+        const rect = buttonRef.current.getBoundingClientRect()
+        const POPOVER_WIDTH = 280
+        const padding = 8
+        let left = rect.left
+        if (left + POPOVER_WIDTH + padding > window.innerWidth) {
+            left = window.innerWidth - POPOVER_WIDTH - padding
+        }
+        if (left < padding) left = padding
+        setPopoverPos({ top: rect.bottom + 4, left })
+    }, [open])
+
+    const filteredUniques = useMemo(() => {
+        const q = valueSearch.trim().toLowerCase()
+        if (!q) return uniqueValues
+        return uniqueValues.filter((v) => v.toLowerCase().includes(q))
+    }, [uniqueValues, valueSearch])
+
+    const allVisibleSelected = filteredUniques.every((v) => !state.excluded.has(v || BLANK_TOKEN))
+    const someVisibleSelected = filteredUniques.some((v) => !state.excluded.has(v || BLANK_TOKEN))
+
+    const toggleValue = (raw: string) => {
+        const key = raw || BLANK_TOKEN
+        const next = new Set(state.excluded)
+        if (next.has(key)) next.delete(key)
+        else next.add(key)
+        onChange({ ...state, excluded: next })
+    }
+
+    const toggleAllVisible = () => {
+        const next = new Set(state.excluded)
+        if (allVisibleSelected) {
+            for (const v of filteredUniques) next.add(v || BLANK_TOKEN)
+        } else {
+            for (const v of filteredUniques) next.delete(v || BLANK_TOKEN)
+        }
+        onChange({ ...state, excluded: next })
+    }
+
+    return (
+        <>
+            <button
+                ref={buttonRef}
+                type="button"
+                onClick={(e) => {
+                    e.stopPropagation()
+                    setOpen((o) => !o)
+                }}
+                className={`ml-1 inline-flex items-center justify-center w-6 h-6 rounded transition-colors ${
+                    active
+                        ? 'bg-[#487749] text-white'
+                        : 'text-[#9E9E9E] hover:text-[#487749] hover:bg-white'
+                }`}
+                title={`Filter ${label}`}
+                aria-label={`Filter ${label}`}
+            >
+                <Filter className="w-3.5 h-3.5" />
+            </button>
+
+            {open && popoverPos && (
+                <div
+                    ref={popoverRef}
+                    style={{ top: popoverPos.top, left: popoverPos.left, width: 280 }}
+                    className="fixed z-[100] bg-white rounded-xl shadow-2xl border border-[#E0E0E0] overflow-hidden text-[#212121]"
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <div className="px-3 py-2 border-b border-[#E0E0E0] flex items-center justify-between">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-[#487749] truncate">
+                            {label}
+                        </span>
+                        <button
+                            type="button"
+                            onClick={() => setOpen(false)}
+                            className="p-0.5 rounded hover:bg-gray-100 text-gray-500"
+                            aria-label="Close"
+                        >
+                            <X className="w-3.5 h-3.5" />
+                        </button>
+                    </div>
+
+                    <div className="px-3 py-2 border-b border-[#E0E0E0] space-y-1">
+                        <div className="text-[10px] font-semibold uppercase tracking-wider text-[#9E9E9E]">
+                            Sort
+                        </div>
+                        <div className="flex gap-1">
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    onChange({
+                                        ...state,
+                                        sort: state.sort === 'asc' ? null : 'asc',
+                                    })
+                                }
+                                className={`flex-1 inline-flex items-center justify-center gap-1 px-2 py-1.5 text-xs rounded-md border ${
+                                    state.sort === 'asc'
+                                        ? 'bg-[#487749] text-white border-[#487749]'
+                                        : 'border-[#E0E0E0] hover:bg-gray-50'
+                                }`}
+                            >
+                                <ArrowUp className="w-3 h-3" /> Asc
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    onChange({
+                                        ...state,
+                                        sort: state.sort === 'desc' ? null : 'desc',
+                                    })
+                                }
+                                className={`flex-1 inline-flex items-center justify-center gap-1 px-2 py-1.5 text-xs rounded-md border ${
+                                    state.sort === 'desc'
+                                        ? 'bg-[#487749] text-white border-[#487749]'
+                                        : 'border-[#E0E0E0] hover:bg-gray-50'
+                                }`}
+                            >
+                                <ArrowDown className="w-3 h-3" /> Desc
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="px-3 py-2 border-b border-[#E0E0E0]">
+                        <div className="text-[10px] font-semibold uppercase tracking-wider text-[#9E9E9E] mb-1">
+                            Contains
+                        </div>
+                        <input
+                            type="text"
+                            value={state.text}
+                            onChange={(e) => onChange({ ...state, text: e.target.value })}
+                            placeholder="Filter text..."
+                            className="w-full text-sm border border-[#E0E0E0] rounded-md px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-[#487749] focus:border-[#487749]"
+                        />
+                    </div>
+
+                    <div className="px-3 py-2">
+                        <div className="text-[10px] font-semibold uppercase tracking-wider text-[#9E9E9E] mb-1">
+                            Values
+                        </div>
+                        <div className="relative mb-2">
+                            <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[#9E9E9E]" />
+                            <input
+                                type="text"
+                                value={valueSearch}
+                                onChange={(e) => setValueSearch(e.target.value)}
+                                placeholder="Search values..."
+                                className="w-full text-xs border border-[#E0E0E0] rounded-md pl-7 pr-2 py-1 focus:outline-none focus:ring-1 focus:ring-[#487749] focus:border-[#487749]"
+                            />
+                        </div>
+                        <label className="flex items-center gap-2 px-1 py-1 text-xs hover:bg-gray-50 rounded cursor-pointer border-b border-gray-100 mb-1">
+                            <input
+                                type="checkbox"
+                                checked={allVisibleSelected}
+                                ref={(el) => {
+                                    if (el) el.indeterminate = !allVisibleSelected && someVisibleSelected
+                                }}
+                                onChange={toggleAllVisible}
+                                className="accent-[#487749]"
+                            />
+                            <span className="font-medium">(Select all)</span>
+                        </label>
+                        <div className="max-h-44 overflow-y-auto pr-1">
+                            {filteredUniques.length === 0 ? (
+                                <div className="text-xs text-[#9E9E9E] py-2 text-center">No values</div>
+                            ) : (
+                                filteredUniques.map((v) => {
+                                    const key = v || BLANK_TOKEN
+                                    const checked = !state.excluded.has(key)
+                                    return (
+                                        <label
+                                            key={key}
+                                            className="flex items-center gap-2 px-1 py-1 text-xs hover:bg-gray-50 rounded cursor-pointer"
+                                        >
+                                            <input
+                                                type="checkbox"
+                                                checked={checked}
+                                                onChange={() => toggleValue(v)}
+                                                className="accent-[#487749]"
+                                            />
+                                            <span className="truncate" title={v || BLANK_LABEL}>
+                                                {v || (
+                                                    <em className="text-[#9E9E9E]">{BLANK_LABEL}</em>
+                                                )}
+                                            </span>
+                                        </label>
+                                    )
+                                })
+                            )}
+                        </div>
+                    </div>
+
+                    <div className="px-3 py-2 border-t border-[#E0E0E0] flex justify-between items-center bg-[#FAF9F6]">
+                        <button
+                            type="button"
+                            onClick={() => {
+                                onClear()
+                                setValueSearch('')
+                            }}
+                            disabled={!active}
+                            className="text-xs text-[#487749] hover:underline disabled:text-[#9E9E9E] disabled:no-underline disabled:cursor-not-allowed"
+                        >
+                            Clear filter
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setOpen(false)}
+                            className="text-xs px-3 py-1 rounded-md bg-[#487749] text-white hover:bg-[#3d6540]"
+                        >
+                            Done
+                        </button>
+                    </div>
+                </div>
+            )}
+        </>
+    )
+}

--- a/frontend/src/components/common/DataTable/DataTable.tsx
+++ b/frontend/src/components/common/DataTable/DataTable.tsx
@@ -10,6 +10,8 @@ import { getFieldValue, ExtendedEntityType } from '@/utils/masterUtils'
 import { ENTITY_TYPES } from '@/constants/entityConstants'
 import { TableCell } from './TableCell'
 import { TableActions } from './TableActions'
+import { ColumnFilter, EMPTY_FILTER, type ColumnFilterState } from './ColumnFilter'
+import { uniqueValuesForField, type ColumnFilters } from './columnFilterUtils'
 
 interface DataTableProps {
     fields: readonly string[] | string[]
@@ -34,6 +36,13 @@ interface DataTableProps {
         className?: string
         icon?: React.ComponentType<{ className?: string }>
     }>
+    /**
+     * Full pre-pagination dataset (used to compute unique values for column filter dropdowns).
+     * Falls back to `data` when omitted.
+     */
+    columnFilterSourceData?: any[]
+    columnFilters?: ColumnFilters
+    onColumnFiltersChange?: (next: ColumnFilters) => void
 }
 
 export const DataTable: React.FC<DataTableProps> = ({
@@ -52,10 +61,48 @@ export const DataTable: React.FC<DataTableProps> = ({
     canEditItem,
     canDeleteItem,
     customActions,
+    columnFilterSourceData,
+    columnFilters,
+    onColumnFiltersChange,
 }) => {
     // Always show table headers, even when there's no data
     // This ensures users can see the field structure and understand what data should be there
     const hasData = data.length > 0
+    const filterSource = columnFilterSourceData ?? data
+    const filtersEnabled = Boolean(columnFilters && onColumnFiltersChange)
+
+    const uniqueValuesByField = React.useMemo(() => {
+        if (!filtersEnabled) return {} as Record<string, string[]>
+        const map: Record<string, string[]> = {}
+        for (const field of fields) {
+            map[field] = uniqueValuesForField(filterSource, field)
+        }
+        return map
+    }, [filtersEnabled, fields, filterSource])
+
+    const updateColumnFilter = (field: string, next: ColumnFilterState) => {
+        if (!onColumnFiltersChange) return
+        const current = columnFilters ?? {}
+        // If the new state sets a sort direction, clear sort on every other column
+        // (we support a single active sort at a time).
+        if (next.sort) {
+            const cleared: ColumnFilters = {}
+            for (const key of Object.keys(current)) {
+                if (key === field) continue
+                cleared[key] = { ...current[key], sort: null }
+            }
+            onColumnFiltersChange({ ...current, ...cleared, [field]: next })
+            return
+        }
+        onColumnFiltersChange({ ...current, [field]: next })
+    }
+
+    const clearColumnFilter = (field: string) => {
+        if (!onColumnFiltersChange) return
+        const current = columnFilters ?? {}
+        const { [field]: _drop, ...rest } = current
+        onColumnFiltersChange(rest)
+    }
 
     return (
         <div className="flex-1 bg-white rounded-xl border border-[#E0E0E0] overflow-hidden flex flex-col min-h-0 relative">
@@ -66,11 +113,30 @@ export const DataTable: React.FC<DataTableProps> = ({
 							<th className="px-6 py-4 text-xs font-semibold text-[#212121] uppercase tracking-wider bg-[#F5F5F5] whitespace-nowrap sticky left-0 z-30 border-b border-l border-[#E0E0E0]">
                                 S.No.
                             </th>
-                            {fields.map((field, idx) => (
-								<th key={idx} className="px-6 py-4 text-xs font-semibold text-[#212121] uppercase tracking-wider bg-[#F5F5F5] whitespace-nowrap border-b border-[#E0E0E0]">
-                                    {formatHeaderLabel(field)}
-                                </th>
-                            ))}
+                            {fields.map((field, idx) => {
+                                const label = formatHeaderLabel(field)
+                                const state = (columnFilters && columnFilters[field]) || EMPTY_FILTER
+                                return (
+                                    <th
+                                        key={idx}
+                                        className="px-6 py-4 text-xs font-semibold text-[#212121] uppercase tracking-wider bg-[#F5F5F5] whitespace-nowrap border-b border-[#E0E0E0]"
+                                    >
+                                        <div className="flex items-center justify-between gap-2">
+                                            <span className="truncate">{label}</span>
+                                            {filtersEnabled && (
+                                                <ColumnFilter
+                                                    field={field}
+                                                    label={label}
+                                                    uniqueValues={uniqueValuesByField[field] || []}
+                                                    state={state}
+                                                    onChange={(s) => updateColumnFilter(field, s)}
+                                                    onClear={() => clearColumnFilter(field)}
+                                                />
+                                            )}
+                                        </div>
+                                    </th>
+                                )
+                            })}
 							<th className="px-6 py-4 text-right text-xs font-semibold text-[#212121] uppercase tracking-wider bg-[#F5F5F5] whitespace-nowrap sticky right-0 z-30 border-b border-r border-[#E0E0E0]">
                                 Action
                             </th>

--- a/frontend/src/components/common/DataTable/columnFilterUtils.ts
+++ b/frontend/src/components/common/DataTable/columnFilterUtils.ts
@@ -1,0 +1,87 @@
+import { getFieldValue } from '@/utils/masterUtils'
+import type { ColumnFilterState } from './ColumnFilter'
+
+export type ColumnFilters = Record<string, ColumnFilterState>
+
+const BLANK_TOKEN = '__blank__'
+
+export function valueToString(value: unknown): string {
+    if (value === null || value === undefined) return ''
+    if (typeof value === 'string') return value
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+    if (value instanceof Date) return value.toISOString()
+    if (typeof value === 'object') {
+        const obj = value as Record<string, unknown>
+        const cand = obj.name ?? obj.label ?? obj.title ?? obj.value
+        if (cand !== undefined) return valueToString(cand)
+        try {
+            return JSON.stringify(value)
+        } catch {
+            return String(value)
+        }
+    }
+    return String(value)
+}
+
+export function uniqueValuesForField(
+    data: any[],
+    field: string,
+): string[] {
+    const set = new Set<string>()
+    for (const item of data) {
+        const v = valueToString(getFieldValue(item, field))
+        set.add(v)
+    }
+    return Array.from(set).sort((a, b) => {
+        if (a === '') return -1
+        if (b === '') return 1
+        const na = Number(a)
+        const nb = Number(b)
+        if (!Number.isNaN(na) && !Number.isNaN(nb)) return na - nb
+        return a.localeCompare(b)
+    })
+}
+
+export function applyColumnFilters<T>(
+    data: T[],
+    fields: readonly string[],
+    filters: ColumnFilters,
+): T[] {
+    if (!filters || Object.keys(filters).length === 0) return data
+    let result = data
+    for (const field of fields) {
+        const f = filters[field]
+        if (!f) continue
+        const text = f.text.trim().toLowerCase()
+        const hasExcluded = f.excluded && f.excluded.size > 0
+        if (!text && !hasExcluded) continue
+        result = result.filter((item) => {
+            const raw = valueToString(getFieldValue(item, field))
+            if (text && !raw.toLowerCase().includes(text)) return false
+            if (hasExcluded) {
+                const key = raw || BLANK_TOKEN
+                if (f.excluded.has(key)) return false
+            }
+            return true
+        })
+    }
+
+    // Single active sort: pick the first field with a sort direction set.
+    const sortField = fields.find((f) => filters[f]?.sort)
+    if (sortField) {
+        const dir = filters[sortField].sort
+        const mult = dir === 'desc' ? -1 : 1
+        result = [...result].sort((a, b) => {
+            const av = valueToString(getFieldValue(a, sortField))
+            const bv = valueToString(getFieldValue(b, sortField))
+            if (av === bv) return 0
+            if (av === '') return 1
+            if (bv === '') return -1
+            const na = Number(av)
+            const nb = Number(bv)
+            if (!Number.isNaN(na) && !Number.isNaN(nb)) return (na - nb) * mult
+            return av.localeCompare(bv) * mult
+        })
+    }
+    return result
+}

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -15,6 +15,10 @@ import { Breadcrumbs } from '@/components/common/Breadcrumbs'
 import { TabNavigation } from '@/components/common/TabNavigation'
 import { DataTable } from '@/components/common/DataTable/DataTable'
 import { Pagination } from '@/components/common/DataTable/Pagination'
+import {
+    applyColumnFilters,
+    type ColumnFilters,
+} from '@/components/common/DataTable/columnFilterUtils'
 import { SearchInput } from '@/components/common/SearchInput'
 import { LoadingState } from '@/components/common/LoadingState'
 // import { ErrorState } from '@/components/common/ErrorState'
@@ -202,6 +206,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     const [currentPage, setCurrentPage] = useState(1)
     const [reportingYearFrom, setReportingYearFrom] = useState<string>('')
     const [reportingYearTo, setReportingYearTo] = useState<string>('')
+    const [columnFilters, setColumnFilters] = useState<ColumnFilters>({})
     const [isExportMenuOpen, setIsExportMenuOpen] = useState(false)
     const [isMobileRouteMenuOpen, setIsMobileRouteMenuOpen] = useState(false)
     const [isOftFldTabMenuOpen, setIsOftFldTabMenuOpen] = useState(false)
@@ -321,8 +326,15 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     useEffect(() => {
         setSearchQuery('')
         setCurrentPage(1)
+        setColumnFilters({})
         closeForm()
     }, [location.pathname, closeForm])
+
+    // Reset to first page whenever column filters change so the user always
+    // sees the start of the new result set.
+    useEffect(() => {
+        setCurrentPage(1)
+    }, [columnFilters])
 
     // Debounce search
     useEffect(() => {
@@ -391,20 +403,29 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
         })
     }, [items, debouncedSearch, fields, reportingYearFrom, reportingYearTo])
 
+    // Apply per-column filters (Excel-style: sort + text + multi-select) on top
+    // of the search/year-filtered set. The column-filter dropdown's unique-value
+    // list is computed from `filteredData` so it represents the full visible
+    // dataset before column filters narrow it further.
+    const columnFilteredData = useMemo(
+        () => applyColumnFilters(filteredData, fields, columnFilters),
+        [filteredData, fields, columnFilters],
+    )
+
     // Pagination calculations - memoized for performance
     const paginationData = useMemo(() => {
         const totalPages = Math.max(
             1,
-            Math.ceil(filteredData.length / itemsPerPage)
+            Math.ceil(columnFilteredData.length / itemsPerPage)
         )
         // Clamp currentPage so it never points beyond the last page (e.g. after a search narrows results)
         const safePage = Math.min(currentPage, totalPages)
         const startIndex = (safePage - 1) * itemsPerPage
         const endIndex = startIndex + itemsPerPage
-        const paginatedData = filteredData.slice(startIndex, endIndex)
+        const paginatedData = columnFilteredData.slice(startIndex, endIndex)
 
         return { totalPages, safePage, startIndex, endIndex, paginatedData }
-    }, [filteredData, currentPage, itemsPerPage])
+    }, [columnFilteredData, currentPage, itemsPerPage])
 
     const { totalPages, safePage, startIndex, endIndex, paginatedData } =
         paginationData
@@ -1736,6 +1757,9 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                                         isEmployeeDetails={isEmployeeDetails}
                                         startIndex={startIndex}
                                         locationPathname={location.pathname}
+                                        columnFilterSourceData={filteredData}
+                                        columnFilters={columnFilters}
+                                        onColumnFiltersChange={setColumnFilters}
                                         onEdit={handleEdit}
                                         onDelete={handleDelete}
                                         canEditItem={canEditItem}
@@ -1767,7 +1791,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                                         totalPages={totalPages}
                                         startIndex={startIndex}
                                         endIndex={endIndex}
-                                        totalItems={filteredData.length}
+                                        totalItems={columnFilteredData.length}
                                         onPageChange={setCurrentPage}
                                     />
                                 </>


### PR DESCRIPTION
## Summary
- Add per-column Excel-style filter (sort asc/desc, contains-text, multi-select unique values) to the shared `DataTable` so it applies to every form table.
- Lift `columnFilters` state into `DataManagementView`; chain order is now `items → year-range → search → columnFilters → pagination`. Single active sort at a time; pagination resets to page 1 on any filter change.
- Raise About KVK fetch caps (repository 100 → 10000, service defaults 100 → 10000) so unique-value lists in the dropdown reflect the full dataset. Other form repositories already return full result sets.

## Test plan
- [ ] Open any form table → click filter icon on any header → verify popover with sort, contains, value list.
- [ ] Multi-select values → only matching rows render; unique list reflects pre-column-filter data.
- [ ] Set sort on a column → other column sorts cleared; data sorts numerically when both sides are numeric, alphabetically otherwise.
- [ ] Switch tabs/routes → column filters reset; current page resets to 1.
- [ ] About KVK forms with > 100 rows now load all rows (no longer capped).
- [ ] Existing global search + year-range filter still compose with column filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)