### PR TITLE
feat(migration): CFLD migration modules — technical params, extension activity, budget utilization

### DIFF
--- a/backend/migration/engine.js
+++ b/backend/migration/engine.js
@@ -49,6 +49,20 @@ async function fetchFromCurl(curl) {
         if (Array.isArray(json.data)) json.data = rows;
     }
 
+    // cfld technical parameter list lacks detail fields — enrich from each edit page.
+    if (req.url.includes('/project/cfld') && !req.url.includes('cfld-extension') && !req.url.includes('cfld-budget') && rows.length) {
+        const { enrichCfldRows } = require('./modules/cfldTechnicalParameter.js');
+        rows = await enrichCfldRows(rows, req.headers);
+        if (Array.isArray(json.data)) json.data = rows;
+    }
+
+    // cfld extension activity list lacks demographic fields — enrich from each edit page.
+    if (req.url.includes('cfld-extension-activity') && rows.length) {
+        const { enrichCfldExtRows } = require('./modules/cfldExtensionActivity.js');
+        rows = await enrichCfldExtRows(rows, req.headers);
+        if (Array.isArray(json.data)) json.data = rows;
+    }
+
     return { raw: json, rowCount: rows.length };
 }
 

--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -69,6 +69,9 @@ const MASTER_CATALOG = {
         nameField: 'subCategoryName',
     },
     fldCrop: { model: 'fldCrop', idField: 'cropId', nameField: 'cropName' },
+    cfldCrop: { model: 'fLDCropMaster', idField: 'cfldId', nameField: 'cropName' },
+    cropType: { model: 'cropType', idField: 'typeId', nameField: 'typeName' },
+    extensionActivity: { model: 'extensionActivity', idField: 'extensionActivityId', nameField: 'extensionName' },
 };
 
 function getMaster(key) {

--- a/backend/migration/modules/cfldBudgetUtilization.js
+++ b/backend/migration/modules/cfldBudgetUtilization.js
@@ -1,0 +1,320 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, stripHtml } = require('../util.js');
+const prisma = require('../../config/prisma.js');
+
+function extractEditUrl(action) {
+    if (!action) return null;
+    const m =
+        action.match(/href="([^"]*cfld-budget[^"]*\/edit[^"]*)"/i) ||
+        action.match(/href="([^"]*cfld-budget[^"]*\/\d+[^"]*)"/i) ||
+        action.match(/href="([^"]*edit[^"]*)"/i);
+    return m ? m[1] : null;
+}
+
+function cfldBudgetEditUrl(id, action) {
+    const fromAction = extractEditUrl(action);
+    if (fromAction) {
+        return fromAction.startsWith('http') ? fromAction : `https://atariams.org${fromAction}`;
+    }
+    const token = Buffer.from(String(id)).toString('base64');
+    return `https://atariams.org/edit-cfld-budget/${token}`;
+}
+
+async function enrichCfldBudgetRows(rows, headers) {
+    const fetchHeaders = {
+        ...headers,
+        accept: 'text/html,application/xhtml+xml',
+        referer: 'https://atariams.org/project/cfld-budget-utilization',
+    };
+    const concurrency = 5;
+    const enriched = new Array(rows.length);
+
+    for (let i = 0; i < rows.length; i += concurrency) {
+        const chunk = rows.slice(i, i + concurrency);
+        await Promise.all(
+            chunk.map(async (row, ci) => {
+                const gi = i + ci;
+                const id = row?.id;
+                if (!id) { enriched[gi] = row; return; }
+
+                try {
+                    const url = cfldBudgetEditUrl(id, row.action);
+                    const res = await fetch(url, { headers: fetchHeaders });
+                    const html = await res.text();
+                    if (res.ok && (html.includes('fund_allocated') || html.includes('area_ha') || html.includes('area_allotted') || html.includes('budget_received'))) {
+                        enriched[gi] = { ...row, _editHtml: html };
+                    } else {
+                        enriched[gi] = { ...row, _editHtml: null, _enrichFailed: true };
+                    }
+                } catch {
+                    enriched[gi] = { ...row, _editHtml: null, _enrichFailed: true };
+                }
+            }),
+        );
+    }
+    return enriched;
+}
+
+function parseInputValue(html, name) {
+    if (!html) return '';
+    const m1 = html.match(new RegExp(`<input[^>]*name="${name}"[^>]*value="([^"]*)"`, 'i'));
+    if (m1) return m1[1].trim();
+    const m2 = html.match(new RegExp(`<input[^>]*value="([^"]*)"[^>]*name="${name}"`, 'i'));
+    return m2 ? m2[1].trim() : '';
+}
+
+function parseSelectedOption(html, name) {
+    if (!html) return null;
+    const sel = html.match(new RegExp(`name="${name}"[^>]*>([\\s\\S]*?)<\\/select>`, 'i'));
+    if (!sel) return null;
+    const opt = sel[1].match(/<option[^>]*value="([^"]*)"[^>]*selected[^>]*>([\s\S]*?)<\/option>/i);
+    if (!opt) return null;
+    return { id: opt[1].trim(), name: stripHtml(opt[2]).trim() };
+}
+
+/**
+ * Parse budget item rows from edit page HTML.
+ * Tries 3 common Laravel form patterns, stops at first that yields results.
+ *
+ * Pattern 1: items[N][budget_item_id] hidden + items[N][budget_received/utilized]
+ * Pattern 2: budget_received[N] / budget_utilized[N]  where N = budget_item_id
+ * Pattern 3: budget_item_id[] / budget_received[] / budget_utilized[]  (positional arrays)
+ */
+function parseBudgetItems(html) {
+    if (!html) return [];
+    const items = [];
+    const seen = new Set();
+
+    // Pattern 1: items[N][field] with explicit budget_item_id hidden input
+    const byIdx = {};
+    for (const [, idx, val] of html.matchAll(/items\[(\d+)\]\[budget_item_id\][^>]*value="(\d+)"/gi)) {
+        byIdx[idx] = { budgetItemId: parseInt(val, 10) };
+    }
+    for (const [idx, obj] of Object.entries(byIdx)) {
+        const r = html.match(new RegExp(`items\\[${idx}\\]\\[budget_received\\][^>]*value="([^"]*)"`, 'i'));
+        const u = html.match(new RegExp(`items\\[${idx}\\]\\[budget_utiliz[^"\\]]*\\][^>]*value="([^"]*)"`, 'i'));
+        obj.budgetReceived = parseFloat(r?.[1] || '0') || 0;
+        obj.budgetUtilized = parseFloat(u?.[1] || '0') || 0;
+        if (!seen.has(obj.budgetItemId)) { seen.add(obj.budgetItemId); items.push(obj); }
+    }
+    if (items.length) return items;
+
+    // Pattern 2: budget_received[N] where N is the budget_item_id directly
+    const recvMap = {};
+    const utilMap = {};
+    for (const [, id, val] of html.matchAll(/budget_received\[(\d+)\][^>]*value="([^"]*)"/gi)) {
+        recvMap[id] = parseFloat(val) || 0;
+    }
+    for (const [, id, val] of html.matchAll(/budget_utiliz[a-z]*\[(\d+)\][^>]*value="([^"]*)"/gi)) {
+        utilMap[id] = parseFloat(val) || 0;
+    }
+    for (const id of new Set([...Object.keys(recvMap), ...Object.keys(utilMap)])) {
+        const n = parseInt(id, 10);
+        if (!seen.has(n)) {
+            seen.add(n);
+            items.push({ budgetItemId: n, budgetReceived: recvMap[id] ?? 0, budgetUtilized: utilMap[id] ?? 0 });
+        }
+    }
+    if (items.length) return items;
+
+    // Pattern 3: positional arrays budget_item_id[] / budget_received[] / budget_utilized[]
+    const ids   = [...html.matchAll(/<input[^>]*name="budget_item_id\[\]"[^>]*value="(\d+)"/gi)].map(x => parseInt(x[1], 10));
+    const recvs = [...html.matchAll(/<input[^>]*name="budget_received\[\]"[^>]*value="([^"]*)"/gi)].map(x => parseFloat(x[1]) || 0);
+    const utils = [...html.matchAll(/<input[^>]*name="budget_utiliz[^"]*\[\]"[^>]*value="([^"]*)"/gi)].map(x => parseFloat(x[1]) || 0);
+    ids.forEach((id, i) => {
+        if (!seen.has(id)) {
+            seen.add(id);
+            items.push({ budgetItemId: id, budgetReceived: recvs[i] ?? 0, budgetUtilized: utils[i] ?? 0 });
+        }
+    });
+
+    return items;
+}
+
+function floatOrZero(v) {
+    const n = parseFloat(String(v ?? '').trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Parse budget items from the `fund_detail` field on a DataTables list row.
+ * The field is an HTML-entity-encoded JSON array:
+ *   [{"item":"Critical input","budget_received":"1100000","budget_utilization":"1098578","balance":1422}, ...]
+ * Returns [{itemName, budgetReceived, budgetUtilized}] for find-or-create seeding.
+ */
+function parseFundDetail(raw) {
+    if (!raw) return [];
+    try {
+        const decoded = String(raw)
+            .replace(/&amp;/gi, '&')
+            .replace(/&lt;/gi, '<')
+            .replace(/&gt;/gi, '>')
+            .replace(/&quot;/gi, '"')
+            .replace(/&#039;/gi, "'")
+            .replace(/\\/g, '');
+        const arr = JSON.parse(decoded);
+        if (!Array.isArray(arr)) return [];
+        return arr
+            .filter(e => e && e.item)
+            .map(e => ({
+                itemName: String(e.item).trim(),
+                budgetReceived: floatOrZero(e.budget_received),
+                budgetUtilized: floatOrZero(e.budget_utilization),
+            }));
+    } catch {
+        return [];
+    }
+}
+
+module.exports = {
+    key: 'cfldBudgetUtilization',
+    label: 'CFLD Budget Utilization',
+    model: 'kvkBudgetUtilization',
+    idField: 'budgetId',
+    naturalKey: ['kvkId', 'year', 'cropId', 'seasonId'],
+    enrichCfldBudgetRows,
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        cropId: { master: 'fldCrop', otherField: null },
+        seasonId: { master: 'season', otherField: 'seasonOther' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // ── KVK ───────────────────────────────────────────────────────────
+        const oldKvkName =
+            decodeEntities(cleanText(row.kvk?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            err('kvkId', 'Missing KVK name');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const mappedKvkId = ctx.kvkId;
+
+        // ── Crop (cropId → FldCrop) ───────────────────────────────────────
+        let cropId = null;
+        const rawCropName =
+            decodeEntities(cleanText(row.crop?.name || row['crop.name'] || row.crop?.crop_name)) || '';
+        if (rawCropName) {
+            const c = await r.resolve('fldCrop', 'cropName', 'cropId', rawCropName);
+            if (c.matched) cropId = c.id;
+            else warn('cropId', `Crop "${rawCropName}" not found — stored as null`);
+        }
+
+        // ── Season ────────────────────────────────────────────────────────
+        let seasonId = null;
+        let seasonOther = null;
+        const rawSeasonName =
+            decodeEntities(cleanText(row.season?.season_name || row['season.season_name'])) || '';
+        if (rawSeasonName) {
+            const s = await r.resolve('season', 'seasonName', 'seasonId', rawSeasonName);
+            if (s.matched) seasonId = s.id;
+            else seasonOther = rawSeasonName;
+        }
+
+        // ── Year (required Int) — direct from row.reporting_year ──────────
+        let year = 0;
+        if (row.reporting_year) year = parseInt(String(row.reporting_year), 10) || 0;
+        if (!year && row.year) year = parseInt(String(row.year), 10) || 0;
+        if (!year) err('year', 'Could not determine year — required');
+
+        // ── Reporting year date ───────────────────────────────────────────
+        let reportingYearDate = null;
+        if (year > 1990 && year < 2100) {
+            reportingYearDate = new Date(Date.UTC(year, 3, 1)).toISOString();
+        }
+
+        // ── Fund allocation — direct from list row ────────────────────────
+        const overallFundAllocation = floatOrZero(row.fund_allocated);
+
+        // ── Area — direct from list row (old site typo: area_alloted) ─────
+        const areaAllotted = floatOrZero(row.area_alloted ?? row.area_allotted);
+        const areaAchieved = floatOrZero(row.area_achieved);
+
+        // ── Budget line items — from fund_detail JSON on list row ─────────
+        // fund_detail is a JSON array (HTML-entity-encoded) embedded in the
+        // DataTables response: [{item, budget_received, budget_utilization}, ...]
+        const _budgetItems = parseFundDetail(row.fund_detail);
+        if (!_budgetItems.length) {
+            warn('_budgetItems', 'No budget items parsed from fund_detail — check raw row');
+        }
+
+        return {
+            data: {
+                kvkId: mappedKvkId,
+                year,
+                reportingYearDate,
+                seasonId: seasonId || null,
+                seasonOther: seasonOther || null,
+                cropId: cropId || null,
+                overallFundAllocation,
+                areaAllotted,
+                areaAchieved,
+                _budgetItems,
+            },
+            issues,
+        };
+    },
+
+    async seedRecord(prisma, data) {
+        const budgetItems = data._budgetItems || [];
+        const mainData = { ...data };
+        delete mainData._budgetItems;
+
+        // Upsert main record
+        const where = {
+            kvkId: mainData.kvkId,
+            year: mainData.year,
+            cropId: mainData.cropId ?? null,
+            seasonId: mainData.seasonId ?? null,
+        };
+        const existing = await prisma.kvkBudgetUtilization.findFirst({ where });
+
+        let budgetId;
+        if (existing) {
+            await prisma.kvkBudgetUtilization.update({
+                where: { budgetId: existing.budgetId },
+                data: mainData,
+            });
+            budgetId = existing.budgetId;
+        } else {
+            const created = await prisma.kvkBudgetUtilization.create({ data: mainData });
+            budgetId = created.budgetId;
+        }
+
+        // Upsert each budget line item (find-or-create BudgetItem by name)
+        for (const item of budgetItems) {
+            if (!item.itemName) continue;
+            let master = await prisma.budgetItem.findFirst({
+                where: { itemName: { equals: item.itemName, mode: 'insensitive' } },
+            });
+            if (!master) {
+                master = await prisma.budgetItem.create({ data: { itemName: item.itemName } });
+            }
+            const budgetItemId = master.budgetItemId;
+            await prisma.kvkBudgetUtilizationItem.upsert({
+                where: { budgetId_budgetItemId: { budgetId, budgetItemId } },
+                create: {
+                    budgetId,
+                    budgetItemId,
+                    budgetReceived: item.budgetReceived ?? 0,
+                    budgetUtilized: item.budgetUtilized ?? 0,
+                },
+                update: {
+                    budgetReceived: item.budgetReceived ?? 0,
+                    budgetUtilized: item.budgetUtilized ?? 0,
+                },
+            });
+        }
+
+        return existing ? 'updated' : 'created';
+    },
+};

--- a/backend/migration/modules/cfldExtensionActivity.js
+++ b/backend/migration/modules/cfldExtensionActivity.js
@@ -1,0 +1,250 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, stripHtml } = require('../util.js');
+const prisma = require('../../config/prisma.js');
+
+function extractEditUrl(action) {
+    if (!action) return null;
+    const m =
+        action.match(/href="([^"]*cfld-extension[^"]*\/edit[^"]*)"/i) ||
+        action.match(/href="([^"]*cfld-extension[^"]*\/\d+[^"]*)"/i) ||
+        action.match(/href="([^"]*edit[^"]*)"/i);
+    return m ? m[1] : null;
+}
+
+function cfldExtEditUrl(id, action) {
+    const fromAction = extractEditUrl(action);
+    if (fromAction) {
+        return fromAction.startsWith('http') ? fromAction : `https://atariams.org${fromAction}`;
+    }
+    const token = Buffer.from(String(id)).toString('base64');
+    return `https://atariams.org/edit-cfld-extension/${token}`;
+}
+
+async function enrichCfldExtRows(rows, headers) {
+    const fetchHeaders = {
+        ...headers,
+        accept: 'text/html,application/xhtml+xml',
+        referer: 'https://atariams.org/project/cfld-extension-activity',
+    };
+    const concurrency = 5;
+    const enriched = new Array(rows.length);
+
+    for (let i = 0; i < rows.length; i += concurrency) {
+        const chunk = rows.slice(i, i + concurrency);
+        await Promise.all(
+            chunk.map(async (row, ci) => {
+                const gi = i + ci;
+                const id = row?.id;
+                if (!id) { enriched[gi] = row; return; }
+
+                try {
+                    const url = cfldExtEditUrl(id, row.action);
+                    const res = await fetch(url, { headers: fetchHeaders });
+                    const html = await res.text();
+                    if (res.ok && (html.includes('general_m') || html.includes('general_f') || html.includes('place'))) {
+                        enriched[gi] = { ...row, _editHtml: html };
+                    } else {
+                        enriched[gi] = { ...row, _editHtml: null, _enrichFailed: true };
+                    }
+                } catch {
+                    enriched[gi] = { ...row, _editHtml: null, _enrichFailed: true };
+                }
+            }),
+        );
+    }
+    return enriched;
+}
+
+function parseInputValue(html, name) {
+    if (!html) return '';
+    const m1 = html.match(new RegExp(`<input[^>]*name="${name}"[^>]*value="([^"]*)"`, 'i'));
+    if (m1) return m1[1].trim();
+    const m2 = html.match(new RegExp(`<input[^>]*value="([^"]*)"[^>]*name="${name}"`, 'i'));
+    return m2 ? m2[1].trim() : '';
+}
+
+function parseSelectedOption(html, name) {
+    if (!html) return null;
+    const sel = html.match(new RegExp(`name="${name}"[^>]*>([\\s\\S]*?)<\\/select>`, 'i'));
+    if (!sel) return null;
+    const opt = sel[1].match(/<option[^>]*value="([^"]*)"[^>]*selected[^>]*>([\s\S]*?)<\/option>/i);
+    if (!opt) return null;
+    return { id: opt[1].trim(), name: stripHtml(opt[2]).trim() };
+}
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+module.exports = {
+    key: 'cfldExtensionActivity',
+    label: 'CFLD Extension Activities',
+    model: 'extensionActivityOrganized',
+    idField: 'organizedId',
+    naturalKey: ['kvkId', 'extensionActivityId', 'activityDate', 'placeOfActivity'],
+    enrichCfldExtRows,
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        seasonId: { master: 'season', otherField: 'seasonOther' },
+        extensionActivityId: { master: 'extensionActivity' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // ── KVK ───────────────────────────────────────────────────────────
+        const oldKvkName =
+            decodeEntities(cleanText(row.kvk?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            err('kvkId', 'Missing KVK name');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const mappedKvkId = ctx.kvkId;
+
+        const html = row._editHtml || null;
+        if (!html) {
+            if (row._enrichFailed) warn('*', 'Edit page fetch failed — demographics default to 0');
+            else warn('*', 'No edit page — demographics default to 0');
+        }
+
+        // ── Season ────────────────────────────────────────────────────────
+        let seasonId = null;
+        let seasonOther = null;
+        const rawSeasonName =
+            decodeEntities(cleanText(row.season?.season_name || row['season.season_name'])) || '';
+        if (rawSeasonName) {
+            const s = await r.resolve('season', 'seasonName', 'seasonId', rawSeasonName);
+            if (s.matched) {
+                seasonId = s.id;
+            } else if (html) {
+                const sel =
+                    parseSelectedOption(html, 'season_id') ||
+                    parseSelectedOption(html, 'season');
+                if (sel?.name) {
+                    const s2 = await r.resolve('season', 'seasonName', 'seasonId', sel.name);
+                    if (s2.matched) seasonId = s2.id;
+                    else seasonOther = sel.name;
+                } else {
+                    seasonOther = rawSeasonName;
+                }
+            } else {
+                seasonOther = rawSeasonName;
+            }
+        }
+
+        // ── Extension activity type (organised field) ─────────────────────
+        // Old-site `organised` column contains the activity name text.
+        // Find by name (case-insensitive); create if missing so all old data lands.
+        let extensionActivityId = null;
+        let resolvedName = decodeEntities(cleanText(String(row.organised || '')));
+
+        // Try HTML select first (has exact name used in DB)
+        if (html) {
+            const sel =
+                parseSelectedOption(html, 'extension_activity_id') ||
+                parseSelectedOption(html, 'organised');
+            if (sel?.id) {
+                const n = parseInt(sel.id, 10);
+                if (Number.isFinite(n) && n > 0) {
+                    const found = await prisma.extensionActivity.findUnique({
+                        where: { extensionActivityId: n },
+                    });
+                    if (found) { extensionActivityId = found.extensionActivityId; resolvedName = found.extensionName; }
+                }
+            }
+            if (!extensionActivityId && sel?.name) resolvedName = sel.name || resolvedName;
+        }
+
+        // Find-or-create by name
+        if (!extensionActivityId && resolvedName) {
+            const found = await prisma.extensionActivity.findFirst({
+                where: { extensionName: { equals: resolvedName, mode: 'insensitive' } },
+            });
+            if (found) {
+                extensionActivityId = found.extensionActivityId;
+            } else {
+                const created = await prisma.extensionActivity.create({
+                    data: { extensionName: resolvedName },
+                });
+                extensionActivityId = created.extensionActivityId;
+                warn('extensionActivityId', `Created ExtensionActivity "${resolvedName}"`);
+            }
+        }
+
+        if (!extensionActivityId)
+            err('extensionActivityId', 'Missing extension activity name — cannot resolve or create');
+
+        // ── Activity date ─────────────────────────────────────────────────
+        let activityDate = null;
+        const rawDate = row.date || row.activity_date;
+        if (rawDate) activityDate = parseDate(String(rawDate));
+        if (!activityDate && html) {
+            const v =
+                parseInputValue(html, 'date') ||
+                parseInputValue(html, 'activity_date');
+            if (v) activityDate = parseDate(v);
+        }
+        if (!activityDate) err('activityDate', 'Missing activity date (required)');
+
+        // ── Place ─────────────────────────────────────────────────────────
+        let placeOfActivity = decodeEntities(cleanText(String(row.place || '')));
+        if (!placeOfActivity && html) {
+            placeOfActivity = decodeEntities(
+                cleanText(
+                    parseInputValue(html, 'place') ||
+                    parseInputValue(html, 'place_of_activity'),
+                ),
+            );
+        }
+        if (!placeOfActivity) warn('placeOfActivity', 'Missing place — stored as empty string');
+
+        // ── Demographics ──────────────────────────────────────────────────
+        let generalM = 0, generalF = 0, obcM = 0, obcF = 0;
+        let scM = 0, scF = 0, stM = 0, stF = 0;
+        if (html) {
+            generalM = intOrZero(parseInputValue(html, 'general_m'));
+            generalF = intOrZero(parseInputValue(html, 'general_f'));
+            obcM    = intOrZero(parseInputValue(html, 'obc_m'));
+            obcF    = intOrZero(parseInputValue(html, 'obc_f'));
+            scM     = intOrZero(parseInputValue(html, 'sc_m'));
+            scF     = intOrZero(parseInputValue(html, 'sc_f'));
+            stM     = intOrZero(parseInputValue(html, 'st_m'));
+            stF     = intOrZero(parseInputValue(html, 'st_f'));
+        } else {
+            const listTotal = intOrZero(row.sub_total);
+            if (listTotal > 0) {
+                generalM = listTotal;
+                warn('generalM', `No edit page — placed sub_total (${listTotal}) into generalM`);
+            }
+        }
+
+        return {
+            data: {
+                kvkId: mappedKvkId,
+                seasonId: seasonId || null,
+                seasonOther: seasonOther || null,
+                extensionActivityId,
+                activityDate,
+                placeOfActivity: placeOfActivity || '',
+                generalM,
+                generalF,
+                obcM,
+                obcF,
+                scM,
+                scF,
+                stM,
+                stF,
+            },
+            issues,
+        };
+    },
+};

--- a/backend/migration/modules/cfldTechnicalParameter.js
+++ b/backend/migration/modules/cfldTechnicalParameter.js
@@ -1,0 +1,757 @@
+const { normalize } = require('../masterResolver.js');
+const prisma = require('../../config/prisma.js');
+const {
+    parseYearMonth,
+    parseDate,
+    decodeEntities,
+    cleanText,
+    stripHtml,
+} = require('../util.js');
+
+const SEASON_MAP = { 1: 'Kharif', 2: 'Rabi', 3: 'Summer' };
+
+const STATUS_MAP = {
+    ongoing: 'ONGOING',
+    transferred: 'TRANSFERRED',
+    transfered: 'TRANSFERRED',
+    transferred_to_next_year: 'TRANSFERRED',
+    completed: 'COMPLETED',
+};
+
+function normalizeCfldStatus(raw) {
+    if (!raw) return 'ONGOING';
+    const key = raw.toLowerCase().replace(/[\s-]+/g, '_');
+    return STATUS_MAP[key] || 'ONGOING';
+}
+
+function getRawStatusText(row) {
+    const progressHtml = row.progress_status || '';
+    if (progressHtml.toLowerCase().includes('transfer')) return 'transferred';
+    if (progressHtml.toLowerCase().includes('complete')) return 'completed';
+    if (row.status) return row.status;
+    if (progressHtml) return stripHtml(progressHtml);
+    return '';
+}
+
+/** Extract the edit page URL from the action HTML. */
+function extractEditUrl(action) {
+    if (!action) return null;
+    // matches href="…cfld…edit…" or href="…cfld/{id}/edit" patterns
+    const m =
+        action.match(/href="([^"]*cfld[^"]*\/edit[^"]*)"/i) ||
+        action.match(/href="([^"]*cfld[^"\/]*\/\d+[^"]*)"/i) ||
+        action.match(/href="([^"]*edit[^"]*)"/i);
+    return m ? m[1] : null;
+}
+
+function cfldEditUrl(id, action) {
+    const fromAction = extractEditUrl(action);
+    if (fromAction) {
+        return fromAction.startsWith('http')
+            ? fromAction
+            : `https://atariams.org${fromAction}`;
+    }
+    // Fallback: same base64 token convention as OFT/FLD
+    const token = Buffer.from(String(id)).toString('base64');
+    return `https://atariams.org/edit-cfld/${token}`;
+}
+
+/** Extract numeric record id from the row or its action HTML. */
+function extractNumericId(row) {
+    if (row?.id && /^\d+$/.test(String(row.id))) return String(row.id);
+    const action = row?.action || '';
+    const m =
+        action.match(/\/cfld\/(\d+)\//i) ||
+        action.match(/\/(\d+)\/edit/i) ||
+        action.match(/data-id=['"](\d+)['"]/i) ||
+        action.match(/\?id=(\d+)/i);
+    return m ? m[1] : null;
+}
+
+/**
+ * Candidate sub-form URLs for each section. The old site uses one of these
+ * route patterns; we try them all and accept the first that returns valid HTML
+ * containing a known section-specific field name.
+ */
+function subformUrlCandidates(numericId, section) {
+    const token = Buffer.from(String(numericId)).toString('base64');
+    const base = 'https://atariams.org';
+
+    const routes = {
+        economic: [
+            `${base}/edit-cfld-economic/${token}`,
+            `${base}/project/cfldeconomicparameters/${numericId}/edit`,
+            `${base}/project/cfldeconomic/${numericId}/edit`,
+            `${base}/project/cfld-economic-parameters/${numericId}/edit`,
+            `${base}/project/cfld/${numericId}/economic/edit`,
+        ],
+        socio: [
+            `${base}/edit-cfld-socio/${token}`,
+            `${base}/project/cfldsocioeconomicparameters/${numericId}/edit`,
+            `${base}/project/cfldsocioeconomic/${numericId}/edit`,
+            `${base}/project/cfld-socio-economic-parameters/${numericId}/edit`,
+            `${base}/project/cfld/${numericId}/socioeconomic/edit`,
+        ],
+        perception: [
+            `${base}/edit-cfld-perception/${token}`,
+            `${base}/project/cfldfarmersperceptionparameters/${numericId}/edit`,
+            `${base}/project/cfldfarmerspercption/${numericId}/edit`,
+            `${base}/project/cfldperception/${numericId}/edit`,
+            `${base}/project/cfld-farmers-perception-parameters/${numericId}/edit`,
+            `${base}/project/cfld/${numericId}/perception/edit`,
+        ],
+    };
+    return routes[section] || [];
+}
+
+/** Try each candidate URL; return first HTML that contains `checkStr`. */
+async function tryFetchSubform(candidates, headers, checkStr) {
+    for (const url of candidates) {
+        try {
+            const res = await fetch(url, { headers });
+            if (!res.ok) continue;
+            const html = await res.text();
+            if (html.includes(checkStr)) return html;
+        } catch { /* next */ }
+    }
+    return null;
+}
+
+/**
+ * Scan main edit page HTML for sub-form links as a FASTER fallback before
+ * brute-force URL construction. Returns { economic, socio, perception } hrefs.
+ */
+function parseSubformLinks(html) {
+    const links = {};
+    for (const [, href] of html.matchAll(/href="([^"]+)"/gi)) {
+        const u = href.toLowerCase();
+        if (!links.economic && (u.includes('economic') && !u.includes('socio'))) links.economic = href;
+        if (!links.socio && u.includes('socio')) links.socio = href;
+        if (!links.perception && (u.includes('perception') || u.includes('perceiv'))) links.perception = href;
+    }
+    return links;
+}
+
+function toAbsoluteUrl(href) {
+    if (!href) return null;
+    return href.startsWith('http') ? href : `https://atariams.org${href}`;
+}
+
+async function enrichCfldRows(rows, headers) {
+    const fetchHeaders = {
+        ...headers,
+        accept: 'text/html,application/xhtml+xml',
+        referer: 'https://atariams.org/project/cfld',
+    };
+    const concurrency = 5;
+    const enriched = new Array(rows.length);
+
+    for (let i = 0; i < rows.length; i += concurrency) {
+        const chunk = rows.slice(i, i + concurrency);
+        await Promise.all(
+            chunk.map(async (row, ci) => {
+                const gi = i + ci;
+                const id = row?.id;
+                if (!id) { enriched[gi] = row; return; }
+
+                let enrichedRow = {
+                    ...row,
+                    _editHtml: null,
+                    _economicHtml: null,
+                    _socioHtml: null,
+                    _perceptionHtml: null,
+                };
+
+                // 1. Main edit page
+                let mainHtml = null;
+                try {
+                    const url = cfldEditUrl(id, row.action);
+                    const res = await fetch(url, { headers: fetchHeaders });
+                    const html = await res.text();
+                    if (res.ok && (html.includes('variety_name') || html.includes('existing_yield') || html.includes('yield_max'))) {
+                        mainHtml = html;
+                        enrichedRow._editHtml = html;
+                    } else {
+                        enrichedRow._enrichFailed = true;
+                    }
+                } catch {
+                    enrichedRow._enrichFailed = true;
+                }
+
+                // 2. Sub-form pages
+                // Strategy: parse links from main page first (fast); fall back to
+                // trying all known URL patterns (slow but exhaustive).
+                if (mainHtml) {
+                    const numId = extractNumericId(row);
+                    const subLinks = parseSubformLinks(mainHtml);
+
+                    const fetchSubform = async (section, checkStr) => {
+                        // a. Link extracted from main page HTML
+                        const fromLink = subLinks[section];
+                        if (fromLink) {
+                            try {
+                                const res = await fetch(toAbsoluteUrl(fromLink), { headers: fetchHeaders });
+                                if (res.ok) {
+                                    const html = await res.text();
+                                    if (html.includes(checkStr)) return html;
+                                }
+                            } catch { /* fall through */ }
+                        }
+                        // b. Brute-force URL candidates
+                        if (numId) {
+                            return tryFetchSubform(
+                                subformUrlCandidates(numId, section),
+                                fetchHeaders,
+                                checkStr,
+                            );
+                        }
+                        return null;
+                    };
+
+                    const [econHtml, socioHtml, percHtml] = await Promise.all([
+                        fetchSubform('economic', 'gross_cost'),
+                        fetchSubform('socio', 'total_produce'),
+                        fetchSubform('perception', 'suitability'),
+                    ]);
+
+                    if (econHtml) enrichedRow._economicHtml = econHtml;
+                    if (socioHtml) enrichedRow._socioHtml = socioHtml;
+                    if (percHtml) enrichedRow._perceptionHtml = percHtml;
+                }
+
+                enriched[gi] = enrichedRow;
+            }),
+        );
+    }
+    return enriched;
+}
+
+function parseInputValue(html, name) {
+    if (!html) return '';
+    const m1 = html.match(new RegExp(`<input[^>]*name="${name}"[^>]*value="([^"]*)"`, 'i'));
+    if (m1) return m1[1].trim();
+    const m2 = html.match(new RegExp(`<input[^>]*value="([^"]*)"[^>]*name="${name}"`, 'i'));
+    return m2 ? m2[1].trim() : '';
+}
+
+function parseTextarea(html, name) {
+    if (!html) return '';
+    const m = html.match(new RegExp(`name="${name}"[^>]*>([\\s\\S]*?)<\\/textarea>`, 'i'));
+    return m ? m[1].trim() : '';
+}
+
+function parseSelectedOption(html, name) {
+    if (!html) return null;
+    const sel = html.match(new RegExp(`name="${name}"[^>]*>([\\s\\S]*?)<\\/select>`, 'i'));
+    if (!sel) return null;
+    const opt = sel[1].match(/<option[^>]*value="([^"]*)"[^>]*selected[^>]*>([\s\S]*?)<\/option>/i);
+    return opt ? { id: opt[1].trim(), name: stripHtml(opt[2]).trim() } : null;
+}
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+function floatOrZero(v) {
+    const n = parseFloat(String(v ?? '').trim());
+    return Number.isFinite(n) ? n : 0;
+}
+function maybeFloat(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return null;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : null;
+}
+
+module.exports = {
+    key: 'cfldTechnicalParameter',
+    label: 'CFLD Technical Parameters',
+    model: 'cfldTechnicalParameter',
+    idField: 'cfldTechId',
+    // status included: old site has distinct ONGOING and COMPLETED records for the same
+    // crop+tech+month — without status they collide and update instead of creating.
+    naturalKey: ['kvkId', 'cropId', 'technologyDemonstrated', 'month', 'status'],
+    enrichCfldRows,
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        cropId: { master: 'cfldCrop', otherField: 'cropOther' },
+        typeId: { master: 'cropType', otherField: 'typeOther' },
+        seasonId: { master: 'season', otherField: 'seasonOther' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // ── KVK match by name ──────────────────────────────────────────────
+        const oldKvkName =
+            decodeEntities(cleanText(row.kvk?.kvk_name || row['kvk.kvk_name'])) || '';
+        const targetKvkName = ctx.targetKvkName || '';
+        const mappedKvkId = ctx.kvkId;
+
+        if (!oldKvkName) {
+            err('kvkId', 'Missing KVK name on old row (kvk.kvk_name)');
+        } else if (normalize(oldKvkName) !== normalize(targetKvkName)) {
+            return {
+                data: null,
+                issues: [{
+                    field: 'kvkId',
+                    message: `Row KVK "${oldKvkName}" ≠ selected "${targetKvkName}" — skipped`,
+                    severity: 'warn',
+                }],
+            };
+        }
+
+        const html = row._editHtml || null;
+        if (!html) {
+            if (row._enrichFailed) {
+                warn('*', 'Edit page fetch failed — many fields will default to 0/empty');
+            } else {
+                warn('*', 'No edit page — using list-view fields only (incomplete)');
+            }
+        }
+
+        // ── Status ────────────────────────────────────────────────────────
+        const status = normalizeCfldStatus(getRawStatusText(row));
+
+        // ── Reporting year ────────────────────────────────────────────────
+        let reportingYear = null;
+        const rawYear = row.reporting_year;
+        if (rawYear) {
+            const y = parseInt(String(rawYear).trim(), 10);
+            if (Number.isFinite(y) && y > 1990 && y < 2100) {
+                reportingYear = new Date(Date.UTC(y, 3, 1)).toISOString(); // April = Indian FY
+            }
+        }
+
+        // ── Month (required) ──────────────────────────────────────────────
+        // Primary: start_date from DataTables list already encodes YYYY-MM.
+        // Secondary: month select dropdown (value 1-12 month name) + year from start_date.
+        let month = null;
+
+        if (row.start_date) {
+            month = parseYearMonth(String(row.start_date)) || parseDate(String(row.start_date));
+        }
+
+        if (!month && html) {
+            // Month select gives month number 1-12 (or month name); combine with year
+            const monthSel = parseSelectedOption(html, 'month');
+            let monthNum = 0;
+            if (monthSel?.id) monthNum = parseInt(monthSel.id, 10);
+            else if (monthSel?.name) {
+                const MONTH_NAMES = ['january','february','march','april','may','june',
+                    'july','august','september','october','november','december'];
+                monthNum = MONTH_NAMES.indexOf(monthSel.name.toLowerCase()) + 1;
+            }
+            if (monthNum >= 1 && monthNum <= 12) {
+                let year = 0;
+                if (row.start_date) {
+                    const m = String(row.start_date).match(/^(\d{4})/);
+                    if (m) year = parseInt(m[1], 10);
+                }
+                if (!year && reportingYear) year = new Date(reportingYear).getUTCFullYear();
+                if (year) month = new Date(Date.UTC(year, monthNum - 1, 1)).toISOString();
+            }
+        }
+
+        if (!month && reportingYear) {
+            month = reportingYear;
+            warn('month', 'No start_date or month select — defaulted to reporting year start');
+        }
+        if (!month) err('month', 'Missing month (required)');
+
+        // ── Season ────────────────────────────────────────────────────────
+        let seasonId = null;
+        let seasonOther = null;
+        if (html) {
+            const sel =
+                parseSelectedOption(html, 'season_id') ||
+                parseSelectedOption(html, 'season');
+            if (sel?.name) {
+                const s = await r.resolve('season', 'seasonName', 'seasonId', sel.name);
+                if (s.matched) seasonId = s.id;
+                else seasonOther = sel.name;
+            }
+        }
+        if (!seasonId && row.crop?.season_id) {
+            const nm = SEASON_MAP[row.crop.season_id];
+            if (nm) {
+                const s = await r.resolve('season', 'seasonName', 'seasonId', nm);
+                if (s.matched) seasonId = s.id;
+            }
+        }
+        if (!seasonId) warn('seasonId', 'Season not found — will be null');
+
+        // ── Crop type (typeId → CropType) ─────────────────────────────────
+        // Resolution order:
+        //  1. HTML select id passthrough (old ids 1=Pulses 2=Oilseed align with ours)
+        //  2. HTML select label name match
+        //  3. row.crop_type string (DataTables list sends this as plain text e.g. "oilseed")
+        //  4. row.crop?.type_id numeric passthrough
+        let typeId = null;
+        let typeOther = null;
+
+        if (html) {
+            const sel =
+                parseSelectedOption(html, 'crop_type_id') ||
+                parseSelectedOption(html, 'type_id');
+            if (sel?.id) {
+                const byId = await r.resolveById('cropType', 'typeName', 'typeId', sel.id);
+                if (byId.matched) typeId = byId.id;
+            }
+            if (!typeId && sel?.name) {
+                const byName = await r.resolve('cropType', 'typeName', 'typeId', sel.name);
+                if (byName.matched) typeId = byName.id;
+                else typeOther = sel.name;
+            }
+        }
+        // row.crop_type is the plain-text type name from the DataTables list JSON
+        if (!typeId && row.crop_type) {
+            const byName = await r.resolve('cropType', 'typeName', 'typeId', row.crop_type);
+            if (byName.matched) typeId = byName.id;
+        }
+        if (!typeId && row.crop?.type_id) {
+            const byId = await r.resolveById('cropType', 'typeName', 'typeId', row.crop.type_id);
+            if (byId.matched) typeId = byId.id;
+        }
+        if (!typeId) err('typeId', `Crop type "${row.crop_type || ''}" not found (required)`);
+
+        // ── Crop (cropId → FLDCropMaster.cfldId) ─────────────────────────
+        let cropId = null;
+        let cropOther = null;
+        const cropName =
+            decodeEntities(
+                cleanText(row.crop?.name || row['crop.name'] || row.crop?.crop_name),
+            ) || '';
+
+        if (cropName) {
+            const where = { cropName: { equals: cropName, mode: 'insensitive' } };
+            if (typeId) where.typeId = typeId;
+            if (seasonId) where.seasonId = seasonId;
+            const found = await prisma.fLDCropMaster.findFirst({ where });
+            if (found) {
+                cropId = found.cfldId;
+            } else if (typeId && seasonId) {
+                const created = await prisma.fLDCropMaster.create({
+                    data: { cropName, typeId, seasonId },
+                });
+                cropId = created.cfldId;
+                warn('cropId', `Created FLDCropMaster "${cropName}" (typeId=${typeId}, seasonId=${seasonId})`);
+            } else {
+                cropOther = cropName;
+                err('cropId', `Crop "${cropName}" not found; need typeId+seasonId to create`);
+            }
+        } else {
+            err('cropId', 'Missing crop name');
+        }
+
+        // ── Technology demonstrated ───────────────────────────────────────
+        let technologyDemonstrated =
+            decodeEntities(cleanText(row.technology_demo)) || '';
+        if (html) {
+            const fromHtml = decodeEntities(
+                cleanText(
+                    parseInputValue(html, 'technology_demonstrated') ||
+                    parseTextarea(html, 'technology_demonstrated'),
+                ),
+            );
+            if (fromHtml) technologyDemonstrated = fromHtml;
+        }
+        if (!technologyDemonstrated) err('technologyDemonstrated', 'Missing technology demonstrated');
+
+        // ── Variety name ─────────────────────────────────────────────────
+        let varietyName = '';
+        if (html) varietyName = decodeEntities(cleanText(parseInputValue(html, 'variety_name'))) || '';
+        if (!varietyName) {
+            varietyName = 'Not specified';
+            warn('varietyName', 'Missing variety_name — defaulted to "Not specified"');
+        }
+
+        // ── Existing farmer practice ──────────────────────────────────────
+        // Old site stores this as "existing_variety_name" (misleadingly named —
+        // it's the existing farmer practice / variety in farmer's field).
+        let existingFarmerPractice = '';
+        if (html) {
+            existingFarmerPractice =
+                decodeEntities(
+                    cleanText(
+                        parseInputValue(html, 'existing_variety_name') ||
+                        parseTextarea(html, 'existing_variety_name') ||
+                        parseTextarea(html, 'existing_farmer_practice') ||
+                        parseInputValue(html, 'existing_farmer_practice'),
+                    ),
+                ) || '';
+        }
+        if (!existingFarmerPractice) warn('existingFarmerPractice', 'Missing — stored as empty string');
+
+        // ── Area ─────────────────────────────────────────────────────────
+        let areaInHa = floatOrZero(row.area);
+        if (html) {
+            const v = floatOrZero(
+                parseInputValue(html, 'area_in_ha') || parseInputValue(html, 'area'),
+            );
+            if (v > 0) areaInHa = v;
+        }
+
+        // ── Yield fields ──────────────────────────────────────────────────
+        // Old-site HTML field names (confirmed from edit form):
+        //   existing_yield → farmerYield   (label: "Yield (q/ha) in farmer field Local")
+        //   yield_max      → demoYieldMax
+        //   yield_min      → demoYieldMin
+        //   yield_avg      → demoYieldAvg
+        //   yield_increase → percentIncrease
+        //   yield_gap_d    → yieldGapDistrictMinimized
+        //   yield_gap_s    → yieldGapStateMinimized
+        //   yield_gap_p    → yieldGapPotentialMinimized
+        // district_yield / state_yield / potential_yield keep their names.
+        let districtYield = floatOrZero(row.district_yield);
+        let stateYield = floatOrZero(row.state_yield);
+        let potentialYield = floatOrZero(row.potential_yield);
+        let farmerYield = 0;
+        let demoYieldMax = 0;
+        let demoYieldMin = 0;
+        let demoYieldAvg = 0;
+        let percentIncrease = 0;
+        let yieldGapDistrictMinimized = 0;
+        let yieldGapStateMinimized = 0;
+        let yieldGapPotentialMinimized = 0;
+
+        if (html) {
+            farmerYield = floatOrZero(parseInputValue(html, 'existing_yield') || parseInputValue(html, 'farmer_yield'));
+            demoYieldMax = floatOrZero(parseInputValue(html, 'yield_max') || parseInputValue(html, 'demo_yield_max'));
+            demoYieldMin = floatOrZero(parseInputValue(html, 'yield_min') || parseInputValue(html, 'demo_yield_min'));
+            demoYieldAvg = floatOrZero(parseInputValue(html, 'yield_avg') || parseInputValue(html, 'demo_yield_avg'));
+            percentIncrease = floatOrZero(parseInputValue(html, 'yield_increase') || parseInputValue(html, 'percent_increase'));
+            // district/state/potential yield: list-view values are authoritative.
+            // Edit page often has differently-scaled or stale values — only use as
+            // fallback when the DataTables list gave us 0.
+            if (!districtYield) districtYield = floatOrZero(parseInputValue(html, 'district_yield'));
+            if (!stateYield) stateYield = floatOrZero(parseInputValue(html, 'state_yield'));
+            if (!potentialYield) potentialYield = floatOrZero(parseInputValue(html, 'potential_yield'));
+            yieldGapDistrictMinimized = floatOrZero(parseInputValue(html, 'yield_gap_d') || parseInputValue(html, 'yield_gap_district_minimized'));
+            yieldGapStateMinimized = floatOrZero(parseInputValue(html, 'yield_gap_s') || parseInputValue(html, 'yield_gap_state_minimized'));
+            yieldGapPotentialMinimized = floatOrZero(parseInputValue(html, 'yield_gap_p') || parseInputValue(html, 'yield_gap_potential_minimized'));
+        }
+
+        // ── Farmer demographics ───────────────────────────────────────────
+        let generalM = 0, generalF = 0, obcM = 0, obcF = 0;
+        let scM = 0, scF = 0, stM = 0, stF = 0;
+        if (html) {
+            generalM = intOrZero(parseInputValue(html, 'general_m'));
+            generalF = intOrZero(parseInputValue(html, 'general_f'));
+            obcM = intOrZero(parseInputValue(html, 'obc_m'));
+            obcF = intOrZero(parseInputValue(html, 'obc_f'));
+            scM = intOrZero(parseInputValue(html, 'sc_m'));
+            scF = intOrZero(parseInputValue(html, 'sc_f'));
+            stM = intOrZero(parseInputValue(html, 'st_m'));
+            stF = intOrZero(parseInputValue(html, 'st_f'));
+        } else {
+            // No edit HTML: put list sub_total into generalM as best-effort
+            const listTotal = intOrZero(row.sub_total);
+            if (listTotal > 0) {
+                generalM = listTotal;
+                warn('generalM', `No edit page — placed sub_total (${listTotal}) into generalM`);
+            }
+        }
+
+        // ── Photo paths ───────────────────────────────────────────────────
+        let trainingPhotoPath = null;
+        let qualityActionPhotoPath = null;
+        if (html) {
+            trainingPhotoPath =
+                cleanText(parseInputValue(html, 'training_photo_path') || parseInputValue(html, 'training_photo')) || null;
+            qualityActionPhotoPath =
+                cleanText(parseInputValue(html, 'quality_action_photo_path') || parseInputValue(html, 'quality_action_photo')) || null;
+        }
+
+        // Helper: HTML textarea/input first, then raw DataTables row field.
+        // Old-site list JSON sometimes embeds sub-form values directly on each row.
+        const anyVal = (hHtml, ...names) => {
+            if (hHtml) {
+                for (const n of names) {
+                    const v = parseTextarea(hHtml, n) || parseInputValue(hHtml, n);
+                    if (v) return v;
+                }
+            }
+            for (const n of names) {
+                const v = row[n];
+                if (v !== null && v !== undefined && String(v).trim() !== '') return String(v);
+            }
+            return '';
+        };
+
+        // ── Economic parameters ───────────────────────────────────────────
+        // Sources tried in order: dedicated sub-form HTML → main edit HTML → raw row fields
+        // Old-site field names: farmer_gross_cost, farmer_gross_return, farmer_net_return,
+        // farmer_bc_ratio, demo_gross_return, demo_net_return, demo_bc_ratio, income
+        let economicParameters = null;
+        {
+            const eHtml = row._economicHtml || html;
+            const farmerCostF  = maybeFloat(anyVal(eHtml, 'farmer_gross_cost'));
+            const demoReturnF  = maybeFloat(anyVal(eHtml, 'demo_gross_return'));
+            if (farmerCostF || demoReturnF) {
+                economicParameters = {
+                    status,
+                    existingPlotGrossCost:        farmerCostF,
+                    existingPlotGrossReturn:      maybeFloat(anyVal(eHtml, 'farmer_gross_return')),
+                    existingPlotNetReturn:        maybeFloat(anyVal(eHtml, 'farmer_net_return')),
+                    existingPlotBcr:             maybeFloat(anyVal(eHtml, 'farmer_bc_ratio')),
+                    demonstrationPlotGrossCost:   null,
+                    demonstrationPlotGrossReturn: demoReturnF,
+                    demonstrationPlotNetReturn:   maybeFloat(anyVal(eHtml, 'demo_net_return')),
+                    demonstrationPlotBcr:         maybeFloat(anyVal(eHtml, 'demo_bc_ratio')),
+                    additionalIncome:             maybeFloat(anyVal(eHtml, 'income')),
+                };
+            } else {
+                warn('_economicParameters', 'No economic data found in sub-form HTML or list row fields');
+            }
+        }
+
+        // ── Socio-economic parameters ─────────────────────────────────────
+        // Old-site field names: total_produce, produce_sold, selling_rate,
+        // produce_used, produce_distributed, purpose, employment_generated
+        let socioEconomicParameters = null;
+        {
+            const sHtml = row._socioHtml || html;
+            const totalProduceF = maybeFloat(anyVal(sHtml, 'total_produce'));
+            if (totalProduceF) {
+                socioEconomicParameters = {
+                    status,
+                    totalProduceObtainedKg:                totalProduceF,
+                    produceSoldKgPerHousehold:              maybeFloat(anyVal(sHtml, 'produce_sold')),
+                    sellingRateRsPerKg:                     maybeFloat(anyVal(sHtml, 'selling_rate')),
+                    produceUsedForOwnSowingKg:              maybeFloat(anyVal(sHtml, 'produce_used')),
+                    produceDistributedToOtherFarmersKg:     maybeFloat(anyVal(sHtml, 'produce_distributed')),
+                    incomeUtilizationPurpose:               cleanText(anyVal(sHtml,  'purpose')),
+                    employmentGeneratedMandaysPerHousehold: maybeFloat(anyVal(sHtml, 'employment_generated')),
+                };
+            } else {
+                warn('_socioEconomicParameters', 'No socio-economic data found in sub-form HTML or list row fields');
+            }
+        }
+
+        // ── Farmers perception parameters ─────────────────────────────────
+        // Old-site field names: sustainability, linkings, affordability,
+        // negative_effect, is_acceptable, suggestions, farmer_feedback
+        let farmersPerceptionParameters = null;
+        {
+            const pHtml = row._perceptionHtml || html;
+            const sustainability = anyVal(pHtml, 'sustainability');
+            if (sustainability) {
+                farmersPerceptionParameters = {
+                    status,
+                    suitabilityToFarmingSystem:             cleanText(sustainability),
+                    likingPreference:                       cleanText(anyVal(pHtml, 'linkings')),
+                    affordability:                          cleanText(anyVal(pHtml, 'affordability')),
+                    anyNegativeEffect:                      cleanText(anyVal(pHtml, 'negative_effect')),
+                    technologyAcceptableToAllGroupVillage:  cleanText(anyVal(pHtml, 'is_acceptable')),
+                    suggestionsForChangeOrImprovementIfAny: cleanText(anyVal(pHtml, 'suggestions')),
+                    farmerFeedback:                         cleanText(anyVal(pHtml, 'farmer_feedback')),
+                };
+            } else {
+                warn('_farmersPerceptionParameters', 'No farmers perception data found in sub-form HTML or list row fields');
+            }
+        }
+
+        const data = {
+            kvkId: mappedKvkId,
+            cropId,
+            cropOther: cropOther || null,
+            month,
+            typeId,
+            typeOther: typeOther || null,
+            seasonId: seasonId || null,
+            seasonOther: seasonOther || null,
+            reportingYear: reportingYear || null,
+            status,
+            varietyName,
+            areaInHa,
+            technologyDemonstrated,
+            existingFarmerPractice,
+            farmerYield,
+            demoYieldMax,
+            demoYieldMin,
+            demoYieldAvg,
+            percentIncrease,
+            districtYield,
+            stateYield,
+            potentialYield,
+            yieldGapDistrictMinimized,
+            yieldGapStateMinimized,
+            yieldGapPotentialMinimized,
+            generalM,
+            generalF,
+            obcM,
+            obcF,
+            scM,
+            scF,
+            stM,
+            stF,
+            trainingPhotoPath,
+            qualityActionPhotoPath,
+            _economicParameters: economicParameters,
+            _socioEconomicParameters: socioEconomicParameters,
+            _farmersPerceptionParameters: farmersPerceptionParameters,
+        };
+
+        return { data, issues };
+    },
+
+    async seedRecord(prisma, data) {
+        const ep = data._economicParameters;
+        const sep = data._socioEconomicParameters;
+        const fpp = data._farmersPerceptionParameters;
+
+        const mainData = { ...data };
+        delete mainData._economicParameters;
+        delete mainData._socioEconomicParameters;
+        delete mainData._farmersPerceptionParameters;
+
+        const where = {
+            kvkId: mainData.kvkId,
+            cropId: mainData.cropId,
+            technologyDemonstrated: mainData.technologyDemonstrated,
+            month: mainData.month,
+            status: mainData.status,
+        };
+        const existing = await prisma.cfldTechnicalParameter.findFirst({ where });
+
+        let cfldTechId;
+        if (existing) {
+            await prisma.cfldTechnicalParameter.update({
+                where: { cfldTechId: existing.cfldTechId },
+                data: mainData,
+            });
+            cfldTechId = existing.cfldTechId;
+        } else {
+            const created = await prisma.cfldTechnicalParameter.create({ data: mainData });
+            cfldTechId = created.cfldTechId;
+        }
+
+        if (ep) {
+            await prisma.cfldEconomicParameters.upsert({
+                where: { cfldTechId },
+                create: { cfldTechId, ...ep },
+                update: ep,
+            });
+        }
+        if (sep) {
+            await prisma.cfldSocioEconomicParameters.upsert({
+                where: { cfldTechId },
+                create: { cfldTechId, ...sep },
+                update: sep,
+            });
+        }
+        if (fpp) {
+            await prisma.cfldFarmersPerceptionParameters.upsert({
+                where: { cfldTechId },
+                create: { cfldTechId, ...fpp },
+                update: fpp,
+            });
+        }
+
+        return existing ? 'updated' : 'created';
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -10,6 +10,9 @@ const specs = [
     require('./modules/vehicle.js'),
     require('./modules/vehicleDetails.js'),
     require('./modules/fld.js'),
+    require('./modules/cfldTechnicalParameter.js'),
+    require('./modules/cfldExtensionActivity.js'),
+    require('./modules/cfldBudgetUtilization.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));

--- a/frontend/src/pages/migration/views/tableUtils.ts
+++ b/frontend/src/pages/migration/views/tableUtils.ts
@@ -10,9 +10,10 @@ export interface IndexedRow {
 /** Nested objects from atariams.org DataTables rows → flat columns for tables. */
 const NESTED_FLATTEN: Record<string, string[]> = {
     kvks: ['kvk_name'],
+    kvk: ['kvk_name'],
     subject_name: ['oft_subject'],
     cropcategory: ['title'],
-    crop: ['crop_name'],
+    crop: ['crop_name', 'name'],
 }
 
 /** Keys too noisy for spreadsheet views (HTML blobs, row counters). */


### PR DESCRIPTION
## Summary

- **cfldTechnicalParameter**: maps all three CFLD sub-forms (economic parameters, socio-economic parameters, farmers perception) using exact old-site field names (`farmer_gross_cost`, `sustainability`, `linkings`, etc.); `naturalKey` includes `cropId` + `status` to prevent within-batch collisions between ONGOING/COMPLETED rows
- **cfldExtensionActivity**: resolves `organised` → `ExtensionActivity` master via find-or-create (case-insensitive); enriches demographic breakdown (general/OBC/SC/ST M+F) from edit page HTML
- **cfldBudgetUtilization**: parses `fund_detail` JSON field embedded in DataTables list row directly (no edit page fetch needed); find-or-create `BudgetItem` master by `itemName`; upserts `KvkBudgetUtilizationItem` per line item
- **engine.js**: enrichment hooks for CFLD technical-param and extension-activity curl endpoints
- **masterCatalog.js**: added `cfldCrop`, `cropType`, `extensionActivity` masters
- **registry.js**: registered three new CFLD module specs
- **tableUtils.ts**: flatten `kvk.kvk_name` and `crop.name` nested fields for DataTables display

## Test plan

- [ ] Paste CFLD technical parameter curl → verify mapped rows show economic/socio-economic/farmers-perception sub-objects populated (not null)
- [ ] Seed CFLD technical parameter → confirm all rows created, ONGOING and COMPLETED distinct records both land in DB
- [ ] Paste CFLD extension activity curl → verify `extensionActivityId` resolved; new activity names auto-created in master
- [ ] Seed extension activity → demographic fields (generalM/F, obcM/F, scM/F, stM/F) persisted
- [ ] Paste CFLD budget utilization curl → verify `_budgetItems` populated from `fund_detail` (not empty)
- [ ] Seed budget utilization → `BudgetItem` master entries created; `KvkBudgetUtilizationItem` rows upserted per line item

🤖 Generated with [Claude Code](https://claude.com/claude-code)