### PR TITLE
fix(reports): correct KVK & super-admin rendering for agri-drone, NF physical, OFT

### DIFF
--- a/backend/repositories/reports/agriDroneReport/agriDroneDemonstrationDetailsReportRepository.js
+++ b/backend/repositories/reports/agriDroneReport/agriDroneDemonstrationDetailsReportRepository.js
@@ -85,6 +85,14 @@ function buildWhere(kvkId, filters = {}) {
     return where;
 }
 
+function payloadLabel(p) {
+    if (!p) return '';
+    const kvk = String(p.kvkName || '').trim();
+    if (!kvk) return '';
+    const loc = String(p.stateName || '').trim();
+    return loc ? `${kvk} — ${loc}` : kvk;
+}
+
 async function getAgriDroneDemonstrationDetailsData(kvkId, filters = {}) {
     const where = buildWhere(kvkId, filters);
     const records = await prisma.kvkAgriDroneDemonstration.findMany({
@@ -92,11 +100,22 @@ async function getAgriDroneDemonstrationDetailsData(kvkId, filters = {}) {
         include: {
             district: { select: { districtName: true } },
             demonstrationsOn: { select: { demonstrationsOnName: true } },
+            kvk: {
+                select: {
+                    kvkName: true,
+                    state: { select: { stateName: true } },
+                },
+            },
         },
         orderBy: [{ dateOfDemonstration: 'desc' }, { agriDroneDemonstrationId: 'desc' }],
     });
     const rows = records.map(mapDemonstrationRecord).filter(Boolean);
-    return { rows };
+    const first = records[0];
+    return {
+        kvkName: first?.kvk?.kvkName || '',
+        stateName: first?.kvk?.state?.stateName || '',
+        rows,
+    };
 }
 
 /**
@@ -108,20 +127,38 @@ function resolveAgriDroneDemonstrationDetailsPayload(data) {
     if (d && typeof d === 'object' && !Array.isArray(d) && d.data) {
         d = d.data;
     }
-    if (d && typeof d === 'object' && !Array.isArray(d) && Array.isArray(d.rows)) {
-        const first = d.rows[0];
-        if (first && typeof first.grandM === 'number') {
-            return { rows: d.rows };
-        }
-        return { rows: d.rows.map((r) => mapDemonstrationRecord(r)).filter(Boolean) };
-    }
     const list = Array.isArray(d) ? d : [d];
-    const rows = [];
+
+    // One block per KVK so super-admin aggregated output can be labelled.
+    const blocks = [];
     for (const item of list) {
         if (!item || typeof item !== 'object') continue;
+
+        if (Array.isArray(item.rows)) {
+            // Already-built per-KVK payload. Skip empty ones so KVKs without
+            // demonstrations don't render a phantom empty block.
+            const mapped = item.rows
+                .map((r) => (r && typeof r.grandM === 'number') ? r : mapDemonstrationRecord(r))
+                .filter(Boolean);
+            if (mapped.length === 0) continue;
+            blocks.push({ label: payloadLabel(item), rows: mapped });
+            continue;
+        }
+
         const row = mapDemonstrationRecord(item);
-        if (row) rows.push(row);
+        if (row) blocks.push({ label: '', rows: [row] });
     }
+
+    if (blocks.length === 0) return { rows: [] };
+    // Single KVK: keep the original look (no per-block header).
+    if (blocks.length === 1) return { rows: blocks[0].rows };
+
+    const rows = [];
+    blocks.forEach((b, i) => {
+        if (i > 0) rows.push({ _spacer: true });
+        if (b.label) rows.push({ _header: true, label: b.label });
+        rows.push(...b.rows);
+    });
     return { rows };
 }
 

--- a/backend/repositories/reports/agriDroneReport/agriDroneIntroductionReportRepository.js
+++ b/backend/repositories/reports/agriDroneReport/agriDroneIntroductionReportRepository.js
@@ -136,6 +136,21 @@ function isPayloadWithRows(d) {
 }
 
 /**
+ * Build a "KVK — District, State" label so super-admin aggregated reports show
+ * which KVK each block belongs to. Returns '' when no KVK identity is present.
+ */
+function payloadLabel(p) {
+    if (!p) return '';
+    const kvk = String(p.kvkName || '').trim();
+    if (!kvk) return '';
+    const loc = [p.districtName, p.stateName]
+        .map(s => String(s || '').trim())
+        .filter(Boolean)
+        .join(', ');
+    return loc ? `${kvk} — ${loc}` : kvk;
+}
+
+/**
  * Normalize report/export input into { rows: [{ sNo, parameterName, details }] }.
  */
 function resolveAgriDroneIntroductionPayload(data) {
@@ -144,30 +159,52 @@ function resolveAgriDroneIntroductionPayload(data) {
     if (d && typeof d === 'object' && !Array.isArray(d) && d.data && isPayloadWithRows(d.data)) {
         d = d.data;
     }
-    if (isPayloadWithRows(d)) {
-        return d;
-    }
     const list = Array.isArray(d) ? d : [d];
-    const allRows = [];
+
+    // Collect one block per KVK. Each block keeps its own label so super-admin
+    // aggregated output can show which KVK the data is from.
+    const blocks = [];
     for (const item of list) {
         if (!item || typeof item !== 'object') continue;
-        const intro = item;
+
+        if (Array.isArray(item.rows)) {
+            // Already-built per-KVK payload (e.g. { kvkName, rows: [...] }).
+            // Skip empty payloads so KVKs without data don't render a phantom
+            // block of all '—'/0 rows.
+            if (item.rows.length === 0) continue;
+            if (item.rows[0] && typeof item.rows[0].parameterName === 'string') {
+                blocks.push({ label: payloadLabel(item), rows: item.rows });
+                continue;
+            }
+        }
+
+        // Raw intro record → build the 14 parameter rows.
         const demoAgg = {
             areaSum: item._demoAreaSum ?? item.areaSum,
             farmersSum: item._demoFarmersSum ?? item.farmersSum,
         };
-        const rows = buildParameterRows(intro, demoAgg);
+        const rows = buildParameterRows(item, demoAgg);
         if (rows.length === 0) continue;
-        if (allRows.length > 0) {
-            allRows.push({
-                sNo: '',
-                parameterName: '',
-                details: '',
-                _spacer: true,
-            });
-        }
-        allRows.push(...rows);
+        blocks.push({
+            label: payloadLabel({
+                kvkName: item.kvk?.kvkName,
+                stateName: item.kvk?.state?.stateName,
+                districtName: item.kvk?.district?.districtName,
+            }),
+            rows,
+        });
     }
+
+    if (blocks.length === 0) return { rows: [] };
+    // Single KVK: keep the original look (no per-block header).
+    if (blocks.length === 1) return { rows: blocks[0].rows };
+
+    const allRows = [];
+    blocks.forEach((b, i) => {
+        if (i > 0) allRows.push({ sNo: '', parameterName: '', details: '', _spacer: true });
+        if (b.label) allRows.push({ _header: true, label: b.label });
+        allRows.push(...b.rows);
+    });
     return { rows: allRows };
 }
 
@@ -185,16 +222,42 @@ async function sumDemonstrationsForIntro(agriDroneId, kvkId, filters) {
 
 async function getAgriDroneIntroductionData(kvkId, filters = {}) {
     const where = buildIntroWhere(kvkId, filters);
-    const intro = await prisma.kvkAgriDrone.findFirst({
+    // A KVK may have more than one Agri-Drone intro (one per project
+    // implementing centre / PIC). Return them all, stacked, instead of just the
+    // first — otherwise the report drops every PIC after the first.
+    const intros = await prisma.kvkAgriDrone.findMany({
         where,
+        include: {
+            kvk: {
+                select: {
+                    kvkName: true,
+                    state: { select: { stateName: true } },
+                    district: { select: { districtName: true } },
+                },
+            },
+        },
         orderBy: [{ reportingYear: 'desc' }, { agriDroneId: 'desc' }],
     });
-    if (!intro) {
+    if (intros.length === 0) {
         return { rows: [] };
     }
-    const demoAgg = await sumDemonstrationsForIntro(intro.agriDroneId, intro.kvkId, filters);
-    const rows = buildParameterRows(intro, demoAgg);
-    return { rows };
+
+    const rows = [];
+    for (let i = 0; i < intros.length; i++) {
+        const intro = intros[i];
+        const demoAgg = await sumDemonstrationsForIntro(intro.agriDroneId, intro.kvkId, filters);
+        const introRows = buildParameterRows(intro, demoAgg);
+        if (i > 0) rows.push({ sNo: '', parameterName: '', details: '', _spacer: true });
+        rows.push(...introRows);
+    }
+
+    const first = intros[0];
+    return {
+        kvkName: first.kvk?.kvkName || '',
+        stateName: first.kvk?.state?.stateName || '',
+        districtName: first.kvk?.district?.districtName || '',
+        rows,
+    };
 }
 
 /**

--- a/backend/repositories/reports/cfldReport/cfldReportRepository.js
+++ b/backend/repositories/reports/cfldReport/cfldReportRepository.js
@@ -93,6 +93,9 @@ function mapCfldRecord(record) {
         stF: record.stF ?? 0,
         trainingPhotoPath: record.trainingPhotoPath || null,
         qualityActionPhotoPath: record.qualityActionPhotoPath || null,
+        // Populated by attachCfldTargets() from the `targets` table.
+        targetAreaHa: 0,
+        targetDemonstrations: 0,
         economic: {
             existingPlotGrossCost: economic.existingPlotGrossCost ?? null,
             existingPlotGrossReturn: economic.existingPlotGrossReturn ?? null,
@@ -125,6 +128,64 @@ function mapCfldRecord(record) {
     };
 }
 
+const CFLD_TARGET_TYPES = ['CFLD Pulses', 'CFLD Oilseed'];
+
+function normKey(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+// CFLD targets are stored with typeName "CFLD Pulses"/"CFLD Oilseed", while the
+// CropType master uses "Pulses"/"Oilseed". Map a crop-type name to its target type.
+function targetTypeForCropType(cropTypeName) {
+    const t = normKey(cropTypeName);
+    if (t.includes('pulse')) return 'CFLD Pulses';
+    if (t.includes('oilseed') || t.includes('oil seed')) return 'CFLD Oilseed';
+    return null;
+}
+
+/**
+ * Attach CFLD approved-target values (area + no. of demonstrations) onto mapped
+ * technical records by matching the `targets` table on kvk + type + season + crop.
+ * A target is attributed to only the first matching record per key so the
+ * template's per-record summation does not inflate the totals.
+ */
+async function attachCfldTargets(records, filters = {}) {
+    if (!records.length) return;
+    const kvkIds = [...new Set(records.map(r => r.kvkId).filter(Boolean))];
+    if (!kvkIds.length) return;
+
+    const where = { kvkId: { in: kvkIds }, typeName: { in: CFLD_TARGET_TYPES } };
+    const year = Number(filters.year);
+    if (Number.isFinite(year)) where.reportingYear = year;
+
+    const targets = await prisma.target.findMany({ where });
+
+    const targetMap = new Map();
+    for (const t of targets) {
+        const key = [t.kvkId, normKey(t.typeName), normKey(t.season), normKey(t.cropName)].join('|');
+        if (!targetMap.has(key)) {
+            targetMap.set(key, {
+                areaTarget: Number(t.areaTarget || 0),
+                target: Number(t.target || 0),
+            });
+        }
+    }
+
+    const seen = new Set();
+    for (const r of records) {
+        const typeName = targetTypeForCropType(r.cropTypeName);
+        if (!typeName) continue;
+        const key = [r.kvkId, normKey(typeName), normKey(r.seasonName), normKey(r.cropName)].join('|');
+        if (seen.has(key)) continue; // count each target once across duplicate demo rows
+        const t = targetMap.get(key);
+        if (t) {
+            r.targetAreaHa = t.areaTarget;
+            r.targetDemonstrations = t.target;
+            seen.add(key);
+        }
+    }
+}
+
 async function getCfldCombinedData(kvkId, filters = {}) {
     const where = buildWhere(kvkId, filters);
     const records = await prisma.cfldTechnicalParameter.findMany({
@@ -147,7 +208,9 @@ async function getCfldCombinedData(kvkId, filters = {}) {
         orderBy: [{ typeId: 'asc' }, { seasonId: 'asc' }, { cropId: 'asc' }],
     });
 
-    return records.map(mapCfldRecord);
+    const mapped = records.map(mapCfldRecord);
+    await attachCfldTargets(mapped, filters);
+    return mapped;
 }
 
 async function getCfldExtensionActivityData(kvkId, filters = {}) {

--- a/backend/repositories/reports/nariReport/nariBioFortifiedReportRepository.js
+++ b/backend/repositories/reports/nariReport/nariBioFortifiedReportRepository.js
@@ -94,6 +94,17 @@ function mapRecord(record) {
 
         // ── reporting year ────────────────────────────────────────────────
         reportingYear: record.reportingYear || null,
+
+        // ── consumption pattern rows (sub-table 2) ─────────────────────────
+        results: (record.results || []).map(res => ({
+            cropName: res.cropName || '',
+            variety: res.variety || '',
+            areaHa: Number(res.areaHa || 0),
+            productionKg: Number(res.productionKg || 0),
+            consumptionGm: Number(res.consumptionGm || 0),
+            formOfConsumption: res.formOfConsumption || '',
+            daysInYear: Number(res.daysInYear || 0),
+        })),
     };
 }
 
@@ -119,6 +130,7 @@ async function getNariBioFortifiedData(kvkId, filters = {}) {
             season: { select: { seasonName: true } },
             activity: { select: { activityName: true } },
             cropCategory: { select: { name: true } },
+            results: true,
         },
         orderBy: [
             { reportingYear: 'asc' },

--- a/backend/repositories/reports/naturalFarmingReport/physicalInfoReportRepository.js
+++ b/backend/repositories/reports/naturalFarmingReport/physicalInfoReportRepository.js
@@ -75,7 +75,10 @@ async function getNaturalFarmingPhysicalInfoData(kvkId, filters = {}) {
 			remarks: r.remarks || '',
 			innovativeProgrammeName: r.innovativeProgrammeName || '',
 			significanceOfInnovativeProgramme: r.significanceOfInnovativeProgramme || '',
-			isOtherActivity: !r.trainingTitle && !r.trainingDate && !r.venue, // per repository semantics
+			// Match the write path (naturalFarmingRepository): "other activity" is
+			// determined by the activity name, NOT by absent training fields — otherwise
+			// a normal activity saved without title/date/venue is wrongly bucketed here.
+			isOtherActivity: String(r.activityMaster?.activityName || '').trim().toLowerCase() === 'other activity',
 		};
 		const totals = computeRowTotals(r);
 		return { ...base, ...totals };

--- a/backend/services/forms/nariBioFortifiedCropService.js
+++ b/backend/services/forms/nariBioFortifiedCropService.js
@@ -44,11 +44,23 @@ const nariBioFortifiedCropService = {
     },
 
     createResult: async (id, data) => {
-        return await nariBioFortifiedCropRepository.createResult(id, data);
+        const result = await nariBioFortifiedCropRepository.createResult(id, data);
+        const parent = await nariBioFortifiedCropRepository.findById(id);
+        await reportCacheInvalidationService.invalidateDataSourceForKvk(
+            'nariBioFortified',
+            parent?.kvkId,
+        );
+        return result;
     },
 
     updateResult: async (id, data) => {
-        return await nariBioFortifiedCropRepository.updateResult(id, data);
+        const result = await nariBioFortifiedCropRepository.updateResult(id, data);
+        const parent = await nariBioFortifiedCropRepository.findById(id);
+        await reportCacheInvalidationService.invalidateDataSourceForKvk(
+            'nariBioFortified',
+            parent?.kvkId,
+        );
+        return result;
     }
 };
 

--- a/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
@@ -1,20 +1,23 @@
 /**
- * OFT Summary Template (Section 2.2)
+ * OFT Summary Template (Section 2.1)
  *
- * Renders two labeled sub-blocks from the same sector/thematic aggregation:
- *   A. OFT Summary          — sector/thematic rows, totals across all states.
- *   B. State Wise OFT Details — same rows, broken down per state (one column
- *                               group per state) + a Total group.
+ * Renders the OFT Summary table grouped by sectors (OftSubject) and
+ * their thematic areas (OftThematicArea), ALL from the database.
+ * Shows every thematic area even when it has 0 data.
  *
- * Data shape accepted:
- *   - { records, subjects }                (single-KVK)
- *   - [ { records, subjects }, ... ]       (aggregated: one chunk per KVK)
- *   - [ ...oftRows ]                       (plain rows)
+ * Data shape expected:
+ *   { records: [...OFT rows], subjects: [...OftSubject with thematicAreas] }
+ *
+ * Single-KVK:  3 value columns, heading "2.1. OFT Summary"
+ * Multi-state:  per-state columns + total, full heading hierarchy
  *
  * Bound to reportTemplateService (`this`).
  */
 
 // ── Sector label mapping by subject name keyword ────────────────────
+// Maps OftSubject names to sector labels + keys used in the original report.
+// If a subject doesn't match any keyword, it gets its own section.
+
 const SECTOR_MAP = [
     { key: 'A', keyword: /crop\s*production/i, prefix: 'A) Technologies Assessed under Various Crops by KVKs (Crop Production)' },
     { key: 'B', keyword: /livestock|animal|fisheries|poultry|veterinary/i, prefix: 'B) Technologies Assessed under Livestock and Fisheries by KVKs' },
@@ -34,10 +37,12 @@ function classifySubject(subjectName) {
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
-/** Distinct state names across records ("Unknown" when a record has no state). */
 function getUniqueStates(records) {
     const set = new Set();
-    for (const r of records) set.add(r.kvk?.state?.stateName || 'Unknown');
+    for (const r of records) {
+        const name = r.kvk?.state?.stateName;
+        if (name) set.add(name);
+    }
     return Array.from(set).sort();
 }
 
@@ -56,152 +61,66 @@ function sumBuckets(stateMap, stateKeys) {
     return total;
 }
 
-/** Build: subjectId -> thematicAreaName -> stateKey -> {techs, locations, trials}. */
-function buildAggregation(records) {
-    const agg = new Map();
+/**
+ * Build: subjectId -> thematicAreaName -> stateKey -> {techs, locations, trials}
+ */
+function buildAggregation(records, isMultiState) {
+    const agg = new Map(); // subjectId -> Map<thematicAreaName, Map<stateKey, bucket>>
+
     for (const r of records) {
         const subjectId = r.oftSubjectId || 0;
         const thematicArea = r.oftThematicArea?.thematicAreaName || 'Other';
-        const stateKey = r.kvk?.state?.stateName || 'Unknown';
+        const stateKey = isMultiState ? (r.kvk?.state?.stateName || 'Unknown') : '__all__';
 
         if (!agg.has(subjectId)) agg.set(subjectId, new Map());
         const thematicMap = agg.get(subjectId);
+
         if (!thematicMap.has(thematicArea)) thematicMap.set(thematicArea, new Map());
         const stateMap = thematicMap.get(thematicArea);
-        if (!stateMap.has(stateKey)) stateMap.set(stateKey, { techs: 0, locations: 0, trials: 0 });
 
+        if (!stateMap.has(stateKey)) stateMap.set(stateKey, { techs: 0, locations: 0, trials: 0 });
         const bucket = stateMap.get(stateKey);
         bucket.techs += 1;
         bucket.locations += Number(r.numberOfLocation) || 0;
         bucket.trials += Number(r.numberOfTrialReplication) || 0;
     }
+
     return agg;
 }
 
-/** Value cells for one thematic row. perState=false → single Total set. */
-function renderValueCells(perState, states, stateMap) {
+function renderValueCells(isMultiState, stateKeys, stateMap) {
     let html = '';
-    if (perState) {
-        for (const st of states) {
+    if (isMultiState) {
+        for (const st of stateKeys) {
             const b = getBucket(stateMap, st);
-            html += `<td style="text-align:center;">${b.techs}</td><td style="text-align:center;">${b.locations}</td><td style="text-align:center;">${b.trials}</td>`;
+            html += `<td style="text-align:center;">${b.techs}</td>
+                <td style="text-align:center;">${b.locations}</td>
+                <td style="text-align:center;">${b.trials}</td>`;
         }
+        const total = sumBuckets(stateMap, stateKeys);
+        html += `<td style="text-align:center;">${total.techs}</td>
+                <td style="text-align:center;">${total.locations}</td>
+                <td style="text-align:center;">${total.trials}</td>`;
+    } else {
+        const total = sumBuckets(stateMap, stateKeys);
+        html += `<td style="text-align:center;">${total.techs}</td>
+                <td style="text-align:center;">${total.locations}</td>
+                <td style="text-align:center;">${total.trials}</td>`;
     }
-    const total = sumBuckets(stateMap, states);
-    html += `<td style="text-align:center;">${total.techs}</td><td style="text-align:center;">${total.locations}</td><td style="text-align:center;">${total.trials}</td>`;
     return html;
 }
 
-function addBucket(target, b) {
-    target.techs += b.techs;
-    target.locations += b.locations;
-    target.trials += b.trials;
-}
-
-// ── Sector/thematic table (used for both A summary and B state-wise) ──
-function renderSectorTable(ctx, { agg, sectorList, states, perState }) {
-    const esc = (v) => ctx._escapeHtml(v);
-    const valueGroups = perState ? states.length + 1 : 1; // per-state groups + Total, or just Total
-    const colCount = 1 + valueGroups * 3;
-    // The per-state table gets very wide (states x 3). Force it to the page
-    // width (table-layout:fixed) and scale the font down as columns grow so the
-    // right-most border always stays inside the page.
-    const tableClass = perState ? 'data-table oft-statewise' : 'data-table';
-    let tableStyle = '';
-    if (perState) {
-        const groups = states.length + 1; // per-state + Total
-        const fs = groups <= 3 ? 7.5 : groups <= 5 ? 6 : groups <= 7 ? 5 : groups <= 9 ? 4.3 : 3.8;
-        tableStyle = ` style="font-size:${fs}pt;"`;
-    }
-
-    let head = '';
-    if (perState) {
-        head += `<tr><th rowspan="2" style="vertical-align:bottom;">Sector wise Thematic Area</th>`;
-        for (const st of states) head += `<th colspan="3" style="text-align:center;">${esc(st)}</th>`;
-        head += `<th colspan="3" style="text-align:center;">Total</th></tr><tr>`;
-        for (let i = 0; i <= states.length; i++) {
-            head += `<th style="text-align:center;">No. of technologies assessed</th><th style="text-align:center;">No. of Locations</th><th style="text-align:center;">No. of trials</th>`;
-        }
-        head += `</tr>`;
-    } else {
-        head += `<tr><th>Sector wise Thematic Area</th><th style="text-align:center;">No. of technologies assessed</th><th style="text-align:center;">No. of Locations</th><th style="text-align:center;">No. of Trial/Replications</th></tr>`;
-    }
-
-    let body = '';
-    // Grand totals (per state + overall)
-    const grandByState = {};
-    for (const st of states) grandByState[st] = { techs: 0, locations: 0, trials: 0 };
-    const grandTotal = { techs: 0, locations: 0, trials: 0 };
-
-    for (const sector of sectorList) {
-        const thematicMap = agg.get(sector.subjectId) || new Map();
-
-        body += `<tr style="background:#f0f0f0;"><td colspan="${colCount}" style="font-weight:bold;padding:6px 8px;">${esc(sector.label)}</td></tr>`;
-
-        const sectorByState = {};
-        for (const st of states) sectorByState[st] = { techs: 0, locations: 0, trials: 0 };
-        const sectorTotal = { techs: 0, locations: 0, trials: 0 };
-
-        const renderRow = (areaName, stateMap) => {
-            body += `<tr><td>${esc(areaName)}</td>${renderValueCells(perState, states, stateMap)}</tr>`;
-            for (const st of states) addBucket(sectorByState[st], getBucket(stateMap, st));
-            addBucket(sectorTotal, sumBuckets(stateMap, states));
-        };
-
-        const renderedAreas = new Set();
-        for (const areaName of sector.thematicAreas) {
-            renderedAreas.add(areaName);
-            renderRow(areaName, thematicMap.get(areaName) || new Map());
-        }
-        // Extra thematic areas present in data but not in the master list.
-        for (const [areaName, stateMap] of thematicMap) {
-            if (!renderedAreas.has(areaName)) renderRow(areaName, stateMap);
-        }
-
-        // Sub Total
-        const subLabel = perState ? `Sub Total (${sector.key})` : 'Sub Total';
-        body += `<tr style="font-weight:bold;"><td>${subLabel}</td>`;
-        if (perState) {
-            for (const st of states) {
-                body += `<td style="text-align:center;">${sectorByState[st].techs}</td><td style="text-align:center;">${sectorByState[st].locations}</td><td style="text-align:center;">${sectorByState[st].trials}</td>`;
-                addBucket(grandByState[st], sectorByState[st]);
-            }
-        }
-        body += `<td style="text-align:center;">${sectorTotal.techs}</td><td style="text-align:center;">${sectorTotal.locations}</td><td style="text-align:center;">${sectorTotal.trials}</td></tr>`;
-        addBucket(grandTotal, sectorTotal);
-    }
-
-    // Grand Total
-    body += `<tr style="font-weight:bold;"><td>Grand Total</td>`;
-    if (perState) {
-        for (const st of states) {
-            body += `<td style="text-align:center;">${grandByState[st].techs}</td><td style="text-align:center;">${grandByState[st].locations}</td><td style="text-align:center;">${grandByState[st].trials}</td>`;
-        }
-    }
-    body += `<td style="text-align:center;">${grandTotal.techs}</td><td style="text-align:center;">${grandTotal.locations}</td><td style="text-align:center;">${grandTotal.trials}</td></tr>`;
-
-    return `<table class="${tableClass}"${tableStyle}><thead>${head}</thead><tbody>${body}</tbody></table>`;
-}
-
 // ── Main render function ────────────────────────────────────────────
+
 function renderOftSummarySection(section, data, sectionId, isFirstSection) {
-    // Accept single, aggregated-chunks, or plain-rows shapes.
-    let records = [];
-    let subjects = [];
-    if (Array.isArray(data)) {
-        if (data.some(d => d && (d.records || d.subjects))) {
-            for (const chunk of data) {
-                if (Array.isArray(chunk?.records)) records.push(...chunk.records);
-                if (subjects.length === 0 && Array.isArray(chunk?.subjects)) subjects = chunk.subjects;
-            }
-        } else {
-            records = data;
-        }
-    } else if (data && Array.isArray(data.records)) {
+    // data can be { records, subjects } from data service, or plain array from combined template
+    let records, subjects;
+    if (data && !Array.isArray(data) && data.records) {
         records = data.records;
         subjects = data.subjects || [];
-    } else if (data) {
-        records = [data];
+    } else {
+        records = Array.isArray(data) ? data : (data ? [data] : []);
+        subjects = [];
     }
 
     if (records.length === 0 && subjects.length === 0) {
@@ -213,30 +132,41 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
         : 'section-page section-page-continued';
 
     const states = getUniqueStates(records);
-    const agg = buildAggregation(records);
+    const isMultiState = states.length > 1;
+    const stateKeys = isMultiState ? states : ['__all__'];
+
+    const agg = buildAggregation(records, isMultiState);
+    const colCount = isMultiState ? 1 + (states.length * 3) + 3 : 4;
 
     // ── Build ordered sector list from DB subjects ──────────────
     const sectorList = [];
+    const usedSubjectIds = new Set();
+
+    // First pass: map DB subjects to known sectors
     for (const subject of subjects) {
         const mapped = classifySubject(subject.subjectName);
         const sectorKey = mapped ? mapped.key : subject.subjectName.charAt(0).toUpperCase();
         const sectorLabel = mapped ? mapped.prefix : `${sectorKey}) ${subject.subjectName}`;
+
         sectorList.push({
             key: sectorKey,
             label: sectorLabel,
             subjectId: subject.oftSubjectId,
             thematicAreas: (subject.thematicAreas || []).map(ta => ta.thematicAreaName),
         });
+        usedSubjectIds.add(subject.oftSubjectId);
     }
-    // Fallback: derive sectors from the records when no DB subjects supplied.
+
+    // If no subjects from DB, fall back to data-driven sectors
     if (sectorList.length === 0) {
-        const seen = new Map();
+        // Group by subject from the records themselves
+        const seenSubjects = new Map();
         for (const r of records) {
             const sid = r.oftSubjectId || 0;
-            if (!seen.has(sid)) {
+            if (!seenSubjects.has(sid)) {
                 const name = r.oftSubject?.subjectName || 'Unknown';
                 const mapped = classifySubject(name);
-                seen.set(sid, {
+                seenSubjects.set(sid, {
                     key: mapped ? mapped.key : '?',
                     label: mapped ? mapped.prefix : name,
                     subjectId: sid,
@@ -244,19 +174,268 @@ function renderOftSummarySection(section, data, sectionId, isFirstSection) {
                 });
             }
         }
-        sectorList.push(...seen.values());
+        sectorList.push(...seenSubjects.values());
     }
-    // Order sectors by key (A, B, C, D, E …); DB subjects sort by name otherwise.
-    sectorList.sort((a, b) => String(a.key).localeCompare(String(b.key)));
+
+
+    // ── Headings ────────────────────────────────────────────────
+    let html = `
+<div id="${sectionId}" class="${pageClass}">`;
+
+    // Section heading = group (e.g. "2.2 On Farm Trial"). Like the FLD report,
+    // this single section renders two labeled sub-blocks: A. OFT Summary and
+    // B. State Wise OFT Details (KVK Wise OFT Details is its own section).
+    html += `
+    <h1 class="section-title" style="margin-bottom:8px;">${section.id} ${this._escapeHtml(section.title)}</h1>
+    <h2 class="section-subtitle">${section.id}.A OFT Summary</h2>`;
+    if (isMultiState) {
+        html += `
+    <p style="font-size:11px;font-weight:bold;margin-bottom:12px;">Technology Assessed by KVK (Discipline wise)</p>`;
+    }
+
+    // ── Table header ────────────────────────────────────────────
+    html += `
+    <table class="data-table">
+        <thead>`;
+
+    if (isMultiState) {
+        html += `
+            <tr>
+                <th colspan="${colCount}" style="text-align:left;font-weight:bold;font-size:9pt;padding:8px;">
+                    2.1. State wise details of On Farm Trials (OFTs) conducted by KVKs
+                </th>
+            </tr>
+            <tr>
+                <th rowspan="2" style="vertical-align:bottom;">Sector wise Thematic Area</th>`;
+        for (const st of states) {
+            html += `<th colspan="3" style="text-align:center;">${this._escapeHtml(st)}</th>`;
+        }
+        html += `<th colspan="3" style="text-align:center;">Total</th></tr>
+            <tr>`;
+        for (let i = 0; i <= states.length; i++) {
+            html += `
+                <th style="text-align:center;">No. of technologies assessed</th>
+                <th style="text-align:center;">No. of Locations</th>
+                <th style="text-align:center;">No. of Trial/Replications</th>`;
+        }
+        html += `</tr>`;
+    } else {
+        html += `
+            <tr>
+                <th>Sector wise Thematic Area</th>
+                <th style="text-align:center;">No. of technologies assessed</th>
+                <th style="text-align:center;">No. of Locations</th>
+                <th style="text-align:center;">No. of Trial/Replications</th>
+            </tr>`;
+    }
+
+    html += `
+        </thead>
+        <tbody>`;
+
+    // ── Body ────────────────────────────────────────────────────
+    const grandTotal = { techs: 0, locations: 0, trials: 0 };
+    const grandTotalByState = {};
+    for (const st of stateKeys) grandTotalByState[st] = { techs: 0, locations: 0, trials: 0 };
+
+    for (const sector of sectorList) {
+        const thematicMap = agg.get(sector.subjectId) || new Map();
+
+        // Sector header row
+        html += `
+            <tr style="background:#f0f0f0;">
+                <td colspan="${colCount}" style="font-weight:bold;padding:6px 8px;">
+                    ${this._escapeHtml(sector.label)}
+                </td>
+            </tr>`;
+
+        const sectorTotal = { techs: 0, locations: 0, trials: 0 };
+        const sectorTotalByState = {};
+        for (const st of stateKeys) sectorTotalByState[st] = { techs: 0, locations: 0, trials: 0 };
+
+        // Render ALL thematic areas from DB (with 0 defaults)
+        const renderedAreas = new Set();
+
+        for (const areaName of sector.thematicAreas) {
+            renderedAreas.add(areaName);
+            const stateMap = thematicMap.get(areaName) || new Map();
+            const rowTotal = sumBuckets(stateMap, stateKeys);
+
+            html += `
+            <tr>
+                <td>${this._escapeHtml(areaName)}</td>`;
+            const cellsData = renderValueCells(isMultiState, stateKeys, stateMap)
+            html += cellsData
+            html += `</tr>`;
+
+            if (isMultiState) {
+                for (const st of stateKeys) {
+                    const b = getBucket(stateMap, st);
+                    sectorTotalByState[st].techs += b.techs;
+                    sectorTotalByState[st].locations += b.locations;
+                    sectorTotalByState[st].trials += b.trials;
+                }
+            }
+            sectorTotal.techs += rowTotal.techs;
+            sectorTotal.locations += rowTotal.locations;
+            sectorTotal.trials += rowTotal.trials;
+        }
+
+        // Any extra areas from data not in the DB master list
+        for (const [areaName, stateMap] of thematicMap) {
+            if (renderedAreas.has(areaName)) continue;
+            const rowTotal = sumBuckets(stateMap, stateKeys);
+
+            html += `
+            <tr>
+                <td>${this._escapeHtml(areaName)}</td>`;
+            html += renderValueCells(isMultiState, stateKeys, stateMap);
+            html += `</tr>`;
+
+            if (isMultiState) {
+                for (const st of stateKeys) {
+                    const b = getBucket(stateMap, st);
+                    sectorTotalByState[st].techs += b.techs;
+                    sectorTotalByState[st].locations += b.locations;
+                    sectorTotalByState[st].trials += b.trials;
+                }
+            }
+            sectorTotal.techs += rowTotal.techs;
+            sectorTotal.locations += rowTotal.locations;
+            sectorTotal.trials += rowTotal.trials;
+        }
+
+        // Sub Total
+        const subLabel = isMultiState ? `Sub Total (${sector.key})` : 'Sub Total';
+        html += `
+            <tr style="font-weight:bold;">
+                <td>${subLabel}</td>`;
+        if (isMultiState) {
+            for (const st of stateKeys) {
+                html += `<td style="text-align:center;">${sectorTotalByState[st].techs}</td>
+                <td style="text-align:center;">${sectorTotalByState[st].locations}</td>
+                <td style="text-align:center;">${sectorTotalByState[st].trials}</td>`;
+                grandTotalByState[st].techs += sectorTotalByState[st].techs;
+                grandTotalByState[st].locations += sectorTotalByState[st].locations;
+                grandTotalByState[st].trials += sectorTotalByState[st].trials;
+            }
+            html += `<td style="text-align:center;">${sectorTotal.techs}</td>
+                <td style="text-align:center;">${sectorTotal.locations}</td>
+                <td style="text-align:center;">${sectorTotal.trials}</td>`;
+        } else {
+            html += `<td style="text-align:center;">${sectorTotal.techs}</td>
+                <td style="text-align:center;">${sectorTotal.locations}</td>
+                <td style="text-align:center;">${sectorTotal.trials}</td>`;
+        }
+        html += `</tr>`;
+
+        grandTotal.techs += sectorTotal.techs;
+        grandTotal.locations += sectorTotal.locations;
+        grandTotal.trials += sectorTotal.trials;
+    }
+
+    // Grand Total
+    const grandLabel = isMultiState ? 'Grand Total (F)' : 'Grand Total';
+    html += `
+            <tr style="font-weight:bold;">
+                <td>${grandLabel}</td>`;
+    if (isMultiState) {
+        for (const st of stateKeys) {
+            html += `<td style="text-align:center;">${grandTotalByState[st].techs}</td>
+                <td style="text-align:center;">${grandTotalByState[st].locations}</td>
+                <td style="text-align:center;">${grandTotalByState[st].trials}</td>`;
+        }
+        html += `<td style="text-align:center;">${grandTotal.techs}</td>
+                <td style="text-align:center;">${grandTotal.locations}</td>
+                <td style="text-align:center;">${grandTotal.trials}</td>`;
+    } else {
+        html += `<td style="text-align:center;">${grandTotal.techs}</td>
+                <td style="text-align:center;">${grandTotal.locations}</td>
+                <td style="text-align:center;">${grandTotal.trials}</td>`;
+    }
+    html += `</tr>
+        </tbody>
+    </table>`;
+
+    // ── B. State Wise OFT Details ───────────────────────────────
+    html += renderStateWiseBlock.call(this, section, records);
+
+    html += `
+</div>`;
+
+    return html;
+}
+
+/**
+ * "B. State Wise OFT Details" — per-state farmer participation broken down by
+ * category and gender (mirrors the FLD state-wise table). Always rendered, even
+ * for a single state.
+ */
+const FARMER_KEYS = ['genM', 'genF', 'obcM', 'obcF', 'scM', 'scF', 'stM', 'stF'];
+
+function renderStateWiseBlock(section, records) {
+    const byState = new Map();
+    for (const r of records) {
+        const stateName = r.kvk?.state?.stateName || r.kvk?.kvkName || 'Unknown';
+        if (!byState.has(stateName)) {
+            byState.set(stateName, { genM: 0, genF: 0, obcM: 0, obcF: 0, scM: 0, scF: 0, stM: 0, stF: 0 });
+        }
+        const b = byState.get(stateName);
+        b.genM += Number(r.farmersGeneralM) || 0;
+        b.genF += Number(r.farmersGeneralF) || 0;
+        b.obcM += Number(r.farmersObcM) || 0;
+        b.obcF += Number(r.farmersObcF) || 0;
+        b.scM += Number(r.farmersScM) || 0;
+        b.scF += Number(r.farmersScF) || 0;
+        b.stM += Number(r.farmersStM) || 0;
+        b.stF += Number(r.farmersStF) || 0;
+    }
+
+    const sumRow = (b) => FARMER_KEYS.reduce((acc, k) => acc + b[k], 0);
+    const total = { genM: 0, genF: 0, obcM: 0, obcF: 0, scM: 0, scF: 0, stM: 0, stF: 0 };
+    let rows = '';
+    for (const [stateName, b] of byState) {
+        for (const k of FARMER_KEYS) total[k] += b[k];
+        rows += `
+            <tr>
+                <td>${this._escapeHtml(stateName)}</td>
+                ${FARMER_KEYS.map(k => `<td style="text-align:center;">${b[k]}</td>`).join('')}
+                <td style="text-align:center;font-weight:bold;">${sumRow(b)}</td>
+            </tr>`;
+    }
+    if (!rows) {
+        rows = `<tr><td colspan="10" style="text-align:center;">No data</td></tr>`;
+    }
 
     return `
-<div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title" style="margin-bottom:8px;">${section.id} ${this._escapeHtml(section.title)}</h1>
-    <h2 class="section-subtitle">${section.id}.A OFT Summary</h2>
-    ${renderSectorTable(this, { agg, sectorList, states, perState: false })}
     <h2 class="section-subtitle" style="margin-top:14px;">${section.id}.B State Wise OFT Details</h2>
-    ${renderSectorTable(this, { agg, sectorList, states, perState: true })}
-</div>`;
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th rowspan="2" style="vertical-align:middle;">States</th>
+                <th colspan="8" style="text-align:center;">No. of Farmers</th>
+                <th rowspan="2" style="vertical-align:middle;text-align:center;">Total</th>
+            </tr>
+            <tr>
+                <th style="text-align:center;">General M</th>
+                <th style="text-align:center;">General F</th>
+                <th style="text-align:center;">OBC M</th>
+                <th style="text-align:center;">OBC F</th>
+                <th style="text-align:center;">SC M</th>
+                <th style="text-align:center;">SC F</th>
+                <th style="text-align:center;">ST M</th>
+                <th style="text-align:center;">ST F</th>
+            </tr>
+        </thead>
+        <tbody>
+            ${rows}
+            <tr style="font-weight:bold;">
+                <td>Total</td>
+                ${FARMER_KEYS.map(k => `<td style="text-align:center;">${total[k]}</td>`).join('')}
+                <td style="text-align:center;">${sumRow(total)}</td>
+            </tr>
+        </tbody>
+    </table>`;
 }
 
 module.exports = { renderOftSummarySection };

--- a/backend/services/reports/formsTemplate/projectTemplates/cfldCombinedTemplate.js
+++ b/backend/services/reports/formsTemplate/projectTemplates/cfldCombinedTemplate.js
@@ -450,37 +450,19 @@ function renderSeasonWiseTable(ctx, records) {
     return renderCfldTable(headers, rows);
 }
 
+/**
+ * Super-admin / aggregated layout: the SAME four tables as the KVK side, grouped
+ * by state (one "State: X" block per state).
+ */
 function renderSuperAdminLayout(ctx, records) {
-    const byCropType = groupBy(records, r => r.cropTypeName || 'Unknown Crop Type');
-    const cropTypeSections = Array.from(byCropType.entries())
+    const byState = groupBy(records, r => r.stateName || 'Unknown');
+    return Array.from(byState.entries())
         .sort((a, b) => a[0].localeCompare(b[0]))
-        .map(([cropType, cropTypeRecords], cropIndex) => {
-            const bySeason = groupBy(cropTypeRecords, r => r.seasonName || 'Unknown');
-            const seasonSections = Array.from(bySeason.entries())
-                .sort((a, b) => seasonOrder(a[0]) - seasonOrder(b[0]) || a[0].localeCompare(b[0]))
-                .map(([season, seasonRecords]) => `
-                    <h3 class="about-kvk-subheading">Cluster Front Line Demonstration on ${ctx._escapeHtml(season)}</h3>
-                    ${renderSeasonWiseTable(ctx, seasonRecords)}
-                `)
-                .join('');
-
-            return `
-                <div class="about-kvk-report">
-                    <h2 class="about-kvk-heading">${cropIndex + 1}. ${ctx._escapeHtml(cropType)}</h2>
-                    <h3 class="about-kvk-subheading">A. State-wise subsection</h3>
-                    <h3 class="about-kvk-subheading">State wise details of Cluster Front Line Demonstration</h3>
-                    ${renderStateWiseTable(ctx, cropTypeRecords)}
-                    <h3 class="about-kvk-subheading">B. Season-wise subsection</h3>
-                    ${seasonSections}
-                </div>
-            `;
-        })
+        .map(([state, stateRecords]) => `
+            <h2 class="about-kvk-heading" style="margin-top:14px;">State: ${ctx._escapeHtml(state)}</h2>
+            ${renderKvkLayout(ctx, stateRecords)}
+        `)
         .join('');
-
-    return `
-        <h2 class="about-kvk-heading">3. Cluster Front Line Demonstration on</h2>
-        ${cropTypeSections}
-    `;
 }
 
 function renderCfldCombinedSection(section, data, sectionId, isFirstSection, reportContext = {}) {

--- a/backend/services/reports/formsTemplate/projectTemplates/craDetailsStateWiseTemplate.js
+++ b/backend/services/reports/formsTemplate/projectTemplates/craDetailsStateWiseTemplate.js
@@ -146,7 +146,7 @@ function renderCraDetailsStateWiseSection(section, data, sectionId, isFirstSecti
     <style>
         .cra-table-wrap { width: 100%; overflow: visible; }
         .cra-details-table { width: 100%; table-layout: fixed; border-collapse: collapse; }
-        .cra-details-table th, .cra-details-table td { padding: 2px 3px !important; font-size: 6.6pt !important; line-height: 1.15; word-break: break-word; }
+        .cra-details-table th, .cra-details-table td { padding: 2px 3px !important; font-size: 6.6pt !important; line-height: 1.15; word-break: keep-all; overflow-wrap: normal; white-space: normal; }
         .cra-details-table thead th { text-align: center; vertical-align: middle; }
     </style>
     ${groupedHtml}

--- a/backend/services/reports/formsTemplate/projectTemplates/craDetailsStateWiseTemplate.js
+++ b/backend/services/reports/formsTemplate/projectTemplates/craDetailsStateWiseTemplate.js
@@ -145,7 +145,7 @@ function renderCraDetailsStateWiseSection(section, data, sectionId, isFirstSecti
     <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>
     <style>
         .cra-table-wrap { width: 100%; overflow: visible; }
-        .cra-details-table { width: 100%; table-layout: fixed; border-collapse: collapse; }
+        .cra-details-table { width: 100%; table-layout: auto; border-collapse: collapse; }
         .cra-details-table th, .cra-details-table td { padding: 2px 3px !important; font-size: 6.6pt !important; line-height: 1.15; word-break: keep-all; overflow-wrap: normal; white-space: normal; }
         .cra-details-table thead th { text-align: center; vertical-align: middle; }
     </style>

--- a/backend/services/reports/formsTemplate/projectTemplates/nariBioFortifiedTemplate.js
+++ b/backend/services/reports/formsTemplate/projectTemplates/nariBioFortifiedTemplate.js
@@ -166,18 +166,21 @@ function buildTable1(rows, escFn) {
 /* ── Table 2 renderer ─────────────────────────────────────────────────────── */
 
 function buildTable2(rows, escFn) {
-    const bodyRows = rows.map((row, idx) => `<tr>
+    // Consumption-pattern rows live in the `results` relation (one or more per crop).
+    const resultRows = rows.flatMap(row => (Array.isArray(row.results) ? row.results : []));
+
+    const bodyRows = resultRows.map((res, idx) => `<tr>
         <td>${idx + 1}</td>
-        <td class="left">${escFn(row.nameOfCrop || row.cropName || '-')}</td>
-        <td class="left">${escFn(row.variety || '-')}</td>
-        <td>${fmt(row.areaHa)}</td>
-        <td>-</td>
-        <td>-</td>
-        <td>-</td>
-        <td>-</td>
+        <td class="left">${escFn(res.cropName || '-')}</td>
+        <td class="left">${escFn(res.variety || '-')}</td>
+        <td>${fmt(res.areaHa)}</td>
+        <td>${fmt(res.productionKg)}</td>
+        <td>${fmt(res.consumptionGm)}</td>
+        <td class="left">${escFn(res.formOfConsumption || '-')}</td>
+        <td>${fmt(res.daysInYear)}</td>
     </tr>`).join('');
 
-    const emptyRow = rows.length === 0
+    const emptyRow = resultRows.length === 0
         ? `<tr><td colspan="8" class="nbf-no-data">No records found.</td></tr>`
         : '';
 

--- a/backend/services/reports/formsTemplate/projectTemplates/naturalFarmingPhysicalTemplate.js
+++ b/backend/services/reports/formsTemplate/projectTemplates/naturalFarmingPhysicalTemplate.js
@@ -38,15 +38,69 @@ function isOtherRow(r) {
     return (!r.trainingTitle && !r.trainingDate && !r.venue);
 }
 
+function isGroupedObject(o) {
+    return Boolean(
+        o && typeof o === 'object' && !Array.isArray(o)
+        && o.activityGroups && typeof o.activityGroups === 'object',
+    );
+}
+
+/**
+ * Merge several per-KVK grouped objects (super-admin aggregation) into one
+ * combined grouped structure. Without this, an array of grouped objects is
+ * mistaken for raw records and every KVK collapses into a single empty
+ * "Other activities" row.
+ */
+function mergeGroupedObjects(list) {
+    const activityGroups = {};
+    const activityOrder = [];
+    const stateMap = new Map();
+    const META = ['stateName', 'totalProgrammes', 'totM', 'totF', 'totT', 'other'];
+
+    for (const g of list) {
+        if (!isGroupedObject(g)) continue;
+        const order = Array.isArray(g.activityOrder) ? g.activityOrder : Object.keys(g.activityGroups);
+        for (const key of order) {
+            const rows = g.activityGroups[key] || [];
+            if (!activityGroups[key]) { activityGroups[key] = []; activityOrder.push(key); }
+            activityGroups[key].push(...rows);
+        }
+        for (const sa of (g.stateAggregates || [])) {
+            const stKey = sa.stateName || '-';
+            if (!stateMap.has(stKey)) {
+                stateMap.set(stKey, { stateName: stKey, totalProgrammes: 0, totM: 0, totF: 0, totT: 0, other: 0 });
+            }
+            const agg = stateMap.get(stKey);
+            agg.totalProgrammes += n(sa.totalProgrammes);
+            agg.totM += n(sa.totM);
+            agg.totF += n(sa.totF);
+            agg.totT += n(sa.totT);
+            agg.other += n(sa.other);
+            for (const k of Object.keys(sa)) {
+                if (META.includes(k)) continue;
+                agg[k] = n(agg[k]) + n(sa[k]);
+            }
+        }
+    }
+    const activityNames = activityOrder.filter(k => k !== OTHER_KEY);
+    const stateAggregates = Array.from(stateMap.values()).sort((a, b) => a.stateName.localeCompare(b.stateName));
+    return { activityGroups, activityOrder, activityNames, stateAggregates };
+}
+
 /**
  * Build dynamic grouped structure from either:
  *   – a pre-grouped object from the report repository  { activityGroups, activityOrder, activityNames, stateAggregates }
+ *   – an array of per-KVK grouped objects (super-admin aggregation)
  *   – a flat array of PhysicalInfo records from the form page
  */
 function buildGroupedData(data) {
-    // Already grouped (from report data service)
-    if (data && !Array.isArray(data) && data.activityGroups) {
+    // Already grouped (single KVK / report data service)
+    if (isGroupedObject(data)) {
         return data;
+    }
+    // Array of per-KVK grouped objects (super-admin aggregation)
+    if (Array.isArray(data) && data.some(isGroupedObject)) {
+        return mergeGroupedObjects(data.filter(isGroupedObject));
     }
     // Flat array (from form page export)
     const flatRows = Array.isArray(data) ? data : (data ? [data] : []);
@@ -135,11 +189,12 @@ function renderAggregateTop(stateAggregates, activityNames) {
 }
 
 /* ── Activity detail table (same layout for every dynamic activity) ── */
-function renderActivityBlock(title, rows) {
+function renderActivityBlock(title, rows, showKvk) {
     if (!rows || rows.length === 0) return '';
     const body = rows.map((r, idx) => `
     <tr>
       <td>${idx + 1}</td>
+      ${showKvk ? `<td class="l">${esc(r.kvkName || '')}</td>` : ''}
       <td class="l">${esc(r.trainingTitle || r.activityName || '')}</td>
       <td>${esc(r.trainingDate || '')}</td>
       <td class="l">${esc(r.venue || '')}</td>
@@ -157,6 +212,7 @@ function renderActivityBlock(title, rows) {
       <thead>
         <tr>
           <th rowspan="2">S.No.</th>
+          ${showKvk ? '<th rowspan="2">KVK</th>' : ''}
           <th rowspan="2">Title of Natural Farming ${esc(title)} programme</th>
           <th rowspan="2">Date of programme</th>
           <th rowspan="2">Venue of programme</th>
@@ -181,11 +237,12 @@ function renderActivityBlock(title, rows) {
 }
 
 /* ── "Other activities" block (different column layout) ── */
-function renderOtherActivitiesBlock(rows) {
+function renderOtherActivitiesBlock(rows, showKvk) {
     if (!rows || rows.length === 0) return '';
     const body = rows.map((r, idx) => `
     <tr>
       <td>${idx + 1}</td>
+      ${showKvk ? `<td class="l">${esc(r.kvkName || '')}</td>` : ''}
       <td class="l">${esc(r.innovativeProgrammeName || '')}</td>
       <td class="l">${esc(r.significanceOfInnovativeProgramme || '')}</td>
       <td class="l">${esc(r.remarks || '')}</td>
@@ -197,6 +254,7 @@ function renderOtherActivitiesBlock(rows) {
       <thead>
         <tr>
           <th>S.No.</th>
+          ${showKvk ? '<th>KVK</th>' : ''}
           <th>Name of the Innovative programme organized</th>
           <th>Significance of innovative programme</th>
           <th>Remarks/Observation/Feedback Recorded</th>
@@ -215,12 +273,22 @@ function renderNaturalFarmingPhysicalSection(section, data, sectionId, isFirstSe
     const activityNames = resolved.activityNames || [];
     const stateAggregates = resolved.stateAggregates || [];
 
+    // Super-admin view spans many KVKs → add a KVK column so each programme is
+    // attributable. Single-KVK (KVK side) shows only its own rows, no KVK column.
+    const kvkSet = new Set();
+    for (const key of Object.keys(activityGroups)) {
+        for (const r of (activityGroups[key] || [])) {
+            if (r && r.kvkName) kvkSet.add(r.kvkName);
+        }
+    }
+    const showKvk = kvkSet.size > 1;
+
     // Dynamically render one block per activity category (in insertion order)
     const activityBlocksHtml = activityOrder.map(key => {
         if (key === OTHER_KEY) {
-            return renderOtherActivitiesBlock(activityGroups[key]);
+            return renderOtherActivitiesBlock(activityGroups[key], showKvk);
         }
-        return renderActivityBlock(key, activityGroups[key]);
+        return renderActivityBlock(key, activityGroups[key], showKvk);
     }).join('');
 
     return `

--- a/backend/services/reports/formsTemplate/projectTemplates/nfAgriDroneDemonstrationDetailsTemplate.js
+++ b/backend/services/reports/formsTemplate/projectTemplates/nfAgriDroneDemonstrationDetailsTemplate.js
@@ -22,11 +22,20 @@ function tableCss() {
   .ad-demo-tbl th, .ad-demo-tbl td { border:0.35pt solid #000; padding:2px 2px; vertical-align:middle; text-align:center; word-break:break-word; }
   .ad-demo-tbl thead th { background:#e8e8e8; font-weight:bold; }
   .ad-demo-tbl td.l { text-align:left; }
+  .ad-demo-tbl tr.ad-demo-kvk td { background:#d9d9d9; font-weight:bold; text-align:left; }
+  .ad-demo-tbl tr.ad-demo-spacer td { border:none; height:8px; }
 `;
 }
 
 function renderBody(rows) {
-    return rows.map((r) => `
+    return rows.map((r) => {
+        if (r._spacer) {
+            return '<tr class="ad-demo-spacer"><td colspan="22"></td></tr>';
+        }
+        if (r._header) {
+            return `<tr class="ad-demo-kvk"><td colspan="22">${esc(r.label)}</td></tr>`;
+        }
+        return `
       <tr>
         <td class="l">${esc(r.demonstrationsOn)}</td>
         <td class="l">${esc(r.districtName)}</td>
@@ -40,7 +49,8 @@ function renderBody(rows) {
         <td>${num(r.scM)}</td><td>${num(r.scF)}</td><td>${num(r.scT)}</td>
         <td>${num(r.stM)}</td><td>${num(r.stF)}</td><td>${num(r.stT)}</td>
         <td>${num(r.grandM)}</td><td>${num(r.grandF)}</td><td>${num(r.grandT)}</td>
-      </tr>`).join('');
+      </tr>`;
+    }).join('');
 }
 
 function renderAgriDroneDemonstrationDetailsSection(section, data, sectionId, isFirstSection) {

--- a/backend/services/reports/formsTemplate/projectTemplates/nfAgriDroneIntroductionTemplate.js
+++ b/backend/services/reports/formsTemplate/projectTemplates/nfAgriDroneIntroductionTemplate.js
@@ -19,6 +19,7 @@ function tableCss() {
   .ad-intro-tbl td:nth-child(2) { width:42%; text-align:left; }
   .ad-intro-tbl td:nth-child(3) { width:50%; text-align:left; }
   .ad-intro-spacer td { border:none; height:10px; padding:4px 0; }
+  .ad-intro-kvk td { background:#d9d9d9; font-weight:bold; text-align:left; }
 `;
 }
 
@@ -27,6 +28,9 @@ function renderIntroTable(rows) {
         ? rows.map((r) => {
             if (r._spacer) {
                 return '<tr class="ad-intro-spacer"><td colspan="3"></td></tr>';
+            }
+            if (r._header) {
+                return `<tr class="ad-intro-kvk"><td colspan="3">${esc(r.label)}</td></tr>`;
             }
             return `
       <tr>

--- a/backend/services/reports/reportTemplateService.js
+++ b/backend/services/reports/reportTemplateService.js
@@ -1249,7 +1249,9 @@ class ReportTemplateService {
     .oft-statewise,
     .report-fit {
         width: 100%;
-        table-layout: fixed;
+        /* auto layout sizes columns to content, so words/numbers stay on one
+           line and never overlap; the scaled font keeps it within the page. */
+        table-layout: auto;
     }
     .oft-statewise th,
     .oft-statewise td,
@@ -1268,7 +1270,6 @@ class ReportTemplateService {
     .oft-statewise td:first-child,
     .report-fit th:first-child,
     .report-fit td:first-child {
-        width: 13%;
         text-align: left;
     }
 

--- a/backend/services/reports/reportTemplateService.js
+++ b/backend/services/reports/reportTemplateService.js
@@ -1258,8 +1258,10 @@ class ReportTemplateService {
         padding: 1.5px 2px;
         font-size: inherit;
         line-height: 1.1;
-        word-break: break-word;
-        overflow-wrap: break-word;
+        /* Wrap only at spaces — never split a word or a number. */
+        word-break: keep-all;
+        overflow-wrap: normal;
+        white-space: normal;
         text-align: center;
     }
     .oft-statewise th:first-child,


### PR DESCRIPTION
## Summary
Report-generation fixes for the project report PDFs, covering both the single-KVK view and the super-admin (multi-KVK / aggregated) view. Closes the data-not-fetching / mis-rendered report issues (incl. #211).

## Changes (this branch vs dev)
**Agri-Drone Introduction (§3.30)**
- Fetch ALL intros per KVK (`findMany`) — was `findFirst`, dropping every PIC after the first.
- Resolve payloads wrapped in an array (`[{rows}]`) instead of rebuilding them into empty `—`/`0` rows.
- Super-admin: per-KVK header blocks (`KVK — District, State`); single KVK keeps the original layout.

**Agri-Drone Demonstration Details (§3.31)**
- Same wrapped-payload handling + per-KVK header blocks; skip empty KVK payloads (no phantom blocks).

**Natural Farming – Physical Information (§3.25)**
- Merge per-KVK grouped objects for super-admin (previously each KVK collapsed into a single empty "Other activities" row with blank state and zero totals).
- KVK column added in detail tables when more than one KVK is present.

**OFT Summary (§2.x)**
- Finalize sector/thematic OFT summary (A) + new state-wise farmer participation block (B); remove debug logging.

**Earlier report fixes already on this branch** (NF/NARI/CFLD missing data #209, CFLD super-admin KVK tables, table layout/wrapping, FLD report rebuild, OFT summary/state-wise reworks).

## Notes
- Report sections are Redis-cached per dataSource; stale entries were busted during testing. After deploy, bust cache for affected dataSources if needed.
- Verified: JS syntax of all changed files; resolver/merge logic via standalone simulations (single KVK, multi-KVK, empty KVK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
