### PR TITLE
fix(dmv): drag column-filter popover, fix Reset filters, area chart single-row fallback

### DIFF
--- a/frontend/src/components/common/DataTable/ColumnFilter.tsx
+++ b/frontend/src/components/common/DataTable/ColumnFilter.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowUp, ArrowDown, Filter, Search, X } from 'lucide-react'
+import { ArrowUp, ArrowDown, Filter, GripHorizontal, Search, X } from 'lucide-react'
 
 export type SortDir = 'asc' | 'desc' | null
 
@@ -45,6 +45,63 @@ export const ColumnFilter: React.FC<Props> = ({
     const buttonRef = useRef<HTMLButtonElement | null>(null)
     const popoverRef = useRef<HTMLDivElement | null>(null)
     const [popoverPos, setPopoverPos] = useState<{ top: number; left: number } | null>(null)
+    const [dragOffset, setDragOffset] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
+    const dragStateRef = useRef<{
+        pointerId: number
+        startX: number
+        startY: number
+        originX: number
+        originY: number
+    } | null>(null)
+    const [isDragging, setIsDragging] = useState(false)
+
+    const handleDragStart = (e: React.PointerEvent<HTMLDivElement>) => {
+        if (e.button !== 0 && e.pointerType === 'mouse') return
+        try { e.currentTarget.setPointerCapture(e.pointerId) } catch { /* noop */ }
+        dragStateRef.current = {
+            pointerId: e.pointerId,
+            startX: e.clientX,
+            startY: e.clientY,
+            originX: dragOffset.x,
+            originY: dragOffset.y,
+        }
+        setIsDragging(true)
+    }
+
+    const handleDragMove = (e: React.PointerEvent<HTMLDivElement>) => {
+        const drag = dragStateRef.current
+        if (!drag || drag.pointerId !== e.pointerId) return
+        const dx = e.clientX - drag.startX
+        const dy = e.clientY - drag.startY
+        let nextX = drag.originX + dx
+        let nextY = drag.originY + dy
+        if (popoverRef.current && popoverPos && typeof window !== 'undefined') {
+            const rect = popoverRef.current.getBoundingClientRect()
+            const baseLeft = rect.left - dragOffset.x
+            const baseTop = rect.top - dragOffset.y
+            const minX = -baseLeft
+            const minY = -baseTop
+            const maxX = window.innerWidth - baseLeft - rect.width
+            const maxY = window.innerHeight - baseTop - rect.height
+            if (maxX >= minX) nextX = Math.min(Math.max(nextX, minX), maxX)
+            if (maxY >= minY) nextY = Math.min(Math.max(nextY, minY), maxY)
+        }
+        setDragOffset({ x: nextX, y: nextY })
+    }
+
+    const handleDragEnd = (e: React.PointerEvent<HTMLDivElement>) => {
+        const drag = dragStateRef.current
+        if (!drag || drag.pointerId !== e.pointerId) return
+        try { e.currentTarget.releasePointerCapture(e.pointerId) } catch { /* noop */ }
+        dragStateRef.current = null
+        setIsDragging(false)
+    }
+
+    // Reset drag offset whenever the popover closes so re-opens always anchor
+    // to the column-header button.
+    useEffect(() => {
+        if (!open) setDragOffset({ x: 0, y: 0 })
+    }, [open])
 
     const active = isFilterActive(state)
 
@@ -134,16 +191,38 @@ export const ColumnFilter: React.FC<Props> = ({
             {open && popoverPos && (
                 <div
                     ref={popoverRef}
-                    style={{ top: popoverPos.top, left: popoverPos.left, width: 280 }}
+                    style={{
+                        top: popoverPos.top,
+                        left: popoverPos.left,
+                        width: 280,
+                        transform: `translate(${dragOffset.x}px, ${dragOffset.y}px)`,
+                        touchAction: isDragging ? 'none' : undefined,
+                    }}
                     className="fixed z-[100] bg-white rounded-xl shadow-2xl border border-[#E0E0E0] overflow-hidden text-[#212121]"
                     onClick={(e) => e.stopPropagation()}
                 >
-                    <div className="px-3 py-2 border-b border-[#E0E0E0] flex items-center justify-between">
-                        <span className="text-xs font-semibold uppercase tracking-wide text-[#487749] truncate">
-                            {label}
+                    <div
+                        onPointerDown={handleDragStart}
+                        onPointerMove={handleDragMove}
+                        onPointerUp={handleDragEnd}
+                        onPointerCancel={handleDragEnd}
+                        style={{ touchAction: 'none' }}
+                        className={`px-3 py-2 border-b border-[#E0E0E0] flex items-center justify-between gap-2 select-none ${
+                            isDragging ? 'cursor-grabbing' : 'cursor-grab'
+                        }`}
+                        role="button"
+                        aria-label={`Drag ${label} filter`}
+                        title="Drag to move"
+                    >
+                        <span className="inline-flex items-center gap-1.5 min-w-0">
+                            <GripHorizontal className="w-3.5 h-3.5 text-[#9E9E9E] shrink-0" />
+                            <span className="text-xs font-semibold uppercase tracking-wide text-[#487749] truncate">
+                                {label}
+                            </span>
                         </span>
                         <button
                             type="button"
+                            onPointerDown={(e) => e.stopPropagation()}
                             onClick={() => setOpen(false)}
                             className="p-0.5 rounded hover:bg-gray-100 text-gray-500"
                             aria-label="Close"

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -11,7 +11,6 @@ import {
     ChevronDown,
     RotateCcw,
     FilterX,
-    GripHorizontal,
 } from 'lucide-react'
 import { Breadcrumbs } from '@/components/common/Breadcrumbs'
 import { TabNavigation } from '@/components/common/TabNavigation'
@@ -21,6 +20,7 @@ import {
     applyColumnFilters,
     type ColumnFilters,
 } from '@/components/common/DataTable/columnFilterUtils'
+import { isFilterActive as isColumnFilterActive } from '@/components/common/DataTable/ColumnFilter'
 import { SearchInput } from '@/components/common/SearchInput'
 import { LoadingState } from '@/components/common/LoadingState'
 // import { ErrorState } from '@/components/common/ErrorState'
@@ -216,87 +216,6 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     const mobileRouteMenuRef = useRef<HTMLDivElement | null>(null)
     const exportMenuRef = useRef<HTMLDivElement | null>(null)
     const oftFldTabMenuRef = useRef<HTMLDivElement | null>(null)
-
-    // Draggable filter card position (#168). Lifted state so the card
-    // remembers its last position within the React session. Default {0,0}
-    // keeps the original layout untouched when the user has not dragged.
-    const filterCardRef = useRef<HTMLDivElement | null>(null)
-    const [filterCardPos, setFilterCardPos] = useState<{
-        x: number
-        y: number
-    }>({ x: 0, y: 0 })
-    const filterDragStateRef = useRef<{
-        pointerId: number
-        startX: number
-        startY: number
-        originX: number
-        originY: number
-    } | null>(null)
-    const [isDraggingFilterCard, setIsDraggingFilterCard] = useState(false)
-
-    const handleFilterCardPointerDown = (
-        e: React.PointerEvent<HTMLDivElement>
-    ) => {
-        // Only respond to primary mouse button / touch / pen
-        if (e.button !== 0 && e.pointerType === 'mouse') return
-        const target = e.currentTarget
-        try {
-            target.setPointerCapture(e.pointerId)
-        } catch {
-            /* noop — capture not supported in some envs */
-        }
-        filterDragStateRef.current = {
-            pointerId: e.pointerId,
-            startX: e.clientX,
-            startY: e.clientY,
-            originX: filterCardPos.x,
-            originY: filterCardPos.y,
-        }
-        setIsDraggingFilterCard(true)
-    }
-
-    const handleFilterCardPointerMove = (
-        e: React.PointerEvent<HTMLDivElement>
-    ) => {
-        const drag = filterDragStateRef.current
-        if (!drag || drag.pointerId !== e.pointerId) return
-        const card = filterCardRef.current
-        const dx = e.clientX - drag.startX
-        const dy = e.clientY - drag.startY
-        let nextX = drag.originX + dx
-        let nextY = drag.originY + dy
-        if (card && typeof window !== 'undefined') {
-            const rect = card.getBoundingClientRect()
-            // rect already reflects current transform; recover untransformed
-            // bounds by subtracting current pos, then clamp the *next* pos so
-            // the card stays fully inside the viewport.
-            const baseLeft = rect.left - filterCardPos.x
-            const baseTop = rect.top - filterCardPos.y
-            const minX = -baseLeft
-            const minY = -baseTop
-            const maxX = window.innerWidth - baseLeft - rect.width
-            const maxY = window.innerHeight - baseTop - rect.height
-            if (maxX >= minX) {
-                nextX = Math.min(Math.max(nextX, minX), maxX)
-            }
-            if (maxY >= minY) {
-                nextY = Math.min(Math.max(nextY, minY), maxY)
-            }
-        }
-        setFilterCardPos({ x: nextX, y: nextY })
-    }
-
-    const endFilterCardDrag = (e: React.PointerEvent<HTMLDivElement>) => {
-        const drag = filterDragStateRef.current
-        if (!drag || drag.pointerId !== e.pointerId) return
-        try {
-            e.currentTarget.releasePointerCapture(e.pointerId)
-        } catch {
-            /* noop */
-        }
-        filterDragStateRef.current = null
-        setIsDraggingFilterCard(false)
-    }
 
     // Get entity type from path
     const entityType = getEntityTypeFromPath(location.pathname)
@@ -1743,48 +1662,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                                 </div>
                             </div>
 
-                            <div
-                                ref={filterCardRef}
-                                style={{
-                                    transform: `translate(${filterCardPos.x}px, ${filterCardPos.y}px)`,
-                                    willChange:
-                                        filterCardPos.x !== 0 ||
-                                        filterCardPos.y !== 0
-                                            ? 'transform'
-                                            : undefined,
-                                    touchAction: isDraggingFilterCard
-                                        ? 'none'
-                                        : undefined,
-                                    position: 'relative',
-                                    zIndex: isDraggingFilterCard ? 40 : 'auto',
-                                }}
-                                className={
-                                    filterCardPos.x !== 0 ||
-                                    filterCardPos.y !== 0
-                                        ? 'rounded-xl border border-[#E0E0E0] bg-white shadow-sm'
-                                        : ''
-                                }
-                            >
-                                <div
-                                    onPointerDown={handleFilterCardPointerDown}
-                                    onPointerMove={handleFilterCardPointerMove}
-                                    onPointerUp={endFilterCardDrag}
-                                    onPointerCancel={endFilterCardDrag}
-                                    role="button"
-                                    aria-label="Drag filter card"
-                                    title="Drag to move filters"
-                                    className={`flex items-center justify-between gap-2 px-2 py-1 text-[#757575] select-none ${
-                                        isDraggingFilterCard
-                                            ? 'cursor-grabbing'
-                                            : 'cursor-grab'
-                                    }`}
-                                    style={{ touchAction: 'none' }}
-                                >
-                                    <span className="inline-flex items-center gap-1.5 text-xs font-medium">
-                                        <GripHorizontal className="w-4 h-4" />
-                                        Filters
-                                    </span>
-                                </div>
+                            <div>
                                 <div className="flex flex-col sm:flex-row flex-wrap gap-3 sm:items-center px-2 pb-2">
                                     <div className="w-full sm:w-[280px]">
                                         <SearchInput
@@ -1835,16 +1713,20 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                                                 setDebouncedSearch('')
                                                 setReportingYearFrom('')
                                                 setReportingYearTo('')
+                                                setColumnFilters({})
                                                 setCurrentPage(1)
                                             }}
                                             disabled={
                                                 !debouncedSearch &&
                                                 !searchQuery &&
                                                 !reportingYearFrom &&
-                                                !reportingYearTo
+                                                !reportingYearTo &&
+                                                !Object.values(
+                                                    columnFilters
+                                                ).some(isColumnFilterActive)
                                             }
                                             className="h-11 inline-flex items-center gap-1.5 px-3 rounded-xl text-sm border border-[#487749] text-[#487749] bg-white hover:bg-[#E8F5E9] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-white"
-                                            title="Clear search and date filters"
+                                            title="Clear search, dates, and column filters"
                                         >
                                             <FilterX className="w-4 h-4" />
                                             Reset filters

--- a/frontend/src/pages/dashboard/shared/StatChartPanel.tsx
+++ b/frontend/src/pages/dashboard/shared/StatChartPanel.tsx
@@ -460,7 +460,59 @@ export const StatChartPanel: React.FC<Props> = ({
                     </div>
                 )}
 
-                {view === 'area' && (
+                {view === 'area' && chartData.length < 2 && (
+                    <div className="p-6">
+                        {chartData.length === 0 ? (
+                            <div className="text-center text-[#757575] text-sm py-12">
+                                No data to chart yet.
+                            </div>
+                        ) : (
+                            <div className="rounded-xl border border-[#E0E0E0] bg-[#FAF9F6] p-5">
+                                <div className="text-[10px] font-semibold uppercase tracking-widest text-[#9E9E9E] mb-2">
+                                    Single data point
+                                </div>
+                                <div className="text-base font-bold text-[#212121] mb-3">
+                                    {chartData[0].fullName}
+                                </div>
+                                {showStacked ? (
+                                    <div className="flex flex-wrap gap-3">
+                                        {SEG_KEYS.map((k) => (
+                                            <div
+                                                key={k}
+                                                className="flex items-center gap-2 rounded-lg bg-white border border-[#E0E0E0] px-3 py-1.5"
+                                            >
+                                                <span
+                                                    className="w-2.5 h-2.5 rounded-sm"
+                                                    style={{ backgroundColor: SEG_COLOR[k] }}
+                                                />
+                                                <span className="text-[11px] uppercase tracking-wide text-[#757575]">
+                                                    {SEG_LABEL[k]}
+                                                </span>
+                                                <span className="text-sm font-bold text-[#212121]">
+                                                    {(chartData[0][k] as number).toLocaleString()}
+                                                    {unit ? ` ${unit}` : ''}
+                                                </span>
+                                            </div>
+                                        ))}
+                                    </div>
+                                ) : (
+                                    <div className="flex items-baseline gap-2">
+                                        <span className="text-3xl font-bold text-[#487749]">
+                                            {chartData[0].primary.toLocaleString()}
+                                        </span>
+                                        {unit && (
+                                            <span className="text-sm text-[#757575]">{unit}</span>
+                                        )}
+                                    </div>
+                                )}
+                                <div className="mt-3 text-xs text-[#9E9E9E]">
+                                    Area chart needs at least 2 entries — switch to Bar or List for single rows.
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                )}
+                {view === 'area' && chartData.length >= 2 && (
                     <div className="p-3">
                         {showStacked && (
                             <div className="mb-2 flex justify-end">


### PR DESCRIPTION
## Summary
Three fixes off the back of the prior DMV PR:

1. **Move drag to ColumnFilter popover** (was wrong target): the originally-shipped #168 wrapped the date/search header. The user-facing intent was the per-column filter popover. Strips the wrapper from \`DataManagementView\`. Adds pointer-drag handlers to the popover header in \`ColumnFilter\` with viewport clamping; offset resets on close so reopening anchors under the column header again.
2. **Reset filters now actually clears column filters**: button disabled-check and on-click both consult \`columnFilters\` via \`isFilterActive\`. Previously the button was enabled when only column filters were set but didn't clear them.
3. **Area chart single-row fallback**: \`StatChartPanel\` area view rendered as a single point for kvk_admin. When \`chartData.length < 2\` it now renders a stat panel (centered value or per-segment chips, with a hint to switch to Bar/List) instead of trying to draw an unreadable area.

## Test plan
- Click any column-header filter → drag the popover header → it follows pointer; releases on pointerup; can't escape viewport. Close popover and reopen → it anchors back under the column header.
- Apply only a column filter → "Reset filters" button enables → click clears the column filter (badge goes back to neutral) and disables the button.
- View dashboard charts as kvk_admin → switch to Area → see the single-row stat panel instead of an empty waveform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)