### PR TITLE
fix(reports): render Vehicle Status (§1.4.B) + Equipment Status (§1.5.B)

### DIFF
--- a/backend/repositories/reports/aboutkvkReport/assetsReportRepository.js
+++ b/backend/repositories/reports/aboutkvkReport/assetsReportRepository.js
@@ -1,5 +1,5 @@
 const prisma = require('../../../config/prisma.js');
-const { applyCreatedAtFilters } = require('./commonFilters.js');
+const { applyCreatedAtFilters, applyDateFilters } = require('./commonFilters.js');
 
 async function getKvkLandDetails(kvkId, filters = {}) {
     const where = { kvkId };
@@ -62,28 +62,42 @@ async function getKvkVehicles(kvkId, filters = {}) {
     });
 }
 
+// §1.4.B Vehicle Status — reporting-year status rows from KvkVehicleDetail
+// (the base KvkVehicle has no reportingYear, so the old query threw and the
+// whole section was dropped). Year-wise; includes KVK for the aggregated view.
 async function getKvkVehicleDetails(kvkId, filters = {}) {
-    const where = {
-        kvkId,
-        reportingYear: {
-            not: null,
-        },
-    };
-    applyCreatedAtFilters(where, filters);
+    const where = {};
+    if (kvkId) where.kvkId = kvkId;
+    applyDateFilters(where, filters, 'reportingYear');
 
-    return await prisma.kvkVehicle.findMany({
+    const rows = await prisma.kvkVehicleDetail.findMany({
         where,
         include: {
-            kvk: {
-                select: { kvkId: true, kvkName: true },
-            },
+            kvk: { select: { kvkId: true, kvkName: true } },
+            vehicle: { select: { vehicleName: true, registrationNo: true, yearOfPurchase: true, totalCost: true } },
+            vehicleStatus: { select: { statusLabel: true } },
+            assetFundingSource: { select: { name: true } },
         },
         orderBy: [
             { reportingYear: 'desc' },
-            { yearOfPurchase: 'desc' },
-            { vehicleName: 'asc' },
+            { vehicleId: 'asc' },
         ],
     });
+
+    return rows.map((d) => ({
+        reportingYear: d.reportingYear,
+        kvkId: d.kvkId,
+        kvk: d.kvk,
+        kvkName: d.kvk?.kvkName || '',
+        vehicleName: d.vehicle?.vehicleName || '',
+        registrationNo: d.vehicle?.registrationNo || '',
+        yearOfPurchase: d.vehicle?.yearOfPurchase ?? '',
+        totalCost: d.vehicle?.totalCost ?? '',
+        totalRun: d.totalRun ?? '',
+        presentStatus: d.vehicleStatus?.statusLabel ?? '',
+        repairingCost: d.repairingCost ?? '',
+        sourceOfFunding: d.assetFundingSource?.name ?? '',
+    }));
 }
 
 async function getKvkEquipments(kvkId, filters = {}) {
@@ -121,28 +135,45 @@ async function getKvkEquipments(kvkId, filters = {}) {
     });
 }
 
+// §1.5.B Equipment Status — reporting-year status rows from KvkEquipmentDetail.
 async function getKvkEquipmentRecords(kvkId, filters = {}) {
-    const where = {
-        kvkId,
-        reportingYear: {
-            not: null,
-        },
-    };
-    applyCreatedAtFilters(where, filters);
+    const where = {};
+    if (kvkId) where.kvkId = kvkId;
+    applyDateFilters(where, filters, 'reportingYear');
 
-    return await prisma.kvkEquipment.findMany({
+    const rows = await prisma.kvkEquipmentDetail.findMany({
         where,
         include: {
-            kvk: {
-                select: { kvkId: true, kvkName: true },
+            kvk: { select: { kvkId: true, kvkName: true } },
+            equipment: {
+                select: {
+                    equipmentName: true,
+                    yearOfPurchase: true,
+                    totalCost: true,
+                    equipmentMaster: { select: { name: true } },
+                },
             },
+            equipmentStatus: { select: { statusLabel: true } },
+            assetFundingSource: { select: { name: true } },
         },
         orderBy: [
             { reportingYear: 'desc' },
-            { yearOfPurchase: 'desc' },
-            { equipmentName: 'asc' },
+            { equipmentId: 'asc' },
         ],
     });
+
+    return rows.map((d) => ({
+        reportingYear: d.reportingYear,
+        kvkId: d.kvkId,
+        kvk: d.kvk,
+        kvkName: d.kvk?.kvkName || '',
+        equipmentName: d.equipment?.equipmentName || d.equipment?.equipmentMaster?.name || '',
+        yearOfPurchase: d.equipment?.yearOfPurchase ?? '',
+        totalCost: d.equipment?.totalCost ?? '',
+        presentStatus: d.equipmentStatus?.statusLabel ?? '',
+        repairingCost: d.repairingCost ?? '',
+        sourceOfFunding: d.assetFundingSource?.name ?? '',
+    }));
 }
 
 module.exports = {


### PR DESCRIPTION
The Vehicle Status / Equipment Status sub-sections weren't appearing in reports (index showed only 1.4.A / 1.5.A).

**Cause:** `getKvkVehicleDetails` / `getKvkEquipmentRecords` queried the base `KvkVehicle` / `KvkEquipment` tables filtering `reportingYear`, but that column only exists on the **detail** tables → Prisma validation error → the section was dropped.

**Fix:** query `KvkVehicleDetail` / `KvkEquipmentDetail` (reportingYear + status live there), joining parent vehicle/equipment + status master + funding source. Returns **year-wise** rows with a **KVK** column:
- KVK role → own data, year-wise.
- Superadmin (aggregated) → all KVKs, year-wise + KVK-wise.

Year filter on `reportingYear` (DateTime). The PDF table flows through `parseSectionHtml` into the **Excel + Word** exports automatically (no separate template).

**Verified live:** §1.7 Vehicle Status = 3 rows, §1.9 Equipment Status = 4 rows; HTML renders Year / KVK / Vehicle / Reg / Cost / Run / Status / Repairing / Funding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)