### PR TITLE
fix(reports): drop redundant 'Employee Details' (§1.3) from Employee section

### DIFF
--- a/backend/config/reportConfig.js
+++ b/backend/config/reportConfig.js
@@ -78,25 +78,6 @@ const reportConfig = {
             ],
         },
         {
-            id: '1.3',
-            title: 'Employee Details',
-            description: 'Heads of KVKs (position order = 1)',
-            subsection: true,
-            parentSectionId: '1',
-            dataSource: 'kvkEmployeesHeads',
-            format: 'custom',
-            customTemplate: 'about-kvk-employee-contacts',
-            filters: {
-                dateFields: ['createdAt'],
-            },
-            fields: [
-                { dbField: 'kvk.kvkName', displayName: 'KVK' },
-                { dbField: 'staffName', displayName: 'Name' },
-                { dbField: 'mobile', displayName: 'Mobile' },
-                { dbField: 'email', displayName: 'Email' },
-            ],
-        },
-        {
             id: '1.4',
             title: 'All KVK staff Details',
             description: 'All active employees/staff of the KVK',

--- a/backend/config/reportIndexTaxonomy.js
+++ b/backend/config/reportIndexTaxonomy.js
@@ -36,7 +36,6 @@ const REPORT_INDEX_TAXONOMY = {
             {
                 label: 'Employee Information',
                 features: [
-                    { label: 'Employee Details', sectionId: '1.3' },
                     { label: 'All KVK Staff', sectionId: '1.4' },
                     { label: 'Staff Transferred', sectionId: '1.11' },
                 ],

--- a/frontend/src/config/reportIndexTaxonomy.ts
+++ b/frontend/src/config/reportIndexTaxonomy.ts
@@ -42,7 +42,6 @@ export const REPORT_INDEX_TAXONOMY: Record<string, TaxonomyChapter> = {
             {
                 label: 'Employee Information',
                 features: [
-                    { label: 'Employee Details', sectionId: '1.3' },
                     { label: 'All KVK Staff', sectionId: '1.4' },
                     { label: 'Staff Transferred', sectionId: '1.11' },
                 ],


### PR DESCRIPTION
## Problem
In the report index, the **Employee Information** group (shown as **1.2**) had three subpoints. The first — **Employee Details** (§1.3) — only listed KVK heads (name / mobile / email), a thin subset of the second, **All KVK staff Details** (§1.4), which already renders the full staff table (sanctioned post, DOB, discipline, pay, joining date, category, job type, …). The thin one read as broken/incomplete.

## Change
Drop §1.3 entirely so the complete section leads.

- **reportConfig.js** — remove the §1.3 section block. It was pulled into full reports via `getAllSections()`, so removing it from the index alone would have left it in generated PDFs.
- **reportIndexTaxonomy** (backend + frontend) — remove the *Employee Details* feature.

Result — group 1.2 now: **All KVK Staff** (§1.4) → **Staff Transferred** (§1.11).

## Note
The now-orphan `kvkEmployeesHeads` dataSource (repo `getKvkEmployeeHeads` + `about-kvk-employee-contacts` template binding) is left in place — harmless dead code, reusable. Can strip on request.

## Verification
`getAllSections()` no longer includes `1.3`; `1.4` intact; both taxonomy files load clean.