### PR TITLE
fix(reports/forms): report structure, OFT/vehicle/equipment/swachhata, add-buttons, filtered downloads, revoke transfer (#213)

### DIFF
--- a/backend/config/reportConfig.js
+++ b/backend/config/reportConfig.js
@@ -201,6 +201,7 @@ const reportConfig = {
                 dateFields: ['createdAt'],
             },
             fields: [
+                { dbField: 'kvkName', displayName: 'KVK' },
                 { dbField: 'equipmentName', displayName: 'Equipment Name' },
                 { dbField: 'yearOfPurchase', displayName: 'Year of Purchase' },
                 { dbField: 'totalCost', displayName: 'Total Cost', type: 'currency' },
@@ -401,6 +402,9 @@ const reportConfig = {
             title: 'Soil & Water Testing - Laboratory Equipment',
             description: 'Equipment available in the Soil and Water Testing Laboratory (name and quantity)',
             subsection: true,
+            // Excluded from the report index (not part of the approved Achievements
+            // structure); only "Analysis Details" (2.14) shows under Soil & Water Testing.
+            hideInReport: true,
             parentSectionId: '2',
             dataSource: 'soilWaterEquipmentReport',
             format: 'custom',
@@ -1902,6 +1906,7 @@ function _buildTaxonomyChapter(parent, taxonomy, selectedById, consumed, heading
 function _appendLeftovers(chapter, parentId, selectedById, consumed, headingById, taxonomyGroupCount = 0) {
     const leftovers = [];
     selectedById.forEach((section, id) => {
+        if (section.hideInReport) { consumed.add(id); return; }
         if (String(section.parentSectionId) === parentId && !consumed.has(id)) {
             leftovers.push(section);
         }

--- a/backend/config/reportIndexTaxonomy.js
+++ b/backend/config/reportIndexTaxonomy.js
@@ -159,6 +159,128 @@ const REPORT_INDEX_TAXONOMY = {
             },
         ],
     },
+
+    // ── 3. Projects ──────────────────────────────────────────────────────────
+    // Grouped to mirror the Projects form page: each card is a group, its links
+    // are the lettered features. Features with sectionId '' have no backing
+    // report section yet and are skipped in the report.
+    '3': {
+        title: 'Projects',
+        groups: [
+            {
+                label: 'CFLD',
+                features: [
+                    { label: 'Technical Parameter', sectionId: '2.16' },
+                    { label: 'Extension Activity', sectionId: '2.17' },
+                    { label: 'Budget Utilization', sectionId: '2.18' },
+                ],
+            },
+            {
+                label: 'NICRA',
+                features: [
+                    { label: 'Basic Information', sectionId: '2.34' },
+                    { label: 'Details', sectionId: '' },
+                    { label: 'Training', sectionId: '2.35' },
+                    { label: 'Extension Activity', sectionId: '2.36' },
+                ],
+            },
+            {
+                label: 'NICRA Others',
+                features: [
+                    { label: 'Intervention', sectionId: '2.37' },
+                    { label: 'Revenue Generated', sectionId: '' },
+                    { label: 'Custom Hiring', sectionId: '2.38' },
+                    { label: 'VCRMC', sectionId: '2.39' },
+                    { label: 'Soil Health Card', sectionId: '2.40' },
+                    { label: 'Convergence Programme', sectionId: '' },
+                    { label: 'Dignitaries Visited', sectionId: '' },
+                    { label: 'PI/Co-PI List', sectionId: '' },
+                ],
+            },
+            {
+                label: 'ARYA / SAFAL',
+                features: [
+                    { label: 'Current Year Details', sectionId: '2.30' },
+                    { label: 'Previous Year Evaluation', sectionId: '2.31' },
+                ],
+            },
+            {
+                label: 'Natural Farming',
+                features: [
+                    { label: 'Geographical Information', sectionId: '' },
+                    { label: 'Physical Information', sectionId: '2.44' },
+                    { label: 'Demonstration Information', sectionId: '2.46' },
+                    { label: 'Farmers Practicing', sectionId: '2.47' },
+                    { label: 'Beneficiaries', sectionId: '' },
+                    { label: 'Soil Data', sectionId: '2.49' },
+                    { label: 'Budget Expenditure', sectionId: '2.50' },
+                ],
+            },
+            {
+                label: 'TSP/SCSP',
+                features: [
+                    { label: 'TSP Activities', sectionId: '2.33' },
+                    { label: 'SCSP Activities', sectionId: '2.33' },
+                ],
+            },
+            {
+                label: 'NARI',
+                features: [
+                    { label: 'Nutrition Garden', sectionId: '2.25' },
+                    { label: 'Bio-fortified Crops', sectionId: '2.26' },
+                    { label: 'Value Addition', sectionId: '2.27' },
+                    { label: 'Training Program', sectionId: '2.28' },
+                    { label: 'Extension Activities', sectionId: '2.29' },
+                ],
+            },
+            {
+                label: 'Agri-Drone',
+                features: [
+                    { label: 'Introduction', sectionId: '2.51' },
+                    { label: 'Demonstration', sectionId: '2.52' },
+                ],
+            },
+            {
+                label: 'FPO and CBBO',
+                features: [
+                    { label: 'Details FPO and CBBO', sectionId: '2.21' },
+                    { label: 'FPO Management', sectionId: '2.22' },
+                ],
+            },
+            {
+                label: 'DRMR',
+                features: [
+                    { label: 'DRMR Details', sectionId: '2.23' },
+                    { label: 'DRMR Activity', sectionId: '2.24' },
+                ],
+            },
+            {
+                label: 'Climate Resilient Agriculture (CRA)',
+                features: [
+                    { label: 'CRA Details', sectionId: '2.19' },
+                    { label: 'Extension Activity', sectionId: '2.20' },
+                ],
+            },
+            {
+                label: 'CSISA',
+                features: [
+                    { label: 'CSISA', sectionId: '2.32' },
+                ],
+            },
+            {
+                label: 'Seed Hub Program',
+                features: [
+                    { label: 'Seed Hub Program', sectionId: '2.53' },
+                ],
+            },
+            {
+                label: 'Other Programmes',
+                features: [
+                    { label: 'Other Programmes', sectionId: '2.54' },
+                ],
+            },
+        ],
+    },
 };
 
 module.exports = { REPORT_INDEX_TAXONOMY };

--- a/backend/config/reportIndexTaxonomy.js
+++ b/backend/config/reportIndexTaxonomy.js
@@ -93,7 +93,7 @@ const REPORT_INDEX_TAXONOMY = {
                 label: 'Front Line Demonstration',
                 features: [
                     { label: 'FLD Summary', sectionId: '2.4' },
-                    { label: 'State Wise OFT Details', sectionId: '2.4' },
+                    { label: 'State Wise FLD Details', sectionId: '2.4' },
                     { label: 'FLD Details', sectionId: '2.4' },
                     { label: 'Extension & Training activities under FLD', sectionId: '2.5' },
                     { label: 'Technical Feedback on FLD', sectionId: '2.6' },

--- a/backend/controllers/forms/oftController.js
+++ b/backend/controllers/forms/oftController.js
@@ -84,6 +84,16 @@ const oftController = {
         });
     }),
 
+    revokeTransfer: asyncHandler(async (req, res) => {
+        const result = await oftService.revokeTransfer(req.params.id, req.user);
+        res.status(200).json({
+            success: true,
+            message: 'OFT transfer revoked successfully',
+            data: result,
+            timestamp: new Date().toISOString(),
+        });
+    }),
+
     addResult: asyncHandler(async (req, res) => {
         const result = await oftService.addResult(req.params.id, req.body, req.user);
         res.status(201).json({

--- a/backend/controllers/reports/reportController.js
+++ b/backend/controllers/reports/reportController.js
@@ -1,6 +1,6 @@
 const reportService = require('../../services/reports/reportService.js');
 const reportAggregationService = require('../../services/reports/reportAggregationService.js');
-const { generateExcel, generateWord } = require('../../utils/exportHelper.js');
+const { generateWord } = require('../../utils/exportHelper.js');
 const { normalizeReportKvkId } = require('../../utils/reportKvkId.js');
 
 /**
@@ -63,35 +63,37 @@ const generateKvkReport = async (req, res) => {
         const { targetKvkId } = resolved;
         const generatedBy = user.name || user.email || 'Unknown User';
 
-        if (format === 'excel' || format === 'docx') {
-            // Build a compact tabular export from report data
+        if (format === 'excel') {
+            // Structured workbook: one tab per sub-section, grouped per chapter,
+            // mirroring the PDF (see reportExcelService).
+            const result = await reportService.generateKvkReportExcel(targetKvkId, {
+                sectionIds: sectionIds || [],
+                filters: filters || {},
+                generatedBy,
+            });
+            const fileName = `KVK_Report_${targetKvkId}_${Date.now()}.xlsx`;
+            res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+            res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+            res.setHeader('Content-Length', result.excelBuffer.length);
+            return res.send(result.excelBuffer);
+        }
+
+        if (format === 'docx') {
+            // TODO: structured DOCX (planned). Compact tabular fallback for now.
             const data = await reportService.getReportData(targetKvkId, {
                 sectionIds: sectionIds || [],
                 filters: filters || {},
             });
             const headers = ['Section', 'Data'];
             const rows = Object.entries(data.sectionsData || {}).map(([section, value]) => {
-                try {
-                    return [section, JSON.stringify(value)];
-                } catch {
-                    return [section, String(value)];
-                }
+                try { return [section, JSON.stringify(value)]; } catch { return [section, String(value)]; }
             });
-            if (format === 'excel') {
-                const buffer = await generateExcel(`KVK Report ${targetKvkId}`, headers, rows);
-                const fileName = `KVK_Report_${targetKvkId}_${Date.now()}.xlsx`;
-                res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-                res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
-                res.setHeader('Content-Length', buffer.length);
-                return res.send(Buffer.from(buffer));
-            } else {
-                const buffer = await generateWord(`KVK Report ${targetKvkId}`, headers, rows);
-                const fileName = `KVK_Report_${targetKvkId}_${Date.now()}.docx`;
-                res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
-                res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
-                res.setHeader('Content-Length', buffer.length);
-                return res.send(Buffer.from(buffer));
-            }
+            const buffer = await generateWord(`KVK Report ${targetKvkId}`, headers, rows);
+            const fileName = `KVK_Report_${targetKvkId}_${Date.now()}.docx`;
+            res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+            res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+            res.setHeader('Content-Length', buffer.length);
+            return res.send(Buffer.from(buffer));
         }
 
         // Default: Generate PDF
@@ -228,34 +230,36 @@ const generateAggregatedReport = async (req, res) => {
 
         const generatedBy = user.name || user.email || 'Unknown User';
 
-        if (format === 'excel' || format === 'docx') {
+        if (format === 'excel') {
+            // Structured workbook mirroring the PDF (tabs per sub-section).
+            const result = await reportService.generateAggregatedReportExcel(scope, {
+                sectionIds: sectionIds || [],
+                filters: filters || {},
+                generatedBy,
+            });
+            const fileName = `Aggregated_Report_${Date.now()}.xlsx`;
+            res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+            res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+            res.setHeader('Content-Length', result.excelBuffer.length);
+            return res.send(result.excelBuffer);
+        }
+
+        if (format === 'docx') {
+            // TODO: structured DOCX (planned). Compact tabular fallback for now.
             const data = await reportService.getAggregatedReportData(scope, {
                 sectionIds: sectionIds || [],
                 filters: filters || {},
             });
             const headers = ['Section', 'Data'];
             const rows = Object.entries(data.sectionsData || {}).map(([section, value]) => {
-                try {
-                    return [section, JSON.stringify(value)];
-                } catch {
-                    return [section, String(value)];
-                }
+                try { return [section, JSON.stringify(value)]; } catch { return [section, String(value)]; }
             });
-            if (format === 'excel') {
-                const buffer = await generateExcel('Aggregated Report', headers, rows);
-                const fileName = `Aggregated_Report_${Date.now()}.xlsx`;
-                res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-                res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
-                res.setHeader('Content-Length', buffer.length);
-                return res.send(Buffer.from(buffer));
-            } else {
-                const buffer = await generateWord('Aggregated Report', headers, rows);
-                const fileName = `Aggregated_Report_${Date.now()}.docx`;
-                res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
-                res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
-                res.setHeader('Content-Length', buffer.length);
-                return res.send(Buffer.from(buffer));
-            }
+            const buffer = await generateWord('Aggregated Report', headers, rows);
+            const fileName = `Aggregated_Report_${Date.now()}.docx`;
+            res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+            res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+            res.setHeader('Content-Length', buffer.length);
+            return res.send(Buffer.from(buffer));
         }
 
         // Default: PDF

--- a/backend/controllers/reports/reportController.js
+++ b/backend/controllers/reports/reportController.js
@@ -1,6 +1,5 @@
 const reportService = require('../../services/reports/reportService.js');
 const reportAggregationService = require('../../services/reports/reportAggregationService.js');
-const { generateWord } = require('../../utils/exportHelper.js');
 const { normalizeReportKvkId } = require('../../utils/reportKvkId.js');
 
 /**
@@ -79,21 +78,17 @@ const generateKvkReport = async (req, res) => {
         }
 
         if (format === 'docx') {
-            // TODO: structured DOCX (planned). Compact tabular fallback for now.
-            const data = await reportService.getReportData(targetKvkId, {
+            // Structured Word document mirroring the PDF (see reportWordService).
+            const result = await reportService.generateKvkReportWord(targetKvkId, {
                 sectionIds: sectionIds || [],
                 filters: filters || {},
+                generatedBy,
             });
-            const headers = ['Section', 'Data'];
-            const rows = Object.entries(data.sectionsData || {}).map(([section, value]) => {
-                try { return [section, JSON.stringify(value)]; } catch { return [section, String(value)]; }
-            });
-            const buffer = await generateWord(`KVK Report ${targetKvkId}`, headers, rows);
             const fileName = `KVK_Report_${targetKvkId}_${Date.now()}.docx`;
             res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
             res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
-            res.setHeader('Content-Length', buffer.length);
-            return res.send(Buffer.from(buffer));
+            res.setHeader('Content-Length', result.wordBuffer.length);
+            return res.send(result.wordBuffer);
         }
 
         // Default: Generate PDF
@@ -245,21 +240,17 @@ const generateAggregatedReport = async (req, res) => {
         }
 
         if (format === 'docx') {
-            // TODO: structured DOCX (planned). Compact tabular fallback for now.
-            const data = await reportService.getAggregatedReportData(scope, {
+            // Structured Word document mirroring the PDF.
+            const result = await reportService.generateAggregatedReportWord(scope, {
                 sectionIds: sectionIds || [],
                 filters: filters || {},
+                generatedBy,
             });
-            const headers = ['Section', 'Data'];
-            const rows = Object.entries(data.sectionsData || {}).map(([section, value]) => {
-                try { return [section, JSON.stringify(value)]; } catch { return [section, String(value)]; }
-            });
-            const buffer = await generateWord('Aggregated Report', headers, rows);
             const fileName = `Aggregated_Report_${Date.now()}.docx`;
             res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
             res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
-            res.setHeader('Content-Length', buffer.length);
-            return res.send(Buffer.from(buffer));
+            res.setHeader('Content-Length', result.wordBuffer.length);
+            return res.send(result.wordBuffer);
         }
 
         // Default: PDF

--- a/backend/repositories/forms/oftRepository.js
+++ b/backend/repositories/forms/oftRepository.js
@@ -244,6 +244,8 @@ const oftRepository = {
                 farmersStM: sourceOft.farmersStM,
                 farmersStF: sourceOft.farmersStF,
                 status: OFT_STATUS.ONGOING,
+                // Record the transfer chain so the transfer can be revoked later.
+                transferredFromOftId: sourceId,
                 technologies: {
                     create: (sourceOft.technologies || []).map((tech) => ({
                         oftTechnologyTypeId: tech.oftTechnologyTypeId || null,
@@ -268,6 +270,30 @@ const oftRepository = {
                 source: _mapOftResponse(sourceRecord),
                 transferred: _mapOftResponse(newRecord),
             };
+        });
+    },
+
+    // Next-year copies generated from a transferred OFT (the transfer chain).
+    findTransferChildren: async (sourceId) => {
+        return prisma.kvkoft.findMany({
+            where: { transferredFromOftId: parseInt(sourceId) },
+            select: { kvkOftId: true, status: true },
+        });
+    },
+
+    // Undo a transfer: delete the generated next-year copies (technologies and
+    // any result rows cascade) and set the source OFT back to ONGOING.
+    revokeTransferTx: async (sourceId, childIds = []) => {
+        return prisma.$transaction(async (tx) => {
+            if (childIds.length) {
+                await tx.kvkoft.deleteMany({ where: { kvkOftId: { in: childIds } } });
+            }
+            const restored = await tx.kvkoft.update({
+                where: { kvkOftId: parseInt(sourceId) },
+                data: { status: OFT_STATUS.ONGOING },
+                include: OFT_INCLUDE,
+            });
+            return _mapOftResponse(restored);
         });
     },
 

--- a/backend/repositories/reports/aboutkvkReport/assetsReportRepository.js
+++ b/backend/repositories/reports/aboutkvkReport/assetsReportRepository.js
@@ -20,17 +20,33 @@ async function getKvkVehicles(kvkId, filters = {}) {
     const where = { kvkId };
     applyCreatedAtFilters(where, filters);
 
-    return await prisma.kvkVehicle.findMany({
+    const rows = await prisma.kvkVehicle.findMany({
         where,
         include: {
             kvk: {
                 select: { kvkId: true, kvkName: true },
+            },
+            // Total Run + Present Status live on the yearly detail, not on the
+            // base vehicle. Pull the latest detail so the report can show them.
+            vehicleDetails: {
+                include: { vehicleStatus: { select: { statusLabel: true } } },
+                orderBy: { reportingYear: 'desc' },
             },
         },
         orderBy: [
             { yearOfPurchase: 'desc' },
             { vehicleName: 'asc' },
         ],
+    });
+
+    return rows.map((v) => {
+        const latest = Array.isArray(v.vehicleDetails) ? v.vehicleDetails[0] : null;
+        return {
+            ...v,
+            kvkName: v.kvk?.kvkName || '',
+            totalRun: latest?.totalRun ?? '',
+            presentStatus: latest?.vehicleStatus?.statusLabel ?? '',
+        };
     });
 }
 
@@ -62,12 +78,34 @@ async function getKvkEquipments(kvkId, filters = {}) {
     const where = { kvkId };
     applyCreatedAtFilters(where, filters);
 
-    return await prisma.kvkEquipment.findMany({
+    const rows = await prisma.kvkEquipment.findMany({
         where,
+        include: {
+            kvk: { select: { kvkId: true, kvkName: true } },
+            // equipmentName is free-text but often blank; fall back to the master.
+            equipmentMaster: { select: { name: true } },
+            assetFundingSource: { select: { name: true } },
+            // Present Status lives on the yearly detail.
+            equipmentDetails: {
+                include: { equipmentStatus: { select: { statusLabel: true } } },
+                orderBy: { reportingYear: 'desc' },
+            },
+        },
         orderBy: [
             { yearOfPurchase: 'desc' },
             { equipmentName: 'asc' },
         ],
+    });
+
+    return rows.map((e) => {
+        const latest = Array.isArray(e.equipmentDetails) ? e.equipmentDetails[0] : null;
+        return {
+            ...e,
+            kvkName: e.kvk?.kvkName || '',
+            equipmentName: e.equipmentName || e.equipmentMaster?.name || '',
+            sourceOfFunding: e.assetFundingSource?.name || '',
+            presentStatus: latest?.equipmentStatus?.statusLabel ?? '',
+        };
     });
 }
 

--- a/backend/routes/forms/oftRoutes.js
+++ b/backend/routes/forms/oftRoutes.js
@@ -32,6 +32,8 @@ router.get('/:id', requireRole(allRoles), oftController.getById);
 router.patch('/:id', requireRole([...kvkRoles, 'super_admin']), ensureBody(), oftController.update);
 router.put('/:id', requireRole([...kvkRoles, 'super_admin']), ensureBody(), oftController.update);
 router.post('/:id/transfer-next-year', requireRole([...kvkRoles, 'super_admin']), oftController.transferToNextYear);
+// Revoke/undo a transfer — super-admin only.
+router.post('/:id/revoke-transfer', requireRole(['super_admin']), oftController.revokeTransfer);
 router.post('/:id/result', requireRole([...kvkRoles, 'super_admin']), ensureBody(), oftController.addResult);
 router.put('/:id/result', requireRole([...kvkRoles, 'super_admin']), ensureBody(), oftController.editResult);
 router.get('/:id/result', requireRole(allRoles), oftController.getResult);

--- a/backend/services/forms/oftService.js
+++ b/backend/services/forms/oftService.js
@@ -87,6 +87,29 @@ const oftService = {
         return transferred;
     },
 
+    // Revoke/undo a transfer (super-admin). Deletes the generated next-year copy
+    // and restores the source OFT to ONGOING — only when that copy is untouched.
+    revokeTransfer: async (id, user) => {
+        const source = await oftRepository.findRawById(id, user);
+        if (!source) {
+            throw new NotFoundError('OFT record');
+        }
+        if (normalizeOftStatus(source.status) !== OFT_STATUS.TRANSFERRED_TO_NEXT_YEAR) {
+            throw new ValidationError('Only transferred OFT records can have their transfer revoked');
+        }
+        const children = await oftRepository.findTransferChildren(id);
+        for (const child of children) {
+            if (normalizeOftStatus(child.status) !== OFT_STATUS.ONGOING) {
+                throw new ValidationError(
+                    'Cannot revoke: the next-year OFT already has results or was transferred again.'
+                );
+            }
+        }
+        const restored = await oftRepository.revokeTransferTx(id, children.map(c => c.kvkOftId));
+        await _invalidateOftReports(source.kvkId);
+        return restored;
+    },
+
     addResult: async (id, payload, user) => {
         const source = await oftRepository.findRawById(id, user);
         if (!source) throw new NotFoundError('OFT record');
@@ -137,7 +160,9 @@ const oftService = {
         const source = await oftRepository.findRawById(id, user);
         if (!source) throw new NotFoundError('OFT record');
         const result = await oftRepository.getResultByOftId(id);
-        if (!result) throw new NotFoundError('OFT result report');
+        // No result entered yet → return null (200) so the UI can open an empty
+        // result form for first-time entry instead of treating it as an error.
+        if (!result) return null;
         return resultAttachments.decorate({ ...result, kvkId: source.kvkId }, user);
     },
 

--- a/backend/services/reports/formsTemplate/achievementTemplates/extensionOutreachReportTemplate.js
+++ b/backend/services/reports/formsTemplate/achievementTemplates/extensionOutreachReportTemplate.js
@@ -1,6 +1,18 @@
 const { resolveExtensionOutreachPayload } = require('../../../../repositories/reports/extensionOutreachReport/extensionOutreachReportRepository.js');
 const { outreachTableCss, renderOutreachTable } = require('./extensionOutreachHelpers.js');
 
+function tableCss() {
+    return `
+  .wsd-page-wrap { width:100%; font-size:5.5pt; line-height:1.15; }
+  .wsd-page-title { font-size:8pt; font-weight:bold; margin:0 0 4px 0; }
+  .wsd-page-tbl { width:100%; border-collapse:collapse; table-layout:fixed; margin-bottom:10px; page-break-inside:avoid; }
+  .wsd-page-tbl th, .wsd-page-tbl td { border:0.35pt solid #000; padding:2px 3px; vertical-align:middle; }
+  .wsd-page-tbl thead th { background:#e8e8e8; font-weight:bold; text-align:center; }
+  .wsd-page-tbl .c { text-align:center; }
+  .wsd-page-tbl .l { text-align:left; }
+  .wsd-page-tbl .muted { color:#444; font-size:6pt; margin:4px 0 8px 0; }
+`;
+}
 function renderExtensionOutreachReportSection(section, data, sectionId, isFirstSection) {
     const payload = resolveExtensionOutreachPayload(data);
     const y = payload.yearLabel || '';
@@ -35,10 +47,10 @@ function renderExtensionOutreachReportSection(section, data, sectionId, isFirstS
 
     return `
 <div id="${sectionId}" class="${isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued'}">
-  <style>${outreachTableCss()}</style>
+  <style>${tableCss()} ${outreachTableCss()}</style>
   <div class="eox-wrap">
-    <div class="eox-title">${this._escapeHtml(t1)}</div>
-    <div class="eox-sub">${this._escapeHtml(sub)}</div>
+    <h1 class="section-title">${this._escapeHtml(t1)}</h1>
+    <div class="">${this._escapeHtml(sub)}</div>
     ${stateBlock}
     ${actBlock}
   </div>

--- a/backend/services/reports/formsTemplate/achievementTemplates/productionSupplyPageReportTemplate.js
+++ b/backend/services/reports/formsTemplate/achievementTemplates/productionSupplyPageReportTemplate.js
@@ -51,7 +51,7 @@ function renderProductionSupplyPageReportSection(section, data, sectionId, isFir
     if (rows.length === 0) {
         return `
 <div id="${sectionId}" class="${isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued'}">
-  <h1 class="section-title">${this._escapeHtml(section.title)}</h1>
+  <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>
   <p class="no-data">No data found</p>
 </div>`;
     }
@@ -77,6 +77,7 @@ function renderProductionSupplyPageReportSection(section, data, sectionId, isFir
 <div id="${sectionId}" class="${isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued'}">
   <style>${tableCss()}</style>
   <div class="ps-page-wrap">
+    <h1 class="section-title">${section.id} ${esc(section.title)}</h1>
     <div class="ps-page-sec">Production and supply of Technological products${y ? ` — year ${esc(y)}` : ''}</div>
     <table class="ps-page-tbl">
       <thead>

--- a/backend/services/reports/formsTemplate/achievementTemplates/soilWaterAnalysisDetailStateReportTemplate.js
+++ b/backend/services/reports/formsTemplate/achievementTemplates/soilWaterAnalysisDetailStateReportTemplate.js
@@ -38,7 +38,7 @@ function renderSoilWaterAnalysisDetailStateReportSection(section, data, sectionI
     if (!blocks.length) {
         return `
 <div id="${sectionId}" class="${isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued'}">
-  <h1 class="section-title">${this._escapeHtml(section.title)}</h1>
+  <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>
   <p class="no-data">No data found</p>
 </div>`;
     }
@@ -84,8 +84,8 @@ function renderSoilWaterAnalysisDetailStateReportSection(section, data, sectionI
 <div id="${sectionId}" class="${isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued'}">
   <style>${tableCss()}</style>
   <div class="swd-wrap">
-    <div class="swd-title">7. SOIL &amp; WATER TESTING</div>
-    <div class="swd-sub">2.7. Detail of Soil, Water and Plant analysis</div>
+    <h1 class="section-title">${section.id} ${esc(section.title)}</h1>
+    <div class="swd-sub">Detail of Soil, Water and Plant analysis</div>
     ${y ? `<div class="muted">Reporting year ${esc(y)}</div>` : ''}
     <table class="swd-tbl">
       <thead>

--- a/backend/services/reports/formsTemplate/achievementTemplates/soilWaterEquipmentPageReportTemplate.js
+++ b/backend/services/reports/formsTemplate/achievementTemplates/soilWaterEquipmentPageReportTemplate.js
@@ -36,7 +36,7 @@ function renderSoilWaterEquipmentPageReportSection(section, data, sectionId, isF
   if (rows.length === 0) {
     return `
 <div id="${sectionId}" class="${isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued'}">
-  <h1 class="section-title">${this._escapeHtml(section.title)}</h1>
+  <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>
   <p class="no-data">No data found</p>
 </div>`;
   }
@@ -75,8 +75,8 @@ function renderSoilWaterEquipmentPageReportSection(section, data, sectionId, isF
 <div id="${sectionId}" class="${isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued'}">
   <style>${tableCss()}</style>
   <div class="swe-page-wrap">
-    <div class="swe-page-title">7. SOIL &amp; WATER TESTING</div>
-    <div class="swe-page-sub">A. Details of equipment available in Soil and Water Testing Laboratory.</div>
+    <h1 class="section-title">${section.id} ${esc(section.title)}</h1>
+    <div class="swe-page-sub">Details of equipment available in Soil and Water Testing Laboratory.</div>
     ${y ? `<div class="muted">Reporting year ${esc(y)}</div>` : ''}
     <table class="swe-page-tbl">
       <thead>${head}</thead>

--- a/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
+++ b/backend/services/reports/formsTemplate/oftTemplates/oftSummaryTemplate.js
@@ -113,14 +113,30 @@ function renderValueCells(isMultiState, stateKeys, stateMap) {
 // ── Main render function ────────────────────────────────────────────
 
 function renderOftSummarySection(section, data, sectionId, isFirstSection) {
-    // data can be { records, subjects } from data service, or plain array from combined template
-    let records, subjects;
-    if (data && !Array.isArray(data) && data.records) {
+    // Accept every shape the orchestration can hand us:
+    //   - { records, subjects }                  single KVK (data service)
+    //   - [ { records, subjects }, ... ]         super-admin: one chunk per KVK
+    //   - [ ...oftRows ]                          plain rows (combined template)
+    //   - single oft row / object
+    // Without the chunk handling, super-admin aggregation treats each
+    // { records, subjects } object as an OFT row → sector "Unknown",
+    // thematic "Other", farmer counts 0.
+    let records = [];
+    let subjects = [];
+    if (data && !Array.isArray(data) && Array.isArray(data.records)) {
         records = data.records;
         subjects = data.subjects || [];
-    } else {
-        records = Array.isArray(data) ? data : (data ? [data] : []);
-        subjects = [];
+    } else if (Array.isArray(data)) {
+        if (data.some(d => d && (Array.isArray(d.records) || Array.isArray(d.subjects)))) {
+            for (const chunk of data) {
+                if (Array.isArray(chunk?.records)) records.push(...chunk.records);
+                if (subjects.length === 0 && Array.isArray(chunk?.subjects)) subjects = chunk.subjects;
+            }
+        } else {
+            records = data;
+        }
+    } else if (data) {
+        records = [data];
     }
 
     if (records.length === 0 && subjects.length === 0) {

--- a/backend/services/reports/formsTemplate/swachhtaTemplates/swachhtaBudgetTemplate.js
+++ b/backend/services/reports/formsTemplate/swachhtaTemplates/swachhtaBudgetTemplate.js
@@ -1,69 +1,77 @@
 /**
  * Swachhta Budget (Quarterly Expenditure) Template
  *
- * One table per KVK with 2 rows:
- *   1. Vermicomposting
- *   2. Other than vermicomposting activities under Swachata
+ * One combined table, one row per KVK, with grouped columns:
+ *   Vermicomposting (No of village covered | Total Expenditure) |
+ *   Other than vermicomposting activities under Swachata (No of village covered | Total Expenditure)
  *
- * Columns: KVK | Activities | No of village covered | Total Expenditure(Rs.in Lakhs)
+ * KVK side (single KVK)  : simple list (KVK + the 4 value columns).
+ * Super-admin (aggregated): structured — State | KVK prepended, sorted by State then KVK.
  */
 
-const COLGROUP = `
-        <colgroup>
-            <col style="width:15%;"><col style="width:45%;"><col style="width:18%;"><col style="width:22%;">
-        </colgroup>`;
+function _num(v) {
+    return v != null && v !== '' ? v : 0;
+}
 
-const THEAD = `
-        <thead>
-            <tr>
-                <th>KVK</th>
-                <th>Activities</th>
-                <th>No of village covered</th>
-                <th>Total Expenditure(Rs.in Lakhs)</th>
-            </tr>
-        </thead>`;
-
-function renderSwachhtaBudgetSection(section, data, sectionId, isFirstSection) {
+function renderSwachhtaBudgetSection(section, data, sectionId, isFirstSection, reportContext = {}) {
     const records = Array.isArray(data) ? data : (data ? [data] : []);
+    const isAgg = Boolean(reportContext.isAggregatedReport);
     const pageClass = isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued';
+
+    const stateOf = (r) => r.kvk?.state?.stateName || '';
+    const kvkOf = (r) => r.kvk?.kvkName || '-';
+    const rows = isAgg
+        ? [...records].sort((a, b) =>
+            (stateOf(a).localeCompare(stateOf(b))) || (kvkOf(a).localeCompare(kvkOf(b))))
+        : records;
+
+    const leadHead = isAgg
+        ? `<th rowspan="2" style="vertical-align:bottom;">State</th>
+                <th rowspan="2" style="vertical-align:bottom;">KVK</th>`
+        : `<th rowspan="2" style="vertical-align:bottom;">KVK</th>`;
+    const leadCount = isAgg ? 2 : 1;
+    const colCount = leadCount + 4;
 
     let html = `
 <div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title" style="margin-bottom:16px;">Other than vermicomposting activities under Swachata</h1>`;
-
-    if (records.length === 0) {
-        html += `
+    <h1 class="section-title" style="margin-bottom:12px;">${section.id} ${this._escapeHtml(section.title)}</h1>
     <table class="data-table" style="width:100%;table-layout:fixed;">
-        ${COLGROUP}${THEAD}
-        <tbody>
-            <tr><td colspan="4" style="text-align:center;color:#666;font-style:italic;padding:12px;">No data available for this section.</td></tr>
-        </tbody>
-    </table>`;
-    } else {
-        records.forEach(row => {
-            const kvk = row.kvk?.kvkName || '-';
-            html += `
-    <table class="data-table" style="width:100%;table-layout:fixed;margin-bottom:20px;">
-        ${COLGROUP}${THEAD}
-        <tbody>
+        <thead>
             <tr>
-                <td>${this._escapeHtml(kvk)}</td>
-                <td>Vermicomposting</td>
-                <td style="text-align:center;">${row.vermiVillageCovered != null ? row.vermiVillageCovered : 0}</td>
-                <td style="text-align:center;">${row.vermiTotalExpenditure != null ? row.vermiTotalExpenditure : 0}</td>
+                ${leadHead}
+                <th colspan="2" style="text-align:center;">Vermicomposting</th>
+                <th colspan="2" style="text-align:center;">Other than vermicomposting activities under Swachata</th>
             </tr>
             <tr>
-                <td>${this._escapeHtml(kvk)}</td>
-                <td>Other than vermicomposting activities under Swachata</td>
-                <td style="text-align:center;">${row.otherVillageCovered != null ? row.otherVillageCovered : 0}</td>
-                <td style="text-align:center;">${row.otherTotalExpenditure != null ? row.otherTotalExpenditure : 0}</td>
+                <th style="text-align:center;">No of village covered</th>
+                <th style="text-align:center;">Total Expenditure (Rs. in Lakhs)</th>
+                <th style="text-align:center;">No of village covered</th>
+                <th style="text-align:center;">Total Expenditure (Rs. in Lakhs)</th>
             </tr>
-        </tbody>
-    </table>`;
-        });
+        </thead>
+        <tbody>`;
+
+    if (rows.length === 0) {
+        html += `<tr><td colspan="${colCount}" style="text-align:center;color:#666;font-style:italic;padding:12px;">No data available for this section.</td></tr>`;
     }
 
+    rows.forEach(row => {
+        const lead = isAgg
+            ? `<td>${this._escapeHtml(stateOf(row) || '-')}</td><td>${this._escapeHtml(kvkOf(row))}</td>`
+            : `<td>${this._escapeHtml(kvkOf(row))}</td>`;
+        html += `
+            <tr>
+                ${lead}
+                <td style="text-align:center;">${_num(row.vermiVillageCovered)}</td>
+                <td style="text-align:center;">${_num(row.vermiTotalExpenditure)}</td>
+                <td style="text-align:center;">${_num(row.otherVillageCovered)}</td>
+                <td style="text-align:center;">${_num(row.otherTotalExpenditure)}</td>
+            </tr>`;
+    });
+
     html += `
+        </tbody>
+    </table>
 </div>`;
     return html;
 }

--- a/backend/services/reports/formsTemplate/swachhtaTemplates/swachhtaPakhwadaTemplate.js
+++ b/backend/services/reports/formsTemplate/swachhtaTemplates/swachhtaPakhwadaTemplate.js
@@ -1,7 +1,8 @@
 /**
  * Observation of Swachta Pakhwada Template
- * Columns: Date/Duration of Observation | Total No of Activities undertaken |
- *          No. of Participants: Staffs | Farmers | Others | Total
+ *
+ * KVK side (single KVK)  : simple list — Date | Activities | Staffs | Farmers | Others | Total
+ * Super-admin (aggregated): structured — State | KVK prepended, sorted by State then KVK.
  */
 
 function _formatDate(v) {
@@ -11,20 +12,31 @@ function _formatDate(v) {
     return d.toLocaleDateString('en-IN', { year: 'numeric', month: '2-digit', day: '2-digit' });
 }
 
-function renderSwachhtaPakhwadaSection(section, data, sectionId, isFirstSection) {
+function renderSwachhtaPakhwadaSection(section, data, sectionId, isFirstSection, reportContext = {}) {
     const records = Array.isArray(data) ? data : (data ? [data] : []);
+    const isAgg = Boolean(reportContext.isAggregatedReport);
     const pageClass = isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued';
+
+    const stateOf = (r) => r.kvk?.state?.stateName || '';
+    const kvkOf = (r) => r.kvk?.kvkName || '-';
+    const rows = isAgg
+        ? [...records].sort((a, b) =>
+            (stateOf(a).localeCompare(stateOf(b))) || (kvkOf(a).localeCompare(kvkOf(b))))
+        : records;
+
+    const leadHead = isAgg
+        ? `<th rowspan="2" style="vertical-align:bottom;">State</th>
+                <th rowspan="2" style="vertical-align:bottom;">KVK</th>`
+        : '';
+    const colCount = isAgg ? 8 : 6;
 
     let html = `
 <div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title" style="margin-bottom:10px;">Observation of Swachta Pakhwada</h1>
+    <h1 class="section-title" style="margin-bottom:10px;">${section.id} ${this._escapeHtml(section.title)}</h1>
     <table class="data-table" style="width:100%;table-layout:fixed;">
-        <colgroup>
-            <col style="width:22%;"><col style="width:30%;">
-            <col style="width:12%;"><col style="width:12%;"><col style="width:12%;"><col style="width:12%;">
-        </colgroup>
         <thead>
             <tr>
+                ${leadHead}
                 <th rowspan="2" style="vertical-align:bottom;">Date/ Duration of Observation</th>
                 <th rowspan="2" style="vertical-align:bottom;">Total No of Activities undertaken</th>
                 <th colspan="4" style="text-align:center;">No. of Participants</th>
@@ -38,20 +50,24 @@ function renderSwachhtaPakhwadaSection(section, data, sectionId, isFirstSection)
         </thead>
         <tbody>`;
 
-    if (records.length === 0) {
-        html += `<tr><td colspan="6" style="text-align:center;color:#666;font-style:italic;padding:12px;">No data available for this section.</td></tr>`;
+    if (rows.length === 0) {
+        html += `<tr><td colspan="${colCount}" style="text-align:center;color:#666;font-style:italic;padding:12px;">No data available for this section.</td></tr>`;
     }
 
-    records.forEach(row => {
+    rows.forEach(row => {
         const date = _formatDate(row.observationDate);
         const activities = row.totalActivities != null ? row.totalActivities : 0;
         const staff = row.staffCount || 0;
         const farmers = row.farmerCount || 0;
         const others = row.othersCount || 0;
         const total = staff + farmers + others;
+        const lead = isAgg
+            ? `<td>${this._escapeHtml(stateOf(row) || '-')}</td><td>${this._escapeHtml(kvkOf(row))}</td>`
+            : '';
 
         html += `
             <tr>
+                ${lead}
                 <td>${this._escapeHtml(date)}</td>
                 <td style="text-align:center;">${activities}</td>
                 <td style="text-align:center;">${staff}</td>

--- a/backend/services/reports/formsTemplate/swachhtaTemplates/swachhtaSewaTemplate.js
+++ b/backend/services/reports/formsTemplate/swachhtaTemplates/swachhtaSewaTemplate.js
@@ -1,7 +1,8 @@
 /**
  * Observation of Swachhta hi Sewa SBA Template
- * Columns: KVK | Date/Duration of Observation | Total No of Activities undertaken |
- *          No. of Participants: Staffs | Farmers | Others | Total
+ *
+ * KVK side (single KVK)  : simple list — Date | Activities | Staffs | Farmers | Others | Total
+ * Super-admin (aggregated): structured — State | KVK prepended, sorted by State then KVK.
  */
 
 function _formatDate(v) {
@@ -11,21 +12,31 @@ function _formatDate(v) {
     return d.toLocaleDateString('en-IN', { year: 'numeric', month: '2-digit', day: '2-digit' });
 }
 
-function renderSwachhtaSewaSection(section, data, sectionId, isFirstSection) {
+function renderSwachhtaSewaSection(section, data, sectionId, isFirstSection, reportContext = {}) {
     const records = Array.isArray(data) ? data : (data ? [data] : []);
+    const isAgg = Boolean(reportContext.isAggregatedReport);
     const pageClass = isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued';
+
+    const stateOf = (r) => r.kvk?.state?.stateName || '';
+    const kvkOf = (r) => r.kvk?.kvkName || '-';
+    const rows = isAgg
+        ? [...records].sort((a, b) =>
+            (stateOf(a).localeCompare(stateOf(b))) || (kvkOf(a).localeCompare(kvkOf(b))))
+        : records;
+
+    const leadHead = isAgg
+        ? `<th rowspan="2" style="vertical-align:bottom;">State</th>
+                <th rowspan="2" style="vertical-align:bottom;">KVK</th>`
+        : `<th rowspan="2" style="vertical-align:bottom;">KVK</th>`;
+    const colCount = isAgg ? 8 : 7;
 
     let html = `
 <div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title" style="margin-bottom:10px;">Observation of Swachhta hi Sewa SBA</h1>
+    <h1 class="section-title" style="margin-bottom:10px;">${section.id} ${this._escapeHtml(section.title)}</h1>
     <table class="data-table" style="width:100%;table-layout:fixed;">
-        <colgroup>
-            <col style="width:12%;"><col style="width:20%;"><col style="width:28%;">
-            <col style="width:10%;"><col style="width:10%;"><col style="width:10%;"><col style="width:10%;">
-        </colgroup>
         <thead>
             <tr>
-                <th rowspan="2" style="vertical-align:bottom;">KVK</th>
+                ${leadHead}
                 <th rowspan="2" style="vertical-align:bottom;">Date/ Duration of Observation</th>
                 <th rowspan="2" style="vertical-align:bottom;">Total No of Activities undertaken</th>
                 <th colspan="4" style="text-align:center;">No. of Participants</th>
@@ -39,22 +50,24 @@ function renderSwachhtaSewaSection(section, data, sectionId, isFirstSection) {
         </thead>
         <tbody>`;
 
-    if (records.length === 0) {
-        html += `<tr><td colspan="7" style="text-align:center;color:#666;font-style:italic;padding:12px;">No data available for this section.</td></tr>`;
+    if (rows.length === 0) {
+        html += `<tr><td colspan="${colCount}" style="text-align:center;color:#666;font-style:italic;padding:12px;">No data available for this section.</td></tr>`;
     }
 
-    records.forEach(row => {
-        const kvk = row.kvk?.kvkName || '-';
+    rows.forEach(row => {
         const date = _formatDate(row.observationDate);
         const activities = row.totalActivities != null ? row.totalActivities : 0;
         const staff = row.staffCount || 0;
         const farmers = row.farmerCount || 0;
         const others = row.othersCount || 0;
         const total = staff + farmers + others;
+        const lead = isAgg
+            ? `<td>${this._escapeHtml(stateOf(row) || '-')}</td><td>${this._escapeHtml(kvkOf(row))}</td>`
+            : `<td>${this._escapeHtml(kvkOf(row))}</td>`;
 
         html += `
             <tr>
-                <td>${this._escapeHtml(kvk)}</td>
+                ${lead}
                 <td>${this._escapeHtml(date)}</td>
                 <td style="text-align:center;">${activities}</td>
                 <td style="text-align:center;">${staff}</td>

--- a/backend/services/reports/reportAggregationService.js
+++ b/backend/services/reports/reportAggregationService.js
@@ -695,19 +695,37 @@ class ReportAggregationService {
                 });
                 return districts.map(d => ({ id: d.districtId, name: d.districtName }));
 
-            case 'districts':
+            case 'districts': {
                 // Get orgs for selected districts (handle null districtId)
                 const orgs = await prisma.orgMaster.findMany({
-                    where: { 
-                        districtId: { 
+                    where: {
+                        districtId: {
                             in: parentIds,
-                            not: null 
-                        } 
+                            not: null
+                        }
                     },
-                    select: { orgId: true, orgName: true },
+                    select: {
+                        orgId: true,
+                        orgName: true,
+                        district: { select: { districtName: true } },
+                    },
                     orderBy: { orgName: 'asc' },
                 });
-                return orgs.map(o => ({ id: o.orgId, name: o.orgName || 'Unknown' }));
+                // The same org name can exist once per district (e.g. ICAR in two
+                // districts). Append the district to disambiguate duplicates so the
+                // scope list doesn't show identical-looking rows.
+                const nameCounts = {};
+                orgs.forEach(o => {
+                    const n = o.orgName || 'Unknown';
+                    nameCounts[n] = (nameCounts[n] || 0) + 1;
+                });
+                return orgs.map(o => {
+                    const base = o.orgName || 'Unknown';
+                    const dist = o.district?.districtName;
+                    const name = nameCounts[base] > 1 && dist ? `${base} (${dist})` : base;
+                    return { id: o.orgId, name };
+                });
+            }
 
             case 'orgs':
                 // Get KVKs for selected orgs

--- a/backend/services/reports/reportAggregationService.js
+++ b/backend/services/reports/reportAggregationService.js
@@ -134,7 +134,10 @@ class ReportAggregationService {
         }
 
         if (orgIds && orgIds.length > 0) {
-            where.orgId = { in: orgIds };
+            // A selected org represents an org "type" (by name); include every
+            // org of that name, not just the picked representative row.
+            const names = await this._orgNamesForIds(orgIds);
+            if (names.length) where.org = { orgName: { in: names } };
         }
 
         const kvks = await prisma.kvk.findMany({
@@ -143,6 +146,16 @@ class ReportAggregationService {
         });
 
         return kvks.map(k => k.kvkId);
+    }
+
+    /** Map selected org representative ids → the distinct org names they cover. */
+    async _orgNamesForIds(orgIds) {
+        if (!orgIds || orgIds.length === 0) return [];
+        const orgs = await prisma.orgMaster.findMany({
+            where: { orgId: { in: orgIds } },
+            select: { orgName: true },
+        });
+        return [...new Set(orgs.map(o => o.orgName).filter(Boolean))];
     }
 
     /**
@@ -696,45 +709,37 @@ class ReportAggregationService {
                 return districts.map(d => ({ id: d.districtId, name: d.districtName }));
 
             case 'districts': {
-                // Get orgs for selected districts (handle null districtId)
+                // Orgs are stored once per district, so the same org "type"
+                // (ICAR, NGO, SAU, CAU) repeats. Collapse to one option per name
+                // — selecting it expands to every org of that name (see
+                // _orgNamesForIds usage in scope→KVK resolution).
                 const orgs = await prisma.orgMaster.findMany({
-                    where: {
-                        districtId: {
-                            in: parentIds,
-                            not: null
-                        }
-                    },
-                    select: {
-                        orgId: true,
-                        orgName: true,
-                        district: { select: { districtName: true } },
-                    },
+                    where: { districtId: { in: parentIds, not: null } },
+                    select: { orgId: true, orgName: true },
                     orderBy: { orgName: 'asc' },
                 });
-                // The same org name can exist once per district (e.g. ICAR in two
-                // districts). Append the district to disambiguate duplicates so the
-                // scope list doesn't show identical-looking rows.
-                const nameCounts = {};
-                orgs.forEach(o => {
-                    const n = o.orgName || 'Unknown';
-                    nameCounts[n] = (nameCounts[n] || 0) + 1;
-                });
-                return orgs.map(o => {
-                    const base = o.orgName || 'Unknown';
-                    const dist = o.district?.districtName;
-                    const name = nameCounts[base] > 1 && dist ? `${base} (${dist})` : base;
-                    return { id: o.orgId, name };
-                });
+                const seen = new Set();
+                const options = [];
+                for (const o of orgs) {
+                    const name = o.orgName || 'Unknown';
+                    if (seen.has(name)) continue;
+                    seen.add(name);
+                    options.push({ id: o.orgId, name }); // id = representative org of this name
+                }
+                return options;
             }
 
-            case 'orgs':
-                // Get KVKs for selected orgs
+            case 'orgs': {
+                // Selected org options are representatives of an org name; expand
+                // to every org of that name so all their KVKs are listed.
+                const names = await this._orgNamesForIds(parentIds);
                 const kvks = await prisma.kvk.findMany({
-                    where: { orgId: { in: parentIds } },
+                    where: names.length ? { org: { orgName: { in: names } } } : { orgId: { in: parentIds } },
                     select: { kvkId: true, kvkName: true },
                     orderBy: { kvkName: 'asc' },
                 });
                 return kvks.map(k => ({ id: k.kvkId, name: k.kvkName }));
+            }
 
             case 'states-for-districts':
                 // Get states for selected districts (for orgs that need state info)
@@ -787,7 +792,8 @@ class ReportAggregationService {
             where.districtId = { in: filters.districtIds };
         }
         if (filters.orgIds && filters.orgIds.length > 0) {
-            where.orgId = { in: filters.orgIds };
+            const names = await this._orgNamesForIds(filters.orgIds);
+            if (names.length) where.org = { orgName: { in: names } };
         }
 
         const kvks = await prisma.kvk.findMany({

--- a/backend/services/reports/reportExcelService.js
+++ b/backend/services/reports/reportExcelService.js
@@ -1,0 +1,256 @@
+const ExcelJS = require('exceljs');
+const reportTemplateService = require('./reportTemplateService.js');
+const { parseSectionHtml } = require('../../utils/htmlReportTableParser.js');
+
+/**
+ * Report Excel Service
+ *
+ * Builds the all-reports Excel export so it mirrors the PDF: one worksheet (tab)
+ * per rendered sub-section, grouped by chapter (an Index sheet links to each, and
+ * tabs are colour-coded per chapter). It reuses the SAME section HTML the PDF
+ * produces (via reportTemplateService.generateSectionChunks) and converts each
+ * section's tables to worksheet rows with one generic converter — so the Excel
+ * layout always tracks the PDF without per-section duplication.
+ */
+
+const HEADER_FILL = 'FFE8E8E8';
+const CHAPTER_TAB_COLORS = [
+    'FF1F6E43', 'FF2E7D32', 'FF00695C', 'FF5D4037',
+    'FF455A64', 'FF6A1B9A', 'FFAD1457', 'FFEF6C00',
+];
+const MAX_TAB = 31;
+const MAX_COL_WIDTH = 60;
+
+const thinBorder = {
+    top: { style: 'thin', color: { argb: 'FF000000' } },
+    left: { style: 'thin', color: { argb: 'FF000000' } },
+    bottom: { style: 'thin', color: { argb: 'FF000000' } },
+    right: { style: 'thin', color: { argb: 'FF000000' } },
+};
+
+/** Excel-safe, unique, ≤31-char worksheet name. */
+function sanitizeTabName(name, used) {
+    let base = String(name || 'Sheet')
+        // Excel forbids \ / ? * [ ] : in sheet names; apostrophes break the
+        // internal hyperlink reference (#'Sheet'!A1), so drop them too.
+        .replace(/['\\/?*[\]:]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, MAX_TAB) || 'Sheet';
+    let candidate = base;
+    let i = 1;
+    while (used.has(candidate.toLowerCase())) {
+        const suffix = ` (${++i})`;
+        candidate = `${base.slice(0, MAX_TAB - suffix.length)}${suffix}`;
+    }
+    used.add(candidate.toLowerCase());
+    return candidate;
+}
+
+function isNumericText(text) {
+    if (text === '' || text == null) return false;
+    // Allow plain integers/decimals (no thousands separators, currency, units).
+    return /^-?\d+(\.\d+)?$/.test(String(text).trim());
+}
+
+function setCellValue(cell, text) {
+    if (isNumericText(text)) {
+        cell.value = Number(text);
+    } else if (text === '—' || text === '-') {
+        cell.value = text;
+    } else {
+        cell.value = text;
+    }
+}
+
+/**
+ * Write one parsed table into the worksheet starting at `startRow`, reproducing
+ * colspan/rowspan as merged cells. Returns the next free row index.
+ */
+function writeTable(ws, table, startRow, widthTracker) {
+    const occupied = new Set(); // "row,col" cells covered by a previous rowspan
+    let rowIdx = startRow;
+
+    for (const row of table.rows) {
+        let col = 1;
+        for (const cell of row) {
+            while (occupied.has(`${rowIdx},${col}`)) col += 1;
+
+            const top = ws.getCell(rowIdx, col);
+            setCellValue(top, cell.text);
+            top.alignment = { vertical: 'middle', horizontal: cell.header ? 'center' : 'left', wrapText: true };
+            top.border = thinBorder;
+            if (cell.header) {
+                top.font = { bold: true };
+                top.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: HEADER_FILL } };
+            }
+
+            const lastRow = rowIdx + cell.rowspan - 1;
+            const lastCol = col + cell.colspan - 1;
+            if (cell.rowspan > 1 || cell.colspan > 1) {
+                ws.mergeCells(rowIdx, col, lastRow, lastCol);
+            }
+            for (let r = rowIdx; r <= lastRow; r += 1) {
+                for (let c = col; c <= lastCol; c += 1) {
+                    occupied.add(`${r},${c}`);
+                    // Borders on merged-away cells so the grid looks complete.
+                    if (r !== rowIdx || c !== col) ws.getCell(r, c).border = thinBorder;
+                }
+            }
+
+            // Track width by the widest single column the cell starts in.
+            const estimate = Math.min(MAX_COL_WIDTH, Math.max(8, String(cell.text).length + 2));
+            widthTracker[col] = Math.max(widthTracker[col] || 0, cell.header ? Math.min(estimate, 24) : estimate);
+
+            col = lastCol + 1;
+        }
+        rowIdx += 1;
+    }
+    return rowIdx;
+}
+
+/** Write a section's headings + all its tables into a worksheet. */
+function writeSection(ws, chunk) {
+    const { headings, tables } = parseSectionHtml(chunk.html);
+    const widthTracker = {};
+    let rowIdx = 1;
+
+    // Title line (number + title), then any descriptive sub-headings.
+    const title = `${chunk.featureNumber || chunk.sectionNumber} ${chunk.featureTitle || chunk.sectionTitle}`.trim();
+    const titleCell = ws.getCell(rowIdx, 1);
+    titleCell.value = title;
+    titleCell.font = { bold: true, size: 13, color: { argb: 'FF1F6E43' } };
+    rowIdx += 1;
+    for (const h of headings) {
+        // Skip the heading that merely repeats the title we already printed.
+        if (h === title || h === (chunk.featureTitle || chunk.sectionTitle)) continue;
+        ws.getCell(rowIdx, 1).value = h;
+        ws.getCell(rowIdx, 1).font = { italic: true, color: { argb: 'FF555555' } };
+        rowIdx += 1;
+    }
+    rowIdx += 1; // spacer
+
+    if (tables.length === 0) {
+        ws.getCell(rowIdx, 1).value = 'No data available for this section.';
+        ws.getCell(rowIdx, 1).font = { italic: true, color: { argb: 'FF888888' } };
+        ws.getColumn(1).width = 40;
+        return;
+    }
+
+    for (const table of tables) {
+        rowIdx = writeTable(ws, table, rowIdx, widthTracker);
+        rowIdx += 1; // blank row between tables
+    }
+
+    for (const [colStr, width] of Object.entries(widthTracker)) {
+        ws.getColumn(Number(colStr)).width = width;
+    }
+    ws.views = [{ state: 'frozen', ySplit: 0 }];
+}
+
+/** Build the Index sheet: chapters → groups → features, each linking to a tab. */
+function writeIndexSheet(ws, kvkInfo, numbering, sheetBySectionId) {
+    ws.getColumn(1).width = 12;
+    ws.getColumn(2).width = 70;
+    let r = 1;
+    ws.getCell(r, 1).value = 'KVK Comprehensive Report';
+    ws.getCell(r, 1).font = { bold: true, size: 16, color: { argb: 'FF1F6E43' } };
+    r += 1;
+    if (kvkInfo?.kvkName) {
+        ws.getCell(r, 1).value = kvkInfo.kvkName;
+        ws.getCell(r, 1).font = { bold: true, size: 12 };
+        r += 1;
+    }
+    r += 1;
+    ws.getCell(r, 1).value = 'Table of Contents';
+    ws.getCell(r, 1).font = { bold: true, size: 13 };
+    r += 2;
+
+    const linkRow = (number, label, sectionId, opts = {}) => {
+        const numCell = ws.getCell(r, 1);
+        const labelCell = ws.getCell(r, 2);
+        numCell.value = number ? String(number) : '';
+        const tab = sectionId ? sheetBySectionId[String(sectionId)] : null;
+        if (tab) {
+            labelCell.value = { text: label, hyperlink: `#'${tab}'!A1` };
+            labelCell.font = { color: { argb: 'FF1F6E43' }, underline: true, bold: !!opts.bold };
+        } else {
+            labelCell.value = label;
+            labelCell.font = { bold: !!opts.bold, color: opts.muted ? { argb: 'FF999999' } : undefined };
+        }
+        if (opts.indent) labelCell.alignment = { indent: opts.indent };
+        if (opts.bold) numCell.font = { bold: true };
+        r += 1;
+    };
+
+    for (const chapter of numbering.chapters) {
+        linkRow(`${chapter.number}.`, chapter.title, null, { bold: true });
+        if (chapter.type === 'grouped') {
+            for (const group of (chapter.groups || [])) {
+                const first = group.features[0] && group.features[0].sectionId;
+                linkRow(group.number, group.label, first, { bold: true, indent: 1 });
+                for (const feature of (group.features || [])) {
+                    if (!feature.label || !feature.number) continue;
+                    linkRow(feature.number, feature.label, feature.sectionId, {
+                        indent: 2,
+                        muted: !sheetBySectionId[String(feature.sectionId)],
+                    });
+                }
+            }
+        } else {
+            for (const s of (chapter.sections || [])) {
+                linkRow(s.number, s.title, s.sectionId, { indent: 1 });
+            }
+        }
+    }
+}
+
+class ReportExcelService {
+    /**
+     * Generate the structured all-reports Excel workbook.
+     * @returns {Promise<Buffer>}
+     */
+    async generateReportExcel(kvkInfo, sectionsData, _filters = {}, generatedBy = 'System') {
+        const reportContext = {
+            isAggregatedReport: kvkInfo?.kvkId === null || kvkInfo?.kvkId === undefined,
+            isStandalone: false,
+        };
+        const { numbering, chunks } = await reportTemplateService.generateSectionChunks(
+            sectionsData,
+            reportContext,
+        );
+
+        const workbook = new ExcelJS.Workbook();
+        workbook.creator = generatedBy;
+        workbook.created = new Date(0); // deterministic; avoids Date.now in service layer
+
+        const indexSheet = workbook.addWorksheet('Index', { properties: { tabColor: { argb: 'FF263238' } } });
+
+        // Map each chapter to a stable tab colour for visual grouping.
+        const chapterColor = new Map();
+        const usedTabNames = new Set(['index']);
+        const sheetBySectionId = {};
+
+        for (const chunk of chunks) {
+            if (!chapterColor.has(chunk.chapter)) {
+                chapterColor.set(chunk.chapter, CHAPTER_TAB_COLORS[chapterColor.size % CHAPTER_TAB_COLORS.length]);
+            }
+            const tabBase = `${chunk.featureNumber || chunk.sectionNumber} ${chunk.featureTitle || chunk.sectionTitle}`;
+            const tabName = sanitizeTabName(tabBase, usedTabNames);
+            sheetBySectionId[String(chunk.sectionId)] = tabName;
+
+            const ws = workbook.addWorksheet(tabName, {
+                properties: { tabColor: { argb: chapterColor.get(chunk.chapter) } },
+                pageSetup: { fitToPage: true, fitToWidth: 1, fitToHeight: 0 },
+            });
+            writeSection(ws, chunk);
+        }
+
+        writeIndexSheet(indexSheet, kvkInfo, numbering, sheetBySectionId);
+
+        const buffer = await workbook.xlsx.writeBuffer();
+        return Buffer.from(buffer);
+    }
+}
+
+module.exports = new ReportExcelService();

--- a/backend/services/reports/reportService.js
+++ b/backend/services/reports/reportService.js
@@ -1,6 +1,7 @@
 const reportDataService = require('./reportDataService.js');
 const pdfGenerationService = require('./pdfGenerationService.js');
 const reportExcelService = require('./reportExcelService.js');
+const reportWordService = require('./reportWordService.js');
 const reportAggregationService = require('./reportAggregationService.js');
 const { validateSectionIds, getAllSections } = require('../../config/reportConfig.js');
 
@@ -68,6 +69,23 @@ class ReportService {
         const excelBuffer = await reportExcelService.generateReportExcel(kvkInfo, sectionsData, filters, generatedBy);
 
         return { excelBuffer, kvkInfo, sectionsData };
+    }
+
+    /**
+     * Generate KVK report as a Word document (same structure as the PDF).
+     */
+    async generateKvkReportWord(kvkId, options = {}) {
+        const { sectionIds = [], filters = {}, generatedBy = 'System' } = options;
+        if (sectionIds.length === 0) {
+            sectionIds.push(...getAllSections().map(s => s.id));
+        }
+        validateSectionIds(sectionIds);
+
+        const kvkInfo = await reportDataService.getKvkInfoForHeader(kvkId);
+        const sectionsData = await reportDataService.getMultipleSectionData(sectionIds, kvkId, filters);
+        const wordBuffer = await reportWordService.generateReportWord(kvkInfo, sectionsData, filters, generatedBy);
+
+        return { wordBuffer, kvkInfo, sectionsData };
     }
 
     /**
@@ -191,6 +209,28 @@ class ReportService {
         const excelBuffer = await reportExcelService.generateReportExcel(kvkInfo, sectionsData, filters, generatedBy);
 
         return { excelBuffer, kvkInfo, sectionsData, kvkCount: kvkIds.length };
+    }
+
+    /**
+     * Generate aggregated (super-admin) report as a Word document (matches PDF).
+     */
+    async generateAggregatedReportWord(scope, options = {}) {
+        const { sectionIds = [], filters = {}, generatedBy = 'System' } = options;
+        if (sectionIds.length === 0) {
+            sectionIds.push(...getAllSections().map(s => s.id));
+        }
+        validateSectionIds(sectionIds);
+
+        const kvkIds = await reportAggregationService.getKvkIdsForScope(scope);
+        if (kvkIds.length === 0) {
+            throw new Error('No KVKs found for the selected scope');
+        }
+
+        const sectionsData = await reportAggregationService.aggregateMultipleSections(sectionIds, kvkIds, filters);
+        const kvkInfo = await this._buildAggregatedKvkInfo(scope, kvkIds);
+        const wordBuffer = await reportWordService.generateReportWord(kvkInfo, sectionsData, filters, generatedBy);
+
+        return { wordBuffer, kvkInfo, sectionsData, kvkCount: kvkIds.length };
     }
 
     /**

--- a/backend/services/reports/reportService.js
+++ b/backend/services/reports/reportService.js
@@ -1,5 +1,6 @@
 const reportDataService = require('./reportDataService.js');
 const pdfGenerationService = require('./pdfGenerationService.js');
+const reportExcelService = require('./reportExcelService.js');
 const reportAggregationService = require('./reportAggregationService.js');
 const { validateSectionIds, getAllSections } = require('../../config/reportConfig.js');
 
@@ -50,6 +51,23 @@ class ReportService {
             kvkInfo,
             sectionsData,
         };
+    }
+
+    /**
+     * Generate KVK report as a structured Excel workbook (same structure as PDF).
+     */
+    async generateKvkReportExcel(kvkId, options = {}) {
+        const { sectionIds = [], filters = {}, generatedBy = 'System' } = options;
+        if (sectionIds.length === 0) {
+            sectionIds.push(...getAllSections().map(s => s.id));
+        }
+        validateSectionIds(sectionIds);
+
+        const kvkInfo = await reportDataService.getKvkInfoForHeader(kvkId);
+        const sectionsData = await reportDataService.getMultipleSectionData(sectionIds, kvkId, filters);
+        const excelBuffer = await reportExcelService.generateReportExcel(kvkInfo, sectionsData, filters, generatedBy);
+
+        return { excelBuffer, kvkInfo, sectionsData };
     }
 
     /**
@@ -151,6 +169,28 @@ class ReportService {
             sectionsData,
             kvkCount: kvkIds.length,
         };
+    }
+
+    /**
+     * Generate aggregated (super-admin) report as a structured Excel workbook.
+     */
+    async generateAggregatedReportExcel(scope, options = {}) {
+        const { sectionIds = [], filters = {}, generatedBy = 'System' } = options;
+        if (sectionIds.length === 0) {
+            sectionIds.push(...getAllSections().map(s => s.id));
+        }
+        validateSectionIds(sectionIds);
+
+        const kvkIds = await reportAggregationService.getKvkIdsForScope(scope);
+        if (kvkIds.length === 0) {
+            throw new Error('No KVKs found for the selected scope');
+        }
+
+        const sectionsData = await reportAggregationService.aggregateMultipleSections(sectionIds, kvkIds, filters);
+        const kvkInfo = await this._buildAggregatedKvkInfo(scope, kvkIds);
+        const excelBuffer = await reportExcelService.generateReportExcel(kvkInfo, sectionsData, filters, generatedBy);
+
+        return { excelBuffer, kvkInfo, sectionsData, kvkCount: kvkIds.length };
     }
 
     /**

--- a/backend/services/reports/reportTemplateService.js
+++ b/backend/services/reports/reportTemplateService.js
@@ -242,7 +242,9 @@ class ReportTemplateService {
             isStandalone: false,
         };
         // Filter sections that have valid data (not errors, not null/undefined)
+        // and aren't explicitly excluded from the report index.
         const selectedSections = sections.filter(s => {
+            if (s.hideInReport) return false;
             const sectionData = sectionsData[s.id];
             return sectionData &&
                 !sectionData.error &&
@@ -253,7 +255,30 @@ class ReportTemplateService {
         // Curated/clean index numbering (raw section.id values are unreliable).
         const numbering = buildSectionNumbering(selectedSections);
 
-        const sectionsBody = await this._generateSectionPages(selectedSections, sectionsData, reportContext, numbering.headingById);
+        // Render the section pages in the SAME order as the curated index
+        // (taxonomy), not raw section-id order — otherwise e.g. HR Development
+        // (2.59) prints before Awards (2.56), and soil-water lands out of place.
+        const orderIndex = new Map();
+        let _oi = 0;
+        for (const chapter of numbering.chapters) {
+            if (chapter.type === 'grouped') {
+                for (const group of (chapter.groups || [])) {
+                    for (const feature of (group.features || [])) {
+                        const sid = String(feature.sectionId);
+                        if (sid && !orderIndex.has(sid)) orderIndex.set(sid, _oi++);
+                    }
+                }
+            } else {
+                for (const s of (chapter.sections || [])) {
+                    const sid = String(s.sectionId);
+                    if (sid && !orderIndex.has(sid)) orderIndex.set(sid, _oi++);
+                }
+            }
+        }
+        const orderRank = (id) => (orderIndex.has(String(id)) ? orderIndex.get(String(id)) : Number.MAX_SAFE_INTEGER);
+        const orderedSections = [...selectedSections].sort((a, b) => orderRank(a.id) - orderRank(b.id));
+
+        const sectionsBody = await this._generateSectionPages(orderedSections, sectionsData, reportContext, numbering.headingById);
 
         const html = `
 <!DOCTYPE html>
@@ -386,11 +411,16 @@ class ReportTemplateService {
         </li>`;
 
             if (chapter.type === 'grouped') {
-                // TOC lists section (group) level only, e.g. "1.1 Basic Information".
-                // The lettered features (sub-sections) appear only as body headings.
+                // List the group row (e.g. "2.2 On Farm Trial") followed by its
+                // lettered features (e.g. "2.2.A OFT Summary"), each a clickable
+                // link that jumps to the backing section.
                 chapter.groups.forEach((group) => {
                     const firstSection = group.features[0] && group.features[0].sectionId;
-                    tocHtml += tocItem(group.number, group.label, firstSection, '');
+                    tocHtml += tocItem(group.number, group.label, firstSection, 'toc-group');
+                    group.features.forEach((feature) => {
+                        if (!feature.label || !feature.number) return;
+                        tocHtml += tocItem(feature.number, feature.label, feature.sectionId, 'toc-subitem');
+                    });
                 });
             } else {
                 chapter.sections.forEach((s) => {
@@ -1121,6 +1151,25 @@ class ReportTemplateService {
 
     .toc-feature {
         margin-left: 34px;
+    }
+
+    .toc-item.toc-group {
+        margin-left: 18px;
+    }
+
+    .toc-item.toc-group .toc-section-id,
+    .toc-item.toc-group .toc-section-title {
+        font-weight: bold;
+    }
+
+    .toc-item.toc-subitem {
+        margin-left: 40px;
+    }
+
+    .toc-item.toc-subitem .toc-section-id,
+    .toc-item.toc-subitem .toc-section-title {
+        font-weight: normal;
+        font-size: 7.5pt;
     }
 
     .toc-link {

--- a/backend/services/reports/reportTemplateService.js
+++ b/backend/services/reports/reportTemplateService.js
@@ -235,14 +235,13 @@ class ReportTemplateService {
     /**
      * Generate complete HTML for the report
      */
-    async generateReportHTML(kvkInfo, sectionsData, filters, generatedBy) {
+    /**
+     * Pick the sections that have data (and aren't excluded), and order them to
+     * match the curated taxonomy index. Shared by the PDF and Excel exports so
+     * both use the exact same section set, order, and numbering.
+     */
+    _selectAndOrderSections(sectionsData) {
         const sections = getAllSections();
-        const reportContext = {
-            isAggregatedReport: kvkInfo?.kvkId === null || kvkInfo?.kvkId === undefined,
-            isStandalone: false,
-        };
-        // Filter sections that have valid data (not errors, not null/undefined)
-        // and aren't explicitly excluded from the report index.
         const selectedSections = sections.filter(s => {
             if (s.hideInReport) return false;
             const sectionData = sectionsData[s.id];
@@ -255,30 +254,48 @@ class ReportTemplateService {
         // Curated/clean index numbering (raw section.id values are unreliable).
         const numbering = buildSectionNumbering(selectedSections);
 
-        // Render the section pages in the SAME order as the curated index
-        // (taxonomy), not raw section-id order — otherwise e.g. HR Development
-        // (2.59) prints before Awards (2.56), and soil-water lands out of place.
+        // Order to match the curated index (taxonomy), not raw section-id order —
+        // otherwise e.g. HR (2.59) prints before Awards (2.56).
         const orderIndex = new Map();
-        let _oi = 0;
+        let oi = 0;
         for (const chapter of numbering.chapters) {
-            if (chapter.type === 'grouped') {
-                for (const group of (chapter.groups || [])) {
-                    for (const feature of (group.features || [])) {
-                        const sid = String(feature.sectionId);
-                        if (sid && !orderIndex.has(sid)) orderIndex.set(sid, _oi++);
-                    }
-                }
-            } else {
-                for (const s of (chapter.sections || [])) {
-                    const sid = String(s.sectionId);
-                    if (sid && !orderIndex.has(sid)) orderIndex.set(sid, _oi++);
+            const featureLists = chapter.type === 'grouped'
+                ? (chapter.groups || []).map(g => g.features || [])
+                : [(chapter.sections || [])];
+            for (const list of featureLists) {
+                for (const f of list) {
+                    const sid = String(f.sectionId);
+                    if (sid && !orderIndex.has(sid)) orderIndex.set(sid, oi++);
                 }
             }
         }
-        const orderRank = (id) => (orderIndex.has(String(id)) ? orderIndex.get(String(id)) : Number.MAX_SAFE_INTEGER);
-        const orderedSections = [...selectedSections].sort((a, b) => orderRank(a.id) - orderRank(b.id));
+        const rank = (id) => (orderIndex.has(String(id)) ? orderIndex.get(String(id)) : Number.MAX_SAFE_INTEGER);
+        const orderedSections = [...selectedSections].sort((a, b) => rank(a.id) - rank(b.id));
 
-        const sectionsBody = await this._generateSectionPages(orderedSections, sectionsData, reportContext, numbering.headingById);
+        return { orderedSections, numbering };
+    }
+
+    /**
+     * Render every selected section to its own HTML chunk plus index metadata.
+     * Returns { numbering, chunks: [{ sectionId, chapter, sectionNumber,
+     * sectionTitle, featureNumber, featureTitle, html }] }. Used by both the PDF
+     * (chunks joined) and the Excel export (one sheet per chunk).
+     */
+    async generateSectionChunks(sectionsData, reportContext = {}) {
+        const { orderedSections, numbering } = this._selectAndOrderSections(sectionsData);
+        const chunks = await this._renderSectionChunks(
+            orderedSections, sectionsData, reportContext, numbering.headingById,
+        );
+        return { numbering, chunks };
+    }
+
+    async generateReportHTML(kvkInfo, sectionsData, filters, generatedBy) {
+        const reportContext = {
+            isAggregatedReport: kvkInfo?.kvkId === null || kvkInfo?.kvkId === undefined,
+            isStandalone: false,
+        };
+        const { numbering, chunks } = await this.generateSectionChunks(sectionsData, reportContext);
+        const sectionsBody = chunks.map(c => c.html).join('');
 
         const html = `
 <!DOCTYPE html>
@@ -437,10 +454,13 @@ class ReportTemplateService {
     }
 
     /**
-     * Generate section pages with unique IDs for TOC linking
+     * Render each selected section to its own HTML chunk (with chapter/feature
+     * headers applied) plus the index metadata for that section. Returns an array
+     * of { sectionId, chapter, sectionNumber, sectionTitle, featureNumber,
+     * featureTitle, html }.
      */
-    async _generateSectionPages(selectedSections, sectionsData, reportContext = {}, headingById = new Map()) {
-        let html = '';
+    async _renderSectionChunks(selectedSections, sectionsData, reportContext = {}, headingById = new Map()) {
+        const chunks = [];
         let isFirstSection = true;
         const seenChapters = new Set(); // chapter header shown once per chapter
         const seenSections = new Set(); // section (group) heading shown once per group
@@ -490,11 +510,19 @@ class ReportTemplateService {
                 }
             }
 
-            html += this._withSectionHeaders(chunk || '', heading, seenChapters, firstInGroup);
+            chunks.push({
+                sectionId: rawSection.id,
+                chapter: heading?.chapter || '',
+                sectionNumber: heading?.sectionNumber || rawSection.id,
+                sectionTitle: heading?.sectionTitle || rawSection.title,
+                featureNumber: heading?.featureNumber || null,
+                featureTitle: heading?.featureTitle || null,
+                html: this._withSectionHeaders(chunk || '', heading, seenChapters, firstInGroup),
+            });
             isFirstSection = false;
         }
 
-        return html;
+        return chunks;
     }
 
     /**

--- a/backend/services/reports/reportWordService.js
+++ b/backend/services/reports/reportWordService.js
@@ -1,0 +1,213 @@
+const {
+    Document,
+    Packer,
+    Paragraph,
+    TextRun,
+    HeadingLevel,
+    AlignmentType,
+    Table,
+    TableRow,
+    TableCell,
+    WidthType,
+    VerticalMerge,
+    ShadingType,
+    BorderStyle,
+    InternalHyperlink,
+    Bookmark,
+    PageBreak,
+} = require('docx');
+const reportTemplateService = require('./reportTemplateService.js');
+const { parseSectionHtml } = require('../../utils/htmlReportTableParser.js');
+
+/**
+ * Report Word (DOCX) Service
+ *
+ * Builds the all-reports Word export to match the PDF exactly: a cover, a
+ * clickable Table of Contents, then every rendered section in the same order
+ * and numbering, with the same tables. Like the Excel export it reuses the PDF
+ * section HTML (reportTemplateService.generateSectionChunks) and the shared
+ * htmlReportTableParser — one converter for all ~50 templates, no duplication.
+ */
+
+const HEADER_SHADE = 'E8E8E8';
+const CELL_BORDER = { style: BorderStyle.SINGLE, size: 4, color: '000000' };
+const CELL_BORDERS = { top: CELL_BORDER, bottom: CELL_BORDER, left: CELL_BORDER, right: CELL_BORDER };
+
+function bookmarkIdFor(sectionId) {
+    return `sec_${String(sectionId).replace(/[^a-zA-Z0-9]/g, '_')}`;
+}
+
+function textCell(text, { colSpan = 1, vMerge = null, header = false } = {}) {
+    const run = new TextRun({ text: String(text ?? ''), bold: header, size: 16 });
+    return new TableCell({
+        children: [new Paragraph({
+            children: [run],
+            alignment: header ? AlignmentType.CENTER : AlignmentType.LEFT,
+        })],
+        columnSpan: colSpan,
+        ...(vMerge ? { verticalMerge: vMerge } : {}),
+        ...(header ? { shading: { type: ShadingType.CLEAR, fill: HEADER_SHADE } } : {}),
+        borders: CELL_BORDERS,
+    });
+}
+
+/**
+ * Lay parsed cells (with colspan/rowspan) into a full grid, then emit docx
+ * TableRows using columnSpan (horizontal) + verticalMerge RESTART/CONTINUE
+ * (vertical) so merged cells render exactly like the PDF.
+ */
+function buildDocxTable(table) {
+    const grid = []; // grid[r][c] = { kind: 'anchor'|'vcont'|'hcovered', cell }
+    table.rows.forEach((row, r) => {
+        grid[r] = grid[r] || [];
+        let c = 0;
+        for (const cell of row) {
+            while (grid[r][c]) c += 1;
+            for (let dr = 0; dr < cell.rowspan; dr += 1) {
+                grid[r + dr] = grid[r + dr] || [];
+                for (let dc = 0; dc < cell.colspan; dc += 1) {
+                    grid[r + dr][c + dc] = (dr === 0 && dc === 0)
+                        ? { kind: 'anchor', cell }
+                        : (dc === 0 ? { kind: 'vcont', cell } : { kind: 'hcovered' });
+                }
+            }
+            c += cell.colspan;
+        }
+    });
+
+    const totalCols = grid.reduce((m, row) => Math.max(m, row.length), 0);
+
+    const tableRows = grid.map((row) => {
+        const cells = [];
+        let c = 0;
+        while (c < totalCols) {
+            const g = row[c];
+            if (!g) { cells.push(textCell('', {})); c += 1; continue; }
+            if (g.kind === 'anchor') {
+                cells.push(textCell(g.cell.text, {
+                    colSpan: g.cell.colspan,
+                    vMerge: g.cell.rowspan > 1 ? VerticalMerge.RESTART : null,
+                    header: g.cell.header,
+                }));
+                c += g.cell.colspan;
+            } else if (g.kind === 'vcont') {
+                cells.push(textCell('', {
+                    colSpan: g.cell.colspan,
+                    vMerge: VerticalMerge.CONTINUE,
+                    header: g.cell.header,
+                }));
+                c += g.cell.colspan;
+            } else {
+                c += 1; // covered horizontally by an anchor's columnSpan
+            }
+        }
+        return new TableRow({ children: cells });
+    });
+
+    return new Table({
+        rows: tableRows,
+        width: { size: 100, type: WidthType.PERCENTAGE },
+    });
+}
+
+/** Build the document children for one section chunk. */
+function buildSectionChildren(chunk, isFirst) {
+    const { headings, tables } = parseSectionHtml(chunk.html);
+    const out = [];
+    const title = `${chunk.featureNumber || chunk.sectionNumber} ${chunk.featureTitle || chunk.sectionTitle}`.trim();
+
+    out.push(new Paragraph({
+        heading: HeadingLevel.HEADING_2,
+        ...(isFirst ? {} : { pageBreakBefore: true }),
+        children: [new Bookmark({ id: bookmarkIdFor(chunk.sectionId), children: [new TextRun({ text: title, bold: true })] })],
+    }));
+
+    for (const h of headings) {
+        if (h === title || h === (chunk.featureTitle || chunk.sectionTitle)) continue;
+        out.push(new Paragraph({ children: [new TextRun({ text: h, italics: true, color: '555555' })] }));
+    }
+
+    if (tables.length === 0) {
+        out.push(new Paragraph({ children: [new TextRun({ text: 'No data available for this section.', italics: true, color: '888888' })] }));
+        return out;
+    }
+    for (const table of tables) {
+        out.push(buildDocxTable(table));
+        out.push(new Paragraph({ children: [] })); // spacer
+    }
+    return out;
+}
+
+/** Cover + clickable Table of Contents. */
+function buildFrontMatter(kvkInfo, numbering, renderedSectionIds) {
+    const children = [
+        new Paragraph({ heading: HeadingLevel.TITLE, children: [new TextRun({ text: 'KVK Comprehensive Report', bold: true })] }),
+    ];
+    if (kvkInfo?.kvkName) {
+        children.push(new Paragraph({ children: [new TextRun({ text: kvkInfo.kvkName, bold: true, size: 24 })] }));
+    }
+    children.push(new Paragraph({ heading: HeadingLevel.HEADING_1, children: [new TextRun({ text: 'Table of Contents', bold: true })] }));
+
+    const tocLine = (number, label, sectionId, { bold = false, indent = 0 } = {}) => {
+        const text = `${number ? number + '  ' : ''}${label}`;
+        const child = (sectionId && renderedSectionIds.has(String(sectionId)))
+            ? new InternalHyperlink({ anchor: bookmarkIdFor(sectionId), children: [new TextRun({ text, bold, color: '1F6E43', underline: {} })] })
+            : new TextRun({ text, bold });
+        return new Paragraph({ children: [child], indent: { left: indent * 360 } });
+    };
+
+    for (const chapter of numbering.chapters) {
+        children.push(tocLine(`${chapter.number}.`, chapter.title, null, { bold: true }));
+        if (chapter.type === 'grouped') {
+            for (const group of (chapter.groups || [])) {
+                const first = group.features[0] && group.features[0].sectionId;
+                children.push(tocLine(group.number, group.label, first, { bold: true, indent: 1 }));
+                for (const f of (group.features || [])) {
+                    if (!f.label || !f.number) continue;
+                    children.push(tocLine(f.number, f.label, f.sectionId, { indent: 2 }));
+                }
+            }
+        } else {
+            for (const s of (chapter.sections || [])) {
+                children.push(tocLine(s.number, s.title, s.sectionId, { indent: 1 }));
+            }
+        }
+    }
+    children.push(new Paragraph({ children: [new PageBreak()] }));
+    return children;
+}
+
+class ReportWordService {
+    /**
+     * Generate the structured all-reports Word document (matches the PDF).
+     * @returns {Promise<Buffer>}
+     */
+    async generateReportWord(kvkInfo, sectionsData, _filters = {}, generatedBy = 'System') {
+        const reportContext = {
+            isAggregatedReport: kvkInfo?.kvkId === null || kvkInfo?.kvkId === undefined,
+            isStandalone: false,
+        };
+        const { numbering, chunks } = await reportTemplateService.generateSectionChunks(
+            sectionsData,
+            reportContext,
+        );
+
+        const renderedSectionIds = new Set(chunks.map(c => String(c.sectionId)));
+        const body = [
+            ...buildFrontMatter(kvkInfo, numbering, renderedSectionIds),
+        ];
+        chunks.forEach((chunk, i) => {
+            body.push(...buildSectionChildren(chunk, i === 0));
+        });
+
+        const doc = new Document({
+            creator: generatedBy,
+            title: 'KVK Comprehensive Report',
+            sections: [{ children: body }],
+        });
+
+        return Packer.toBuffer(doc);
+    }
+}
+
+module.exports = new ReportWordService();

--- a/backend/utils/htmlReportTableParser.js
+++ b/backend/utils/htmlReportTableParser.js
@@ -1,0 +1,99 @@
+/**
+ * htmlReportTableParser
+ *
+ * Dependency-free parser that turns a rendered report-section HTML chunk (the
+ * exact same HTML the PDF uses) into structured headings + tables, so the Excel
+ * export can mirror the PDF layout with one reusable converter instead of a
+ * bespoke renderer per section.
+ *
+ * Output shape:
+ *   {
+ *     headings: string[],                       // section title + sub-titles
+ *     tables: [{ rows: [ [cell, ...], ... ] }]  // each cell: { text, colspan, rowspan, header }
+ *   }
+ *
+ * Cells keep their colspan/rowspan so the writer can reproduce merged cells.
+ */
+
+function decodeEntities(text) {
+    return String(text)
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#0?39;/g, "'")
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)));
+}
+
+function stripTags(html) {
+    return decodeEntities(
+        String(html)
+            .replace(/<br\s*\/?>/gi, ' ')
+            .replace(/<[^>]+>/g, ''),
+    ).replace(/\s+/g, ' ').trim();
+}
+
+function getAttr(attrs, name) {
+    const m = String(attrs).match(new RegExp(`${name}\\s*=\\s*"([^"]*)"`, 'i'));
+    return m ? m[1] : null;
+}
+
+function toSpan(value) {
+    const n = parseInt(value || '1', 10);
+    return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+function extractHeadings(cleanHtml) {
+    const headings = [];
+    const push = (raw) => {
+        const t = stripTags(raw);
+        if (t && !headings.includes(t)) headings.push(t);
+    };
+    let m;
+    const headingRe = /<(h1|h2|h3)\b[^>]*>([\s\S]*?)<\/\1>/gi;
+    while ((m = headingRe.exec(cleanHtml))) push(m[2]);
+    // Descriptive sub-titles/captions templates render as <div>/<p>.
+    const subRe = /<(div|p)\b[^>]*class="[^"]*(?:subtitle|sub-title|caption|page-sub|page-sec|nbf-subtitle)[^"]*"[^>]*>([\s\S]*?)<\/\1>/gi;
+    while ((m = subRe.exec(cleanHtml))) push(m[2]);
+    return headings;
+}
+
+function parseTable(innerHtml) {
+    const theadMatch = innerHtml.match(/<thead\b[^>]*>([\s\S]*?)<\/thead>/i);
+    const theadHtml = theadMatch ? theadMatch[1] : '';
+    const rows = [];
+    const trRe = /<tr\b[^>]*>([\s\S]*?)<\/tr>/gi;
+    let tr;
+    while ((tr = trRe.exec(innerHtml))) {
+        const isHeaderRow = theadHtml.includes(tr[0]);
+        const cells = [];
+        const cellRe = /<(th|td)\b([^>]*)>([\s\S]*?)<\/\1>/gi;
+        let c;
+        while ((c = cellRe.exec(tr[1]))) {
+            cells.push({
+                text: stripTags(c[3]),
+                colspan: toSpan(getAttr(c[2], 'colspan')),
+                rowspan: toSpan(getAttr(c[2], 'rowspan')),
+                header: c[1].toLowerCase() === 'th' || isHeaderRow,
+            });
+        }
+        if (cells.length) rows.push(cells);
+    }
+    return rows.length ? { rows } : null;
+}
+
+function parseSectionHtml(html) {
+    const clean = String(html || '').replace(/<style[\s\S]*?<\/style>/gi, '');
+    const headings = extractHeadings(clean);
+    const tables = [];
+    const tableRe = /<table\b[^>]*>([\s\S]*?)<\/table>/gi;
+    let m;
+    while ((m = tableRe.exec(clean))) {
+        const table = parseTable(m[1]);
+        if (table) tables.push(table);
+    }
+    return { headings, tables };
+}
+
+module.exports = { parseSectionHtml, stripTags, decodeEntities };

--- a/backend/utils/soilWaterEquipmentPageExport.js
+++ b/backend/utils/soilWaterEquipmentPageExport.js
@@ -11,7 +11,7 @@ const {
     HeadingLevel,
 } = require('docx');
 
-const MAIN_TITLE = '7. SOIL & WATER TESTING';
+const MAIN_TITLE = '2.7. SOIL & WATER TESTING';
 const SUB_TITLE = 'A. Details of equipment available in Soil and Water Testing Laboratory.';
 
 function isAggregatedPayload(payload) {

--- a/frontend/src/components/reports/ReportModuleSelector.tsx
+++ b/frontend/src/components/reports/ReportModuleSelector.tsx
@@ -19,6 +19,8 @@ interface ReportModuleSelectorProps {
     selectedSections: Set<string>;
     onSectionToggle: (sectionId: string) => void;
     onCategorySelectAll: (sectionIds: string[]) => void;
+    onSelectAllForms?: () => void;
+    allFormsSelected?: boolean;
     collapsed?: boolean;
     onToggleCollapse?: () => void;
 }
@@ -28,6 +30,8 @@ export const ReportModuleSelector: React.FC<ReportModuleSelectorProps> = ({
     selectedSections,
     onSectionToggle,
     onCategorySelectAll,
+    onSelectAllForms,
+    allFormsSelected = false,
     collapsed = false,
     onToggleCollapse,
 }) => {
@@ -147,6 +151,18 @@ export const ReportModuleSelector: React.FC<ReportModuleSelectorProps> = ({
                         className="flex items-center gap-2"
                         onClick={event => event.stopPropagation()}
                     >
+                        {onSelectAllForms && (
+                            <button
+                                type="button"
+                                onClick={onSelectAllForms}
+                                className="h-8 px-3 rounded-lg border border-[#D8E3D8] bg-white text-[11px] font-medium text-[#487749] hover:bg-[#F5FAF5] flex items-center gap-1.5"
+                            >
+                                <div className={`w-3.5 h-3.5 rounded-sm border flex items-center justify-center ${allFormsSelected ? 'bg-[#487749] border-[#487749]' : 'bg-white border-[#D1D1D1]'}`}>
+                                    {allFormsSelected && <Check className="w-2.5 h-2.5 text-white" strokeWidth={5} />}
+                                </div>
+                                {allFormsSelected ? 'Clear all' : 'Select all'}
+                            </button>
+                        )}
                         <div className={`overflow-hidden transition-all duration-200 ease-out ${isSearchOpen ? 'w-44 opacity-100' : 'w-0 opacity-0'}`}>
                             <input
                                 id={searchInputId}

--- a/frontend/src/config/reportIndexTaxonomy.ts
+++ b/frontend/src/config/reportIndexTaxonomy.ts
@@ -156,12 +156,133 @@ export const REPORT_INDEX_TAXONOMY: Record<string, TaxonomyChapter> = {
             },
         ],
     },
+
+    // Mirrors backend REPORT_INDEX_TAXONOMY['3'] — keep sectionIds in sync.
+    projects: {
+        tabId: 'projects',
+        title: 'Projects',
+        groups: [
+            {
+                label: 'CFLD',
+                features: [
+                    { label: 'Technical Parameter', sectionId: '2.16' },
+                    { label: 'Extension Activity', sectionId: '2.17' },
+                    { label: 'Budget Utilization', sectionId: '2.18' },
+                ],
+            },
+            {
+                label: 'NICRA',
+                features: [
+                    { label: 'Basic Information', sectionId: '2.34' },
+                    { label: 'Details', sectionId: '' },
+                    { label: 'Training', sectionId: '2.35' },
+                    { label: 'Extension Activity', sectionId: '2.36' },
+                ],
+            },
+            {
+                label: 'NICRA Others',
+                features: [
+                    { label: 'Intervention', sectionId: '2.37' },
+                    { label: 'Revenue Generated', sectionId: '' },
+                    { label: 'Custom Hiring', sectionId: '2.38' },
+                    { label: 'VCRMC', sectionId: '2.39' },
+                    { label: 'Soil Health Card', sectionId: '2.40' },
+                    { label: 'Convergence Programme', sectionId: '' },
+                    { label: 'Dignitaries Visited', sectionId: '' },
+                    { label: 'PI/Co-PI List', sectionId: '' },
+                ],
+            },
+            {
+                label: 'ARYA / SAFAL',
+                features: [
+                    { label: 'Current Year Details', sectionId: '2.30' },
+                    { label: 'Previous Year Evaluation', sectionId: '2.31' },
+                ],
+            },
+            {
+                label: 'Natural Farming',
+                features: [
+                    { label: 'Geographical Information', sectionId: '' },
+                    { label: 'Physical Information', sectionId: '2.44' },
+                    { label: 'Demonstration Information', sectionId: '2.46' },
+                    { label: 'Farmers Practicing', sectionId: '2.47' },
+                    { label: 'Beneficiaries', sectionId: '' },
+                    { label: 'Soil Data', sectionId: '2.49' },
+                    { label: 'Budget Expenditure', sectionId: '2.50' },
+                ],
+            },
+            {
+                label: 'TSP/SCSP',
+                features: [
+                    { label: 'TSP Activities', sectionId: '2.33' },
+                    { label: 'SCSP Activities', sectionId: '2.33' },
+                ],
+            },
+            {
+                label: 'NARI',
+                features: [
+                    { label: 'Nutrition Garden', sectionId: '2.25' },
+                    { label: 'Bio-fortified Crops', sectionId: '2.26' },
+                    { label: 'Value Addition', sectionId: '2.27' },
+                    { label: 'Training Program', sectionId: '2.28' },
+                    { label: 'Extension Activities', sectionId: '2.29' },
+                ],
+            },
+            {
+                label: 'Agri-Drone',
+                features: [
+                    { label: 'Introduction', sectionId: '2.51' },
+                    { label: 'Demonstration', sectionId: '2.52' },
+                ],
+            },
+            {
+                label: 'FPO and CBBO',
+                features: [
+                    { label: 'Details FPO and CBBO', sectionId: '2.21' },
+                    { label: 'FPO Management', sectionId: '2.22' },
+                ],
+            },
+            {
+                label: 'DRMR',
+                features: [
+                    { label: 'DRMR Details', sectionId: '2.23' },
+                    { label: 'DRMR Activity', sectionId: '2.24' },
+                ],
+            },
+            {
+                label: 'Climate Resilient Agriculture (CRA)',
+                features: [
+                    { label: 'CRA Details', sectionId: '2.19' },
+                    { label: 'Extension Activity', sectionId: '2.20' },
+                ],
+            },
+            {
+                label: 'CSISA',
+                features: [
+                    { label: 'CSISA', sectionId: '2.32' },
+                ],
+            },
+            {
+                label: 'Seed Hub Program',
+                features: [
+                    { label: 'Seed Hub Program', sectionId: '2.53' },
+                ],
+            },
+            {
+                label: 'Other Programmes',
+                features: [
+                    { label: 'Other Programmes', sectionId: '2.54' },
+                ],
+            },
+        ],
+    },
 }
 
 /** Chapter numbers shown in the sidebar (match the report: About=1, Achievements=2). */
 export const TAXONOMY_CHAPTER_NUMBER: Record<string, number> = {
     about: 1,
     achievements: 2,
+    projects: 3,
 }
 
 /**

--- a/frontend/src/hooks/useOftWorkflow.ts
+++ b/frontend/src/hooks/useOftWorkflow.ts
@@ -11,6 +11,16 @@ export function useTransferOftToNextYear() {
     })
 }
 
+export function useRevokeOftTransfer() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: (id: number | string) => oftWorkflowApi.revokeTransfer(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['project-data', 'achievement-oft'] })
+        },
+    })
+}
+
 export function useTransferFldToNextYear() {
     const queryClient = useQueryClient()
     return useMutation({

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -18,6 +18,7 @@ import { DataTable } from '@/components/common/DataTable/DataTable'
 import { Pagination } from '@/components/common/DataTable/Pagination'
 import {
     applyColumnFilters,
+    valueToString,
     type ColumnFilters,
 } from '@/components/common/DataTable/columnFilterUtils'
 import { isFilterActive as isColumnFilterActive } from '@/components/common/DataTable/ColumnFilter'
@@ -54,6 +55,7 @@ import { useExportHandler } from '@/hooks/useExportHandler'
 import { useToast } from '@/hooks/useToast'
 import {
     useTransferOftToNextYear,
+    useRevokeOftTransfer,
     useTransferFldToNextYear,
     useCreateOftResult,
     useUpdateOftResult,
@@ -134,6 +136,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
         exportLoading: exportLoadingState,
     } = useExportHandler()
     const transferOftMutation = useTransferOftToNextYear()
+    const revokeOftMutation = useRevokeOftTransfer()
     const transferFldMutation = useTransferFldToNextYear()
     const transferCfldMutation = useTransferCfldTechnicalToNextYear()
     const createOftResultMutation = useCreateOftResult()
@@ -242,6 +245,13 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
         if (moduleCode && !hasPermission('ADD', moduleCode)) return false
         // Explicit opt-out via routeConfig wins for everyone, regardless of role.
         if (routeConfig?.canCreate === 'none') return false
+        // Super-admin may only add KVKs (KVK creation) and master data; the
+        // "Add New" button is hidden on every other form-management page.
+        if (user.role === 'super_admin') {
+            const isMaster = routeConfig?.category === 'All Masters'
+            const isKvkCreation = isAboutKvkEntity && entityType === ENTITY_TYPES.KVKS
+            if (!isMaster && !isKvkCreation) return false
+        }
         // About KVK entities: check routeConfig.canCreate for KVKS, otherwise only KVK role can add details
         if (isAboutKvkEntity) {
             if (entityType === ENTITY_TYPES.KVKS) {
@@ -409,10 +419,27 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     // of the search/year-filtered set. The column-filter dropdown's unique-value
     // list is computed from `filteredData` so it represents the full visible
     // dataset before column filters narrow it further.
-    const columnFilteredData = useMemo(
-        () => applyColumnFilters(filteredData, fields, columnFilters),
-        [filteredData, fields, columnFilters],
-    )
+    const columnFilteredData = useMemo(() => {
+        const result = applyColumnFilters(filteredData, fields, columnFilters)
+        // Default alphabetical order (by the first column) unless the user has
+        // applied an explicit column sort.
+        const hasActiveSort = Object.values(columnFilters || {}).some(
+            (f: any) => f?.sort,
+        )
+        const sortKey = fields[0]
+        if (hasActiveSort || !sortKey || result.length < 2) return result
+        return [...result].sort((a, b) => {
+            const av = valueToString(getFieldValue(a, sortKey))
+            const bv = valueToString(getFieldValue(b, sortKey))
+            if (av === bv) return 0
+            if (av === '') return 1
+            if (bv === '') return -1
+            return av.localeCompare(bv, undefined, {
+                numeric: true,
+                sensitivity: 'base',
+            })
+        })
+    }, [filteredData, fields, columnFilters])
 
     // Pagination calculations - memoized for performance
     const paginationData = useMemo(() => {
@@ -504,6 +531,33 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
             alert({
                 title: 'Transfer failed',
                 message: err?.message || 'Unable to transfer OFT.',
+                variant: 'error',
+            })
+        }
+    }
+
+    const handleRevokeOftTransfer = async (item: any) => {
+        const id = item?.id ?? item?.kvkOftId
+        if (!id) {
+            alert({
+                title: 'Error',
+                message: 'Unable to revoke transfer: missing record id.',
+                variant: 'error',
+            })
+            return
+        }
+        try {
+            await revokeOftMutation.mutateAsync(id)
+            alert({
+                title: 'Success',
+                message: 'OFT transfer revoked; record restored to Ongoing.',
+                variant: 'success',
+                autoClose: true,
+            })
+        } catch (err: any) {
+            alert({
+                title: 'Revoke failed',
+                message: err?.message || 'Unable to revoke OFT transfer.',
                 variant: 'error',
             })
         }
@@ -917,6 +971,18 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                         'px-2 py-1 text-xs rounded-lg border border-purple-300 text-purple-700 hover:bg-purple-50 transition-colors',
                     icon: FilePenLine,
                 },
+                {
+                    key: 'revoke-transfer',
+                    label: 'Revoke Transfer',
+                    onClick: handleRevokeOftTransfer,
+                    // Super-admin only, and only for records already transferred.
+                    isVisible: (item: any) =>
+                        user?.role === 'super_admin' &&
+                        statusValue(item) === 'TRANSFERRED_TO_NEXT_YEAR',
+                    className:
+                        'px-2 py-1 text-xs rounded-lg border border-orange-300 text-orange-700 hover:bg-orange-50 transition-colors',
+                    icon: RotateCcw,
+                },
             ]
             : []
 
@@ -1117,11 +1183,10 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
 
     const handleExport = async (format: 'pdf' | 'excel' | 'word' | 'csv') => {
         const templateKey = getExportTemplateKey(entityType)
-        // Prevent empty custom-template exports when transient UI filters narrow to zero rows.
-        const exportDataSource =
-            templateKey && filteredData.length === 0 && items.length > 0
-                ? items
-                : filteredData
+        // Export exactly what's visible after ALL active filters (search, date
+        // range, and per-column filters/sort), so a filtered download contains
+        // only the filtered rows — not the full dataset.
+        const exportDataSource = columnFilteredData
 
         await handleExportData(format, {
             title,

--- a/frontend/src/pages/reports/KvkReportPage.tsx
+++ b/frontend/src/pages/reports/KvkReportPage.tsx
@@ -68,16 +68,24 @@ export const KvkReportPage: React.FC = () => {
     // Load report configuration using TanStack Query
     const reportConfigQuery = useReportConfig();
 
-    // Initialize all sections as selected by default
-    useEffect(() => {
-        if (reportConfigQuery.data?.sections && selectedSections.size === 0) {
-            // Select only functional sections (those with a data source) by default
-            const functionalSections = reportConfigQuery.data.sections
-                .filter(s => !!s.dataSource)
-                .map(s => s.id);
-            setSelectedSections(new Set(functionalSections));
-        }
-    }, [reportConfigQuery.data?.sections]);
+    // Sections default to UNSELECTED; the user opts in via per-category or the
+    // global "Select all" control.
+    const allFunctionalSectionIds = useMemo(
+        () => (reportConfigQuery.data?.sections || [])
+            .filter(s => !!s.dataSource)
+            .map(s => s.id),
+        [reportConfigQuery.data?.sections],
+    );
+
+    const allFormsSelected =
+        allFunctionalSectionIds.length > 0 &&
+        allFunctionalSectionIds.every(id => selectedSections.has(id));
+
+    const handleSelectAllForms = () => {
+        setSelectedSections(
+            allFormsSelected ? new Set() : new Set(allFunctionalSectionIds),
+        );
+    };
 
     const handleSectionToggle = (sectionId: string) => {
         const newSelected = new Set(selectedSections);
@@ -458,6 +466,8 @@ export const KvkReportPage: React.FC = () => {
                                         selectedSections={selectedSections}
                                         onSectionToggle={handleSectionToggle}
                                         onCategorySelectAll={handleCategorySelectAll}
+                                        onSelectAllForms={handleSelectAllForms}
+                                        allFormsSelected={allFormsSelected}
                                         collapsed={isModuleCollapsed}
                                         onToggleCollapse={() => setIsModuleCollapsed(prev => !prev)}
                                     />

--- a/frontend/src/services/oftWorkflowApi.ts
+++ b/frontend/src/services/oftWorkflowApi.ts
@@ -14,6 +14,10 @@ export const oftWorkflowApi = {
         return apiClient.post(`/forms/achievements/oft/${id}/transfer-next-year`)
     },
 
+    revokeTransfer: async (id: number | string) => {
+        return apiClient.post(`/forms/achievements/oft/${id}/revoke-transfer`)
+    },
+
     getResult: async (id: number | string) => {
         return apiClient.get(`/forms/achievements/oft/${id}/result`)
     },


### PR DESCRIPTION
Batch of report-generation + form-management fixes. Tracking issue #213.

## Completed
**Reports**
- **OFT (§2.2)** — super-admin aggregated shape fixed (was Unknown/Other/0); farmers now render. OFT result GET returns `null` (200) instead of 404 when none exists (#11, #12).
- **Vehicle (§1.x)** — Total Run / Present Status / KVK populated by joining vehicle details (#9).
- **Equipment (§1.8)** — Equipment Name (fallback to master), Source of Funding, Present Status, KVK populated; KVK added to grouped block (#10).
- **Achievements structure (#7)** — Soil & Water Testing at **2.9** (Analysis = 2.9.A; lab-equipment hidden via `hideInReport`), Swachhata under **2.7**, Production **2.8**. Page order now follows the curated taxonomy (HR before Awards, etc.). TOC lists clickable lettered sub-items. Soil-water/production/swachhata templates use dynamic `section.id` headings (no more hardcoded "7."/"2.7"/"2.8"). Swachhata Sewa/Pakhwada/Budget are super-admin-structured (State+KVK) vs KVK simple list; Budget rebuilt as one combined table.
- **Scope Org list (#8)** — append district to disambiguate duplicate org names (ICAR/NGO/SAU).

**Forms**
- **#1** super-admin "Add New" hidden except master data + KVK creation.
- **#2** report-gen forms default unselected + global Select all / Clear all.
- **#6** form data lists default to alphabetical (first column) until sorted.
- **#4** module PDF/Excel/Word downloads export the fully-filtered set.
- **#5** OFT revoke/undo transfer (super-admin): records transfer chain, deletes untouched next-year copy, restores source to ONGOING; super-admin-only route + row action.

## Not in this PR
- **#3** All-master "Other → specify" conditional input — plan posted on #213 (per-master new column + form UI + report); to be done as a follow-up.

Verified: frontend `tsc --noEmit` clean; backend `node -c` clean. Runtime PDF render not exhaustively tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
