### PR TITLE
feat(notifications): email-style circulars with file attachments

### DIFF
--- a/backend/controllers/notificationController.js
+++ b/backend/controllers/notificationController.js
@@ -1,4 +1,5 @@
 const notificationService = require('../services/notificationService.js');
+const notificationAttachmentService = require('../services/notificationAttachmentService.js');
 
 const notificationController = {
   /**
@@ -79,6 +80,49 @@ const notificationController = {
       return res.status(200).json(data);
     } catch (error) {
       return res.status(400).json({ error: error.message });
+    }
+  },
+
+  /**
+   * POST /api/admin/notifications/attachments/presign
+   */
+  presignAttachment: async (req, res) => {
+    try {
+      const data = await notificationAttachmentService.presignUpload(req.body || {}, req.user);
+      return res.status(200).json(data);
+    } catch (error) {
+      const isAuth = /super_admin/i.test(error.message);
+      return res.status(isAuth ? 403 : 400).json({ error: error.message });
+    }
+  },
+
+  /**
+   * POST /api/admin/notifications/attachments/confirm
+   */
+  confirmAttachment: async (req, res) => {
+    try {
+      const data = await notificationAttachmentService.confirmUpload(req.body || {}, req.user);
+      return res.status(201).json(data);
+    } catch (error) {
+      const isAuth = /super_admin/i.test(error.message);
+      return res.status(isAuth ? 403 : 400).json({ error: error.message });
+    }
+  },
+
+  /**
+   * DELETE /api/admin/notifications/attachments/:attachmentId
+   */
+  deleteAttachment: async (req, res) => {
+    try {
+      const attachmentId = Number(req.params.attachmentId);
+      if (!Number.isInteger(attachmentId) || attachmentId <= 0) {
+        return res.status(400).json({ error: 'Invalid attachmentId' });
+      }
+      const data = await notificationAttachmentService.deleteAttachment(attachmentId, req.user);
+      return res.status(200).json(data);
+    } catch (error) {
+      const isAuth = /super_admin/i.test(error.message);
+      return res.status(isAuth ? 403 : 400).json({ error: error.message });
     }
   },
 

--- a/backend/prisma/superadmin/user/notification_schema.prisma
+++ b/backend/prisma/superadmin/user/notification_schema.prisma
@@ -1,16 +1,34 @@
 model Notification {
-  notificationId   Int                @id @default(autoincrement()) @map("notification_id")
+  notificationId   Int                       @id @default(autoincrement()) @map("notification_id")
   subject          String
   content          String
-  createdByUserId  Int                @map("created_by_user_id")
-  createdAt        DateTime           @default(now()) @map("created_at")
-  updatedAt        DateTime           @updatedAt @map("updated_at")
-  createdBy        User               @relation("CreatedNotifications", fields: [createdByUserId], references: [userId], onDelete: Cascade)
+  createdByUserId  Int                       @map("created_by_user_id")
+  createdAt        DateTime                  @default(now()) @map("created_at")
+  updatedAt        DateTime                  @updatedAt @map("updated_at")
+  createdBy        User                      @relation("CreatedNotifications", fields: [createdByUserId], references: [userId], onDelete: Cascade)
   userNotifications UserNotification[]
+  attachments      NotificationAttachment[]
 
   @@index([createdAt])
   @@index([createdByUserId])
   @@map("notifications")
+}
+
+model NotificationAttachment {
+  attachmentId     Int          @id @default(autoincrement()) @map("attachment_id")
+  notificationId   Int?         @map("notification_id")
+  s3Key            String       @map("s3_key")
+  fileName         String?      @map("file_name")
+  mimeType         String       @map("mime_type")
+  size             Int          @default(0)
+  uploadedByUserId Int?         @map("uploaded_by_user_id")
+  createdAt        DateTime     @default(now()) @map("created_at")
+  notification     Notification? @relation(fields: [notificationId], references: [notificationId], onDelete: Cascade)
+  uploadedBy       User?        @relation("UploadedNotificationAttachments", fields: [uploadedByUserId], references: [userId], onDelete: SetNull)
+
+  @@index([notificationId])
+  @@index([uploadedByUserId])
+  @@map("notification_attachments")
 }
 
 model UserNotification {

--- a/backend/prisma/superadmin/user/user_schema.prisma
+++ b/backend/prisma/superadmin/user/user_schema.prisma
@@ -101,6 +101,7 @@ model User {
   refreshTokens      RefreshToken[]
   transfersPerformed StaffTransferHistory[]
   userNotifications  UserNotification[]     @relation("UserNotifications")
+  uploadedNotificationAttachments NotificationAttachment[] @relation("UploadedNotificationAttachments")
   userPermissions    UserPermission[]
   district           DistrictMaster?        @relation(fields: [districtId], references: [districtId])
   kvk                Kvk?                   @relation(fields: [kvkId], references: [kvkId])

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -79,6 +79,9 @@ router.get('/notifications/recent', apiRateLimiter, requirePermission(NOTIFICATI
 router.get('/notifications/unread-count', apiRateLimiter, requirePermission(NOTIFICATIONS_MODULE, 'VIEW'), notificationController.getUnreadCountForCurrentUser);
 router.get('/notifications/users', apiRateLimiter, requirePermission(NOTIFICATIONS_MODULE, 'VIEW'), notificationController.getRecipientUsers);
 router.post('/notifications', strictRateLimiter, requirePermission(NOTIFICATIONS_MODULE, 'ADD'), notificationController.createNotification);
+router.post('/notifications/attachments/presign', strictRateLimiter, requirePermission(NOTIFICATIONS_MODULE, 'ADD'), notificationController.presignAttachment);
+router.post('/notifications/attachments/confirm', strictRateLimiter, requirePermission(NOTIFICATIONS_MODULE, 'ADD'), notificationController.confirmAttachment);
+router.delete('/notifications/attachments/:attachmentId', strictRateLimiter, requirePermission(NOTIFICATIONS_MODULE, 'ADD'), notificationController.deleteAttachment);
 router.patch('/notifications/read-all', strictRateLimiter, requirePermission(NOTIFICATIONS_MODULE, 'VIEW'), notificationController.markAllAsRead);
 router.patch('/notifications/:userNotificationId/read', strictRateLimiter, requirePermission(NOTIFICATIONS_MODULE, 'VIEW'), notificationController.markAsRead);
 

--- a/backend/services/notificationAttachmentService.js
+++ b/backend/services/notificationAttachmentService.js
@@ -1,0 +1,177 @@
+const prisma = require('../config/prisma.js');
+const s3 = require('./storage/s3Service.js');
+const { ValidationError, NotFoundError, UnauthorizedError } = require('../utils/errorHandler.js');
+
+const SUPER_ADMIN_ROLE = 'super_admin';
+
+const MAX_BYTES = 25 * 1024 * 1024;
+const MAX_FILES_PER_NOTIFICATION = 10;
+
+const ALLOWED_MIME_PREFIXES = [
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml',
+    'application/vnd.ms-powerpoint',
+    'application/vnd.openxmlformats-officedocument.presentationml',
+    'image/',
+    'text/csv',
+    'text/plain',
+];
+
+function assertSuperAdmin(user) {
+    if (!user) throw new UnauthorizedError();
+    if (user.roleName !== SUPER_ADMIN_ROLE) {
+        throw new ValidationError('Only super_admin can manage notification attachments');
+    }
+}
+
+function validateUploadInput({ fileName, mimeType, size }) {
+    if (!fileName || typeof fileName !== 'string' || fileName.length > 255) {
+        throw new ValidationError('fileName is required and must be < 255 chars');
+    }
+    if (!mimeType || typeof mimeType !== 'string') {
+        throw new ValidationError('mimeType is required');
+    }
+    const allowed = ALLOWED_MIME_PREFIXES.some((p) => mimeType.startsWith(p));
+    if (!allowed) {
+        throw new ValidationError(`File type not allowed: ${mimeType}`);
+    }
+    const num = Number(size);
+    if (!Number.isFinite(num) || num <= 0) {
+        throw new ValidationError('Invalid file size');
+    }
+    if (num > MAX_BYTES) {
+        throw new ValidationError(`File exceeds max size ${(MAX_BYTES / (1024 * 1024)).toFixed(0)}MB`);
+    }
+}
+
+async function decorate(row) {
+    if (!row) return row;
+    const url = row.s3Key
+        ? await s3.presignGet({ key: row.s3Key, downloadFileName: row.fileName || undefined })
+        : null;
+    return {
+        attachmentId: row.attachmentId,
+        notificationId: row.notificationId,
+        fileName: row.fileName,
+        mimeType: row.mimeType,
+        size: row.size,
+        createdAt: row.createdAt,
+        fileUrl: url,
+        downloadUrl: url,
+        uploadedBy: row.uploadedBy
+            ? { userId: row.uploadedBy.userId, name: row.uploadedBy.name, email: row.uploadedBy.email }
+            : null,
+    };
+}
+
+async function presignUpload({ fileName, mimeType, size }, user) {
+    assertSuperAdmin(user);
+    validateUploadInput({ fileName, mimeType, size });
+    if (!s3.isConfigured()) {
+        throw new ValidationError('Object storage not configured on server');
+    }
+    const s3Key = s3.buildNotificationAttachmentKey({ fileName, mimeType });
+    const uploadUrl = await s3.presignPut({ key: s3Key, mimeType });
+    return {
+        s3Key,
+        uploadUrl,
+        expiresIn: s3.PUT_TTL_SECONDS,
+        headers: { 'Content-Type': mimeType },
+    };
+}
+
+async function confirmUpload(payload, user) {
+    assertSuperAdmin(user);
+    const { s3Key, fileName, mimeType, size } = payload || {};
+    validateUploadInput({ fileName, mimeType, size });
+    if (!s3Key || typeof s3Key !== 'string' || !s3Key.startsWith('notifications/')) {
+        throw new ValidationError('s3Key does not match notification path');
+    }
+    const row = await prisma.notificationAttachment.create({
+        data: {
+            notificationId: null,
+            s3Key,
+            fileName,
+            mimeType,
+            size: Number(size),
+            uploadedByUserId: user.userId,
+        },
+        include: { uploadedBy: { select: { userId: true, name: true, email: true } } },
+    });
+    return decorate(row);
+}
+
+async function attachToNotification({ attachmentIds, notificationId, user, tx }) {
+    const ids = (Array.isArray(attachmentIds) ? attachmentIds : [])
+        .map((id) => Number(id))
+        .filter((id) => Number.isInteger(id) && id > 0);
+    if (ids.length === 0) return { count: 0 };
+    if (ids.length > MAX_FILES_PER_NOTIFICATION) {
+        throw new ValidationError(`Maximum ${MAX_FILES_PER_NOTIFICATION} attachments per notification`);
+    }
+    const client = tx || prisma;
+    return client.notificationAttachment.updateMany({
+        where: {
+            attachmentId: { in: ids },
+            uploadedByUserId: user.userId,
+            OR: [{ notificationId: null }, { notificationId }],
+        },
+        data: { notificationId },
+    });
+}
+
+async function listForNotification(notificationId) {
+    const rows = await prisma.notificationAttachment.findMany({
+        where: { notificationId },
+        orderBy: [{ attachmentId: 'asc' }],
+        include: { uploadedBy: { select: { userId: true, name: true, email: true } } },
+    });
+    return Promise.all(rows.map(decorate));
+}
+
+async function listForNotificationIds(notificationIds) {
+    if (!Array.isArray(notificationIds) || notificationIds.length === 0) {
+        return new Map();
+    }
+    const rows = await prisma.notificationAttachment.findMany({
+        where: { notificationId: { in: notificationIds } },
+        orderBy: [{ attachmentId: 'asc' }],
+        include: { uploadedBy: { select: { userId: true, name: true, email: true } } },
+    });
+    const decorated = await Promise.all(rows.map(decorate));
+    const grouped = new Map();
+    for (const att of decorated) {
+        if (att.notificationId == null) continue;
+        const list = grouped.get(att.notificationId) || [];
+        list.push(att);
+        grouped.set(att.notificationId, list);
+    }
+    return grouped;
+}
+
+async function deleteAttachment(attachmentId, user) {
+    assertSuperAdmin(user);
+    const existing = await prisma.notificationAttachment.findUnique({
+        where: { attachmentId: Number(attachmentId) },
+    });
+    if (!existing) throw new NotFoundError('Attachment');
+    await prisma.notificationAttachment.delete({ where: { attachmentId: existing.attachmentId } });
+    if (existing.s3Key) {
+        try { await s3.deleteOne(existing.s3Key); } catch { /* best-effort */ }
+    }
+    return { ok: true };
+}
+
+module.exports = {
+    presignUpload,
+    confirmUpload,
+    attachToNotification,
+    listForNotification,
+    listForNotificationIds,
+    deleteAttachment,
+    MAX_BYTES,
+    MAX_FILES_PER_NOTIFICATION,
+};

--- a/backend/services/notificationService.js
+++ b/backend/services/notificationService.js
@@ -1,4 +1,5 @@
 const notificationRepository = require('../repositories/notificationRepository.js');
+const notificationAttachmentService = require('./notificationAttachmentService.js');
 
 const SUPER_ADMIN_ROLE = 'super_admin';
 
@@ -13,7 +14,8 @@ function normalizeLimit(limit, fallback = 10) {
   return Math.min(parsed, 100);
 }
 
-function mapUserNotification(row) {
+function mapUserNotification(row, attachmentsById) {
+  const attachments = attachmentsById?.get(row.notificationId) || [];
   return {
     userNotificationId: row.userNotificationId,
     notificationId: row.notificationId,
@@ -30,6 +32,8 @@ function mapUserNotification(row) {
           email: row.notification.createdBy.email,
         }
       : null,
+    attachments,
+    attachmentCount: attachments.length,
   };
 }
 
@@ -81,12 +85,24 @@ const notificationService = {
       throw new Error('Selected users are not active');
     }
 
+    const rawAttachmentIds = Array.isArray(payload?.attachmentIds) ? payload.attachmentIds : [];
+
     const notification = await notificationRepository.createNotificationWithRecipients({
       subject,
       content,
       createdByUserId: actor.userId,
       recipientUserIds,
     });
+
+    if (rawAttachmentIds.length > 0) {
+      await notificationAttachmentService.attachToNotification({
+        attachmentIds: rawAttachmentIds,
+        notificationId: notification.notificationId,
+        user: actor,
+      });
+    }
+
+    const attachments = await notificationAttachmentService.listForNotification(notification.notificationId);
 
     return {
       notificationId: notification.notificationId,
@@ -95,6 +111,8 @@ const notificationService = {
       createdByUserId: notification.createdByUserId,
       createdAt: notification.createdAt,
       recipientCount: recipientUserIds.length,
+      attachments,
+      attachmentCount: attachments.length,
     };
   },
 
@@ -146,8 +164,12 @@ const notificationService = {
       take: limit,
     });
 
+    const attachmentsById = await notificationAttachmentService.listForNotificationIds(
+      rows.map((r) => r.notificationId),
+    );
+
     return {
-      data: rows.map(mapUserNotification),
+      data: rows.map((r) => mapUserNotification(r, attachmentsById)),
       meta: {
         page,
         limit,
@@ -165,7 +187,10 @@ const notificationService = {
   getRecentForUser: async (userId, limit = 5) => {
     const safeLimit = normalizeLimit(limit, 5);
     const rows = await notificationRepository.getRecentForUser(userId, safeLimit);
-    return rows.map(mapUserNotification);
+    const attachmentsById = await notificationAttachmentService.listForNotificationIds(
+      rows.map((r) => r.notificationId),
+    );
+    return rows.map((r) => mapUserNotification(r, attachmentsById));
   },
 
   /**

--- a/backend/services/storage/s3Service.js
+++ b/backend/services/storage/s3Service.js
@@ -56,6 +56,12 @@ function buildAttachmentKey({ formCode, fileName, mimeType }) {
     return `forms/${formCode}/${id}.${ext}`;
 }
 
+function buildNotificationAttachmentKey({ fileName, mimeType }) {
+    const ext = sanitizeExt(fileName, mimeType);
+    const id = randomUUID();
+    return `notifications/${id}.${ext}`;
+}
+
 async function presignPut({ key, mimeType, expiresIn = PUT_TTL_SECONDS }) {
     const cmd = new PutObjectCommand({
         Bucket: BUCKET,
@@ -97,6 +103,7 @@ function isConfigured() {
 
 module.exports = {
     buildAttachmentKey,
+    buildNotificationAttachmentKey,
     presignPut,
     presignGet,
     deleteOne,

--- a/frontend/src/pages/admin/Notifications.tsx
+++ b/frontend/src/pages/admin/Notifications.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { ChevronLeft, Plus, Search, X } from 'lucide-react'
+import { ChevronLeft, Download, FileIcon, Loader2, Paperclip, Plus, Search, X } from 'lucide-react'
 import { Breadcrumbs } from '../../components/common/Breadcrumbs'
 import { Card, CardContent } from '../../components/ui/Card'
 import { getBreadcrumbsForPath, getRouteConfig } from '../../config/route'
@@ -13,6 +13,25 @@ import {
   useRecipientUsers,
 } from '@/hooks/useNotifications'
 import { useAlert } from '@/hooks/useAlert'
+import {
+  notificationApi,
+  type NotificationAttachment,
+} from '@/services/notificationApi'
+
+const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
+const MAX_ATTACHMENTS_PER_NOTIFICATION = 10
+const ATTACHMENT_ACCEPT = [
+  'application/pdf',
+  'image/*',
+  '.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.csv,.txt',
+].join(',')
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
 
 const PAGE_SIZE = 10
 
@@ -84,6 +103,10 @@ export const Notifications: React.FC = () => {
   const [subject, setSubject] = useState('')
   const [content, setContent] = useState('')
   const [selectedNotificationId, setSelectedNotificationId] = useState<number | null>(null)
+  const [composeAttachments, setComposeAttachments] = useState<NotificationAttachment[]>([])
+  const [attachmentUploading, setAttachmentUploading] = useState(false)
+  const [attachmentError, setAttachmentError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -165,6 +188,69 @@ export const Notifications: React.FC = () => {
     setSelectedRecipientIds([])
     setSubject('')
     setContent('')
+    setComposeAttachments([])
+    setAttachmentError(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const handleAttachmentSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files
+    if (!files || files.length === 0) return
+    setAttachmentError(null)
+    const list = Array.from(files)
+    const remaining = MAX_ATTACHMENTS_PER_NOTIFICATION - composeAttachments.length
+    if (remaining <= 0) {
+      setAttachmentError(`Maximum ${MAX_ATTACHMENTS_PER_NOTIFICATION} attachments per circular`)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+      return
+    }
+    const accepted = list.slice(0, remaining)
+    const oversized = accepted.find((f) => f.size > MAX_ATTACHMENT_BYTES)
+    if (oversized) {
+      setAttachmentError(`"${oversized.name}" exceeds max size 25 MB`)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+      return
+    }
+
+    setAttachmentUploading(true)
+    try {
+      const uploaded: NotificationAttachment[] = []
+      for (const file of accepted) {
+        const presign = await notificationApi.presignAttachment({
+          fileName: file.name,
+          mimeType: file.type || 'application/octet-stream',
+          size: file.size,
+        })
+        const res = await fetch(presign.uploadUrl, {
+          method: 'PUT',
+          headers: presign.headers,
+          body: file,
+        })
+        if (!res.ok) throw new Error(`Upload failed for ${file.name} (${res.status})`)
+        const row = await notificationApi.confirmAttachment({
+          s3Key: presign.s3Key,
+          fileName: file.name,
+          mimeType: file.type || 'application/octet-stream',
+          size: file.size,
+        })
+        uploaded.push(row)
+      }
+      setComposeAttachments((prev) => [...prev, ...uploaded])
+    } catch (err) {
+      setAttachmentError(err instanceof Error ? err.message : 'Upload failed')
+    } finally {
+      setAttachmentUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  const handleAttachmentRemove = async (attachmentId: number) => {
+    try {
+      await notificationApi.deleteAttachment(attachmentId)
+      setComposeAttachments((prev) => prev.filter((a) => a.attachmentId !== attachmentId))
+    } catch (err) {
+      setAttachmentError(err instanceof Error ? err.message : 'Delete failed')
+    }
   }
 
   const toggleRecipient = (userId: number) => {
@@ -200,6 +286,7 @@ export const Notifications: React.FC = () => {
         content: trimmedContent,
         sendToAll: recipientMode === 'all',
         recipientUserIds: recipientMode === 'selected' ? selectedRecipientIds : undefined,
+        attachmentIds: composeAttachments.map((a) => a.attachmentId),
       })
 
       alert({
@@ -425,6 +512,66 @@ export const Notifications: React.FC = () => {
                 />
               </div>
 
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-[#487749] mb-2">
+                  Attachments ({composeAttachments.length} / {MAX_ATTACHMENTS_PER_NOTIFICATION})
+                </label>
+                <div className="rounded-xl border border-[#E0E0E0] overflow-hidden bg-white">
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept={ATTACHMENT_ACCEPT}
+                    multiple
+                    disabled={
+                      createNotification.isPending ||
+                      attachmentUploading ||
+                      composeAttachments.length >= MAX_ATTACHMENTS_PER_NOTIFICATION
+                    }
+                    onChange={handleAttachmentSelect}
+                    className="block w-full text-sm bg-white px-3 py-2 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-[#487749] file:text-white hover:file:bg-[#3d6540] cursor-pointer disabled:opacity-60"
+                  />
+                  <div className="bg-gray-50 px-3 py-2 text-xs text-gray-600 border-t border-[#E0E0E0]">
+                    {attachmentUploading ? (
+                      <span className="inline-flex items-center gap-2">
+                        <Loader2 className="w-3 h-3 animate-spin" /> Uploading…
+                      </span>
+                    ) : (
+                      `PDF / Word / Excel / PowerPoint / Image. Max 25 MB each, up to ${MAX_ATTACHMENTS_PER_NOTIFICATION} files.`
+                    )}
+                  </div>
+                </div>
+                {attachmentError && (
+                  <div className="mt-2 text-xs text-red-600 break-words">{attachmentError}</div>
+                )}
+                {composeAttachments.length > 0 && (
+                  <ul className="mt-2 space-y-1">
+                    {composeAttachments.map((att) => (
+                      <li
+                        key={att.attachmentId}
+                        className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg border border-[#E0E0E0] bg-white"
+                      >
+                        <span className="flex items-center gap-2 min-w-0">
+                          <FileIcon className="w-4 h-4 text-[#487749] shrink-0" />
+                          <span className="text-sm text-[#212121] truncate" title={att.fileName ?? ''}>
+                            {att.fileName}
+                          </span>
+                          <span className="text-xs text-[#757575] shrink-0">{formatBytes(att.size)}</span>
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleAttachmentRemove(att.attachmentId)}
+                          disabled={createNotification.isPending}
+                          className="p-1 rounded text-red-500 hover:bg-red-50 disabled:opacity-50"
+                          aria-label="Remove attachment"
+                        >
+                          <X className="w-4 h-4" />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
               <div className="flex items-center gap-2">
                 <button
                   type="submit"
@@ -530,7 +677,17 @@ export const Notifications: React.FC = () => {
                         onClick={() => openNotificationDetails(item.userNotificationId)}
                       >
                         <td className="px-4 py-3 text-sm text-[#212121]">{startEntry + index}</td>
-                        <td className="px-4 py-3 text-sm text-[#212121]">{item.subject || 'N/A'}</td>
+                        <td className="px-4 py-3 text-sm text-[#212121]">
+                          <span className="inline-flex items-center gap-2">
+                            {item.subject || 'N/A'}
+                            {(item.attachmentCount ?? item.attachments?.length ?? 0) > 0 && (
+                              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-[#EEF5EE] text-[#487749] text-xs font-medium">
+                                <Paperclip className="w-3 h-3" />
+                                {item.attachmentCount ?? item.attachments?.length ?? 0}
+                              </span>
+                            )}
+                          </span>
+                        </td>
                         <td className="px-4 py-3 text-sm text-[#212121]">{truncateText(item.content || '')}</td>
                         <td className="px-4 py-3 text-sm text-[#212121]">
                           {item.sentBy?.name || item.sentBy?.email || 'System'}
@@ -649,6 +806,39 @@ export const Notifications: React.FC = () => {
                   {selectedNotification.content || 'N/A'}
                 </p>
               </div>
+              {selectedNotification.attachments && selectedNotification.attachments.length > 0 && (
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-[#757575] flex items-center gap-1">
+                    <Paperclip className="w-3 h-3" /> Attachments ({selectedNotification.attachments.length})
+                  </p>
+                  <ul className="mt-2 space-y-1">
+                    {selectedNotification.attachments.map((att) => (
+                      <li
+                        key={att.attachmentId}
+                        className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg border border-[#E0E0E0] bg-[#FAFDF9]"
+                      >
+                        <span className="flex items-center gap-2 min-w-0">
+                          <FileIcon className="w-4 h-4 text-[#487749] shrink-0" />
+                          <span className="text-sm text-[#212121] truncate" title={att.fileName ?? ''}>
+                            {att.fileName}
+                          </span>
+                          <span className="text-xs text-[#757575] shrink-0">{formatBytes(att.size)}</span>
+                        </span>
+                        {att.downloadUrl && (
+                          <a
+                            href={att.downloadUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-1 px-2 py-1 text-xs rounded-md bg-[#487749] text-white hover:bg-[#3d6540]"
+                          >
+                            <Download className="w-3 h-3" /> Open
+                          </a>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
                   <p className="text-xs uppercase tracking-wide text-[#757575]">Sent By</p>

--- a/frontend/src/services/notificationApi.ts
+++ b/frontend/src/services/notificationApi.ts
@@ -12,6 +12,31 @@ export interface CreateNotificationPayload {
   content: string
   sendToAll?: boolean
   recipientUserIds?: number[]
+  attachmentIds?: number[]
+}
+
+export interface NotificationAttachment {
+  attachmentId: number
+  notificationId: number | null
+  fileName: string | null
+  mimeType: string
+  size: number
+  createdAt: string
+  fileUrl: string | null
+  downloadUrl: string | null
+}
+
+export interface PresignAttachmentInput {
+  fileName: string
+  mimeType: string
+  size: number
+}
+
+export interface PresignAttachmentResponse {
+  s3Key: string
+  uploadUrl: string
+  expiresIn: number
+  headers: Record<string, string>
 }
 
 export interface NotificationItem {
@@ -28,6 +53,8 @@ export interface NotificationItem {
     name: string
     email: string
   } | null
+  attachments?: NotificationAttachment[]
+  attachmentCount?: number
 }
 
 export interface NotificationListMeta {
@@ -150,4 +177,63 @@ export const notificationApi = {
       throw error
     }
   },
+
+  presignAttachment: async (input: PresignAttachmentInput): Promise<PresignAttachmentResponse> => {
+    try {
+      return await apiClient.post<PresignAttachmentResponse>(
+        '/admin/notifications/attachments/presign',
+        input,
+      )
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw new Error(error.data?.error || 'Failed to start upload')
+      }
+      throw error
+    }
+  },
+
+  confirmAttachment: async (input: {
+    s3Key: string
+    fileName: string
+    mimeType: string
+    size: number
+  }): Promise<NotificationAttachment> => {
+    try {
+      return await apiClient.post<NotificationAttachment>(
+        '/admin/notifications/attachments/confirm',
+        input,
+      )
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw new Error(error.data?.error || 'Failed to confirm upload')
+      }
+      throw error
+    }
+  },
+
+  deleteAttachment: async (attachmentId: number) => {
+    try {
+      return await apiClient.delete(`/admin/notifications/attachments/${attachmentId}`)
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw new Error(error.data?.error || 'Failed to delete attachment')
+      }
+      throw error
+    }
+  },
+}
+
+export async function uploadFileToS3(
+  uploadUrl: string,
+  file: File,
+  headers?: Record<string, string>,
+): Promise<void> {
+  const res = await fetch(uploadUrl, {
+    method: 'PUT',
+    headers: headers || { 'Content-Type': file.type || 'application/octet-stream' },
+    body: file,
+  })
+  if (!res.ok) {
+    throw new Error(`S3 upload failed (${res.status})`)
+  }
 }


### PR DESCRIPTION
## Summary
- Notifications gain email-like file attachments so super_admin can issue official circulars with attached PDFs / Word / Excel / PowerPoint / images.
- New \`NotificationAttachment\` table cascade-deletes with the parent notification; reuses existing S3 presign/confirm pattern.
- Compose form, list view (paperclip + count), and detail modal (download chips) are all wired.

## Backend
- New model \`NotificationAttachment\` (\`notification_attachments\`), \`User.uploadedNotificationAttachments\` backref. Schema applied via \`db:push\`.
- \`notificationAttachmentService\`: super_admin-only \`presignUpload\` / \`confirmUpload\` / \`attachToNotification\` / \`listForNotification\` / \`listForNotificationIds\` / \`deleteAttachment\`. Caps: 25 MB / file, 10 / notification. MIME allowlist (PDF, Office, images, CSV, text).
- \`notificationService\`: accepts \`attachmentIds[]\` on create, links them post-insert, decorates list / recent / detail with presigned download URLs + \`attachmentCount\`.
- Routes: \`POST /admin/notifications/attachments/presign\`, \`POST /admin/notifications/attachments/confirm\`, \`DELETE /admin/notifications/attachments/:attachmentId\` (\`notifications:ADD\`).
- \`s3Service.buildNotificationAttachmentKey\` for \`notifications/{uuid}.{ext}\` paths.

## Frontend
- \`notificationApi\` adds \`attachmentIds\` to create payload, plus presign / confirm / delete attachment endpoints; \`NotificationItem\` carries \`attachments\` + \`attachmentCount\`.
- Compose form: multi-file picker (PDF / Office / image), 25 MB limit, 10 file cap, inline progress, per-file remove.
- List: paperclip badge with count alongside subject when any attachments are present.
- Detail modal: Attachments section with file chips and Open (presigned URL).

## Test plan
- [ ] Super_admin opens Notifications → composes circular with 1-3 attachments → verify rows in \`form_attachments\`-equivalent table linked to the notification, and each renders in detail modal with working Open link.
- [ ] Try uploading >25 MB or unsupported type → see inline error.
- [ ] Try uploading 11 files → 11th rejected with limit message.
- [ ] Non-super_admin attempts /attachments/presign → 403.
- [ ] Recipient list shows paperclip badge for circulars with files.
- [ ] Delete a notification → cascade removes attachment rows (S3 cleanup is best-effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)