### PR TITLE
fix(reports): Technical Achievement Summary (§2.1) data + grid layout

### DIFF
--- a/backend/repositories/reports/technicalAchievementSummaryReport/index.js
+++ b/backend/repositories/reports/technicalAchievementSummaryReport/index.js
@@ -65,14 +65,21 @@ async function getTechnicalAchievementSummary(kvkId, filters = {}) {
     const targetOf = (typeName) => targets
         .filter((t) => String(t.typeName).toLowerCase() === typeName.toLowerCase())
         .reduce((s, t) => s + Number(t.target || 0), 0);
+    // Farmer/beneficiary target for the same typeName (separate column in §2.1).
+    const farmerTargetOf = (typeName) => targets
+        .filter((t) => String(t.typeName).toLowerCase() === typeName.toLowerCase())
+        .reduce((s, t) => s + Number(t.farmerTarget || 0), 0);
 
-    // OFT
+    // OFT — kvkoft carries farmer demographics (farmersGeneralM, …) like the
+    // extension/production tables, so pick with pickFarmers.
     const ofts = await prisma.kvkoft.findMany({ where: { ...kvkWhere, ...dateWhere('oftStartDate', filters) } });
     const oft = {
         target: targetOf('OFT'),
         achievement: ofts.length,
         locations: ofts.reduce((s, r) => s + Number(r.numberOfLocation || 0), 0),
         trials: ofts.reduce((s, r) => s + Number(r.numberOfTrialReplication || 0), 0),
+        farmerTarget: farmerTargetOf('OFT'),
+        farmers: sumCaste(ofts, pickFarmers),
     };
 
     // FLD
@@ -82,6 +89,7 @@ async function getTechnicalAchievementSummary(kvkId, filters = {}) {
         achievement: flds.length,
         area: flds.reduce((s, r) => s + Number(r.quantity || 0), 0),
         demos: flds.reduce((s, r) => s + Number(r.noOfDemonstration || 0), 0),
+        farmerTarget: farmerTargetOf('FLD'),
         farmers: sumCaste(flds, pickBare),
     };
 
@@ -90,6 +98,7 @@ async function getTechnicalAchievementSummary(kvkId, filters = {}) {
     const training = {
         target: targetOf('Training'),
         courses: trainings.length,
+        farmerTarget: farmerTargetOf('Training'),
         participants: sumCaste(trainings, pickBare),
     };
 
@@ -98,6 +107,7 @@ async function getTechnicalAchievementSummary(kvkId, filters = {}) {
     const extension = {
         target: targetOf('Extension'),
         activities: exts.reduce((s, r) => s + Number(r.numberOfActivities || 0), 0),
+        farmerTarget: farmerTargetOf('Extension'),
         participants: sumCaste(exts, pickFarmers),
     };
 
@@ -124,4 +134,90 @@ async function getTechnicalAchievementSummary(kvkId, filters = {}) {
     return { oft, fld, training, extension, production };
 }
 
-module.exports = { getTechnicalAchievementSummary };
+// Caste×gender keys produced by sumCaste (see EMPTY above).
+const CASTE_KEYS = ['gm', 'gf', 'om', 'of', 'sm', 'sf', 'stm', 'stf'];
+
+// Sum many sumCaste-shaped objects into one, recomputing the totals.
+function mergeCaste(list) {
+    const acc = { ...EMPTY };
+    for (const c of list) {
+        if (!c) continue;
+        for (const k of CASTE_KEYS) acc[k] += Number(c[k] || 0);
+    }
+    const totM = acc.gm + acc.om + acc.sm + acc.stm;
+    const totF = acc.gf + acc.of + acc.sf + acc.stf;
+    return { ...acc, totM, totF, totT: totM + totF };
+}
+
+// Merge per-KVK summaries (each shaped like getTechnicalAchievementSummary's
+// return) into a single aggregate object the §2.1 template can render. Used by
+// the aggregation pipeline so super-admin / multi-KVK scopes show combined
+// totals instead of an array the template can't read.
+function mergeTechnicalAchievementSummaries(summaries) {
+    const valid = (summaries || []).filter(Boolean);
+    if (valid.length === 0) {
+        return { oft: null, fld: null, training: null, extension: null, production: [] };
+    }
+
+    const sum = (pick) => valid.reduce((s, d) => s + Number(pick(d) || 0), 0);
+
+    const oft = {
+        target: sum((d) => d.oft?.target),
+        achievement: sum((d) => d.oft?.achievement),
+        locations: sum((d) => d.oft?.locations),
+        trials: sum((d) => d.oft?.trials),
+        farmerTarget: sum((d) => d.oft?.farmerTarget),
+        farmers: mergeCaste(valid.map((d) => d.oft?.farmers)),
+    };
+
+    const fld = {
+        target: sum((d) => d.fld?.target),
+        achievement: sum((d) => d.fld?.achievement),
+        area: sum((d) => d.fld?.area),
+        demos: sum((d) => d.fld?.demos),
+        farmerTarget: sum((d) => d.fld?.farmerTarget),
+        farmers: mergeCaste(valid.map((d) => d.fld?.farmers)),
+    };
+
+    const training = {
+        target: sum((d) => d.training?.target),
+        courses: sum((d) => d.training?.courses),
+        farmerTarget: sum((d) => d.training?.farmerTarget),
+        participants: mergeCaste(valid.map((d) => d.training?.participants)),
+    };
+
+    const extension = {
+        target: sum((d) => d.extension?.target),
+        activities: sum((d) => d.extension?.activities),
+        farmerTarget: sum((d) => d.extension?.farmerTarget),
+        participants: mergeCaste(valid.map((d) => d.extension?.participants)),
+    };
+
+    // Production / Supply rows are grouped by category — merge the same category
+    // across KVKs rather than listing it once per KVK.
+    const byCat = new Map();
+    for (const d of valid) {
+        for (const p of d.production || []) {
+            const key = p.category || 'Other';
+            if (!byCat.has(key)) {
+                byCat.set(key, { category: key, target: 0, quantity: 0, value: 0, _bene: [] });
+            }
+            const agg = byCat.get(key);
+            agg.target += Number(p.target || 0);
+            agg.quantity += Number(p.quantity || 0);
+            agg.value += Number(p.value || 0);
+            agg._bene.push(p.beneficiaries);
+        }
+    }
+    const production = Array.from(byCat.values()).map((agg) => ({
+        category: agg.category,
+        target: agg.target,
+        quantity: agg.quantity,
+        value: agg.value,
+        beneficiaries: mergeCaste(agg._bene),
+    }));
+
+    return { oft, fld, training, extension, production };
+}
+
+module.exports = { getTechnicalAchievementSummary, mergeTechnicalAchievementSummaries };

--- a/backend/services/reports/formsTemplate/achievementTemplates/technicalAchievementSummaryTemplate.js
+++ b/backend/services/reports/formsTemplate/achievementTemplates/technicalAchievementSummaryTemplate.js
@@ -2,41 +2,88 @@
  * Technical Achievement Summary (§2.1).
  * Target vs Achievement across the main activity blocks + caste×gender
  * beneficiary demographics where captured. Bound to reportTemplateService.
+ *
+ * Rendered as wide merged-header grids (matching the on-screen report): each
+ * block is one table with a section title, a left group of activity metrics and
+ * a right group of farmer/participant demographics broken down by
+ * General/OBC/SC/ST × M/F plus a Total. The same HTML drives PDF (Puppeteer),
+ * Word and Excel — the latter two parse this HTML and reproduce the merges.
  */
 function n(v) { return v === null || v === undefined || v === '' ? 0 : v; }
 
-function demoTable(esc, demo) {
-    if (!demo) return '';
-    const d = demo;
-    const row = (label, m, f, t) =>
-        `<tr><td class="L">${label}</td><td>${m}</td><td>${f}</td><td>${t}</td></tr>`;
+// The 11 demographic data cells (General M/F, OBC M/F, SC M/F, ST M/F,
+// Total M/F/T) from a sumCaste-shaped object.
+function participantCells(demo) {
+    const d = demo || {};
+    const c = (x) => `<td>${n(x)}</td>`;
+    return (
+        c(d.gm) + c(d.gf) +
+        c(d.om) + c(d.of) +
+        c(d.sm) + c(d.sf) +
+        c(d.stm) + c(d.stf) +
+        c(d.totM) + c(d.totF) +
+        `<td style="font-weight:bold;">${n(d.totT)}</td>`
+    );
+}
+
+// Category header row (spans the 11 demographic columns).
+const CATEGORY_HEADER_ROW =
+    '<tr><th colspan="2">General</th><th colspan="2">OBC</th>' +
+    '<th colspan="2">SC</th><th colspan="2">ST</th><th colspan="3">Total</th></tr>';
+
+// M/F (and Total T) header row under each category.
+const GENDER_HEADER_ROW =
+    '<tr><th>M</th><th>F</th><th>M</th><th>F</th><th>M</th><th>F</th>' +
+    '<th>M</th><th>F</th><th>M</th><th>F</th><th>T</th></tr>';
+
+/**
+ * Render one activity block as a grid table.
+ *   title        section heading (e.g. 'OFT')
+ *   subtitle     optional line under the title (e.g. 'No. of Technologies Tested')
+ *   leftLabel    label spanning the activity-metric columns (e.g. 'No. of OFTs')
+ *   leftCols     [[label, value], …] activity metrics
+ *   rightLabel   label spanning the demographic columns (e.g. 'No. of Farmers')
+ *   farmerTarget if not null, adds a 'Farmer Target' column before Achievement
+ *   demo         sumCaste-shaped demographics object
+ */
+function gridBlock(esc, { title, subtitle, leftLabel, leftCols, rightLabel, farmerTarget, demo }) {
+    const leftN = leftCols.length;
+    const farmerTargetCol = farmerTarget !== null && farmerTarget !== undefined;
+    const rightN = farmerTargetCol ? 12 : 11; // +1 for the Farmer Target column
+    const totalCols = leftN + rightN;
+
+    const leftHeadCells = leftCols
+        .map(([label]) => `<th rowspan="3">${esc(label)}</th>`)
+        .join('');
+    const farmerTargetHead = farmerTargetCol ? '<th rowspan="3">Farmer Target</th>' : '';
+    const leftDataCells = leftCols.map(([, value]) => `<td>${n(value)}</td>`).join('');
+    const farmerTargetData = farmerTargetCol ? `<td>${n(farmerTarget)}</td>` : '';
+
     return `
-        <table class="data-table" style="width:auto;margin-top:6px;font-size:8pt;">
-            <thead><tr><th>Category</th><th>Male</th><th>Female</th><th>Total</th></tr></thead>
+        <table class="data-table" style="margin-top:10px;font-size:9pt;text-align:center;">
+            <thead>
+                <tr><th colspan="${totalCols}" style="font-size:11pt;">${esc(title)}</th></tr>
+                ${subtitle ? `<tr><th colspan="${totalCols}">${esc(subtitle)}</th></tr>` : ''}
+                <tr>
+                    <th colspan="${leftN}">${esc(leftLabel)}</th>
+                    <th colspan="${rightN}">${esc(rightLabel)}</th>
+                </tr>
+                <tr>
+                    ${leftHeadCells}
+                    ${farmerTargetHead}
+                    <th colspan="11">Achievement</th>
+                </tr>
+                ${CATEGORY_HEADER_ROW}
+                ${GENDER_HEADER_ROW}
+            </thead>
             <tbody>
-                ${row('General', n(d.gm), n(d.gf), n(d.gm) + n(d.gf))}
-                ${row('OBC', n(d.om), n(d.of), n(d.om) + n(d.of))}
-                ${row('SC', n(d.sm), n(d.sf), n(d.sm) + n(d.sf))}
-                ${row('ST', n(d.stm), n(d.stf), n(d.stm) + n(d.stf))}
-                <tr style="font-weight:bold;">${`<td class="L">Total</td><td>${n(d.totM)}</td><td>${n(d.totF)}</td><td>${n(d.totT)}</td>`}</tr>
+                <tr>
+                    ${leftDataCells}
+                    ${farmerTargetData}
+                    ${participantCells(demo)}
+                </tr>
             </tbody>
         </table>`;
-}
-
-function kv(esc, pairs) {
-    return `
-        <table class="data-table" style="width:auto;font-size:9pt;">
-            <tbody>${pairs.map(([k, v]) => `<tr><td class="L" style="font-weight:bold;">${esc(k)}</td><td>${esc(String(v))}</td></tr>`).join('')}</tbody>
-        </table>`;
-}
-
-function block(esc, title, kvPairs, demo) {
-    return `
-        <div style="margin:14px 0;">
-            <h2 class="section-subtitle">${esc(title)}</h2>
-            ${kv(esc, kvPairs)}
-            ${demo ? demoTable(esc, demo) : ''}
-        </div>`;
 }
 
 function renderTechnicalAchievementSummarySection(section, data, sectionId, isFirstSection) {
@@ -54,39 +101,82 @@ function renderTechnicalAchievementSummarySection(section, data, sectionId, isFi
     <h1 class="section-title">${esc(section.id)} ${esc(section.title)}</h1>`;
 
     if (d.oft) {
-        html += block(esc, 'OFT', [
-            ['Target', n(d.oft.target)],
-            ['Achievement (No. of OFTs)', n(d.oft.achievement)],
-            ['No. of Locations', n(d.oft.locations)],
-            ['No. of Trials', n(d.oft.trials)],
-        ], null);
+        html += gridBlock(esc, {
+            title: 'OFT',
+            subtitle: 'No. of Technologies Tested',
+            leftLabel: 'No. of OFTs',
+            leftCols: [
+                ['Target', d.oft.target],
+                ['Achievement', d.oft.achievement],
+                ['No. of Location', d.oft.locations],
+                ['No. of Trials', d.oft.trials],
+            ],
+            rightLabel: 'No. of Farmers',
+            farmerTarget: d.oft.farmerTarget,
+            demo: d.oft.farmers,
+        });
     }
+
     if (d.fld) {
-        html += block(esc, 'FLD', [
-            ['Target', n(d.fld.target)],
-            ['Achievement (No. of FLDs)', n(d.fld.achievement)],
-            ['No. of Demonstrations', n(d.fld.demos)],
-            ['Area (ha)', n(d.fld.area)],
-        ], d.fld.farmers);
+        html += gridBlock(esc, {
+            title: 'FLD',
+            subtitle: 'No. of Technologies Demonstrated',
+            leftLabel: 'Number of FLDs',
+            leftCols: [
+                ['Target', d.fld.target],
+                ['Achievement', d.fld.achievement],
+                ['Area', d.fld.area],
+            ],
+            rightLabel: 'Number of Farmers',
+            farmerTarget: d.fld.farmerTarget,
+            demo: d.fld.farmers,
+        });
     }
+
     if (d.training) {
-        html += block(esc, 'Training', [
-            ['Target (No. of Courses)', n(d.training.target)],
-            ['Achievement (No. of Courses)', n(d.training.courses)],
-        ], d.training.participants);
+        html += gridBlock(esc, {
+            title: 'Training',
+            subtitle: 'Number of Courses',
+            leftLabel: 'Number of Courses',
+            leftCols: [
+                ['Target', d.training.target],
+                ['Achievement', d.training.courses],
+            ],
+            rightLabel: 'Number of Participants',
+            farmerTarget: d.training.farmerTarget,
+            demo: d.training.participants,
+        });
     }
+
     if (d.extension) {
-        html += block(esc, 'Extension Activities', [
-            ['Target (No. of Activities)', n(d.extension.target)],
-            ['Achievement (No. of Activities)', n(d.extension.activities)],
-        ], d.extension.participants);
+        html += gridBlock(esc, {
+            title: 'Extension Activities',
+            subtitle: 'Number of Activities',
+            leftLabel: 'Number of Activities',
+            leftCols: [
+                ['Target', d.extension.target],
+                ['Achievement', d.extension.activities],
+            ],
+            rightLabel: 'Number of Participants',
+            farmerTarget: d.extension.farmerTarget,
+            demo: d.extension.participants,
+        });
     }
+
     for (const p of (d.production || [])) {
-        html += block(esc, `Production / Supply — ${p.category}`, [
-            ['Target', n(p.target)],
-            ['Quantity', n(p.quantity)],
-            ['Value (Rs.)', n(p.value)],
-        ], p.beneficiaries);
+        html += gridBlock(esc, {
+            title: `Production / Supply — ${p.category}`,
+            subtitle: null,
+            leftLabel: esc(p.category),
+            leftCols: [
+                ['Target', p.target],
+                ['Quantity', p.quantity],
+                ['Value (Rs.)', p.value],
+            ],
+            rightLabel: 'Number of Participants',
+            farmerTarget: null,
+            demo: p.beneficiaries,
+        });
     }
 
     html += `

--- a/backend/services/reports/reportAggregationService.js
+++ b/backend/services/reports/reportAggregationService.js
@@ -501,6 +501,22 @@ class ReportAggregationService {
             };
         }
 
+        if (sectionConfig.dataSource === 'technicalAchievementSummary') {
+            const { mergeTechnicalAchievementSummaries } = require('../../repositories/reports/technicalAchievementSummaryReport/index.js');
+            // Each KVK returns a pre-aggregated object, not a record array — sum
+            // them into one object so the §2.1 template renders combined totals.
+            const merged = mergeTechnicalAchievementSummaries(validData.map((sd) => sd.data));
+            return {
+                sectionId,
+                data: merged,
+                metadata: {
+                    recordCount: validData.length,
+                    lastUpdated: new Date(),
+                    filters: {},
+                },
+            };
+        }
+
         // For custom format sections (OFT, etc.), combine all array data
         if (sectionConfig.format === 'custom') {
             const allRows = [];


### PR DESCRIPTION
## Problem
Reports index §2.1 (Achievements → Technical Achievement Summary) showed **no data** for super-admin / multi-KVK scopes, and rendered as plain key-value tables instead of the approved wide grid.

## Root cause
Each KVK's §2.1 data is a pre-aggregated **object** (`{oft, fld, training, extension, production}`), not a record array. `reportAggregationService._aggregateData` had no handler for this dataSource, so the generic `format: 'custom'` fall-through pushed per-KVK objects into an **array** — which the template reads as `data.oft → undefined` → empty section.

## Changes
- **reportAggregationService**: add a `technicalAchievementSummary` merge branch that sums per-KVK summaries into one object.
- **legacy repo**: compute OFT farmer demographics (`farmersGeneralM`…) + farmer targets; add farmer targets for FLD/Training/Extension; extend `mergeTechnicalAchievementSummaries` to carry them.
- **template**: render each block as a wide merged-header grid — section title, activity metrics, Farmer Target, then General/OBC/SC/ST/Total × M/F/T. Matches the on-screen report.

## Formats
PDF (Puppeteer), Word and Excel all derive from the same section HTML; the Word/Excel writers parse it and reproduce the colspan/rowspan merges. One source → three formats.

## Scope / behaviour
- Respects the year / date-range filter; no filter = all data till now.
- kvk-admin single-KVK path unchanged.

## Verification
- Merge unit-checked (2+3 → 5 across all fields; production categories merged; totals recomputed; empty-safe).
- Template rendered + parsed: all 5 tables grid-aligned; OFT = 16 columns matching the reference layout.