### PR TITLE
feat(migration): equipment-details module fixes

### DIFF
--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -44,6 +44,8 @@ const MASTER_CATALOG = {
     },
     // The parent vehicle, used by the vehicle-details FK picker.
     vehicle: { model: 'kvkVehicle', idField: 'vehicleId', nameField: 'vehicleName' },
+    // The parent equipment, used by the equipment-details FK picker.
+    kvkEquipment: { model: 'kvkEquipment', idField: 'equipmentId', nameField: 'equipmentName' },
     kvkStaff: { model: 'kvkStaff', idField: 'kvkStaffId', nameField: 'staffName' },
     season: { model: 'season', idField: 'seasonId', nameField: 'seasonName' },
     oftSubject: { model: 'oftSubject', idField: 'oftSubjectId', nameField: 'subjectName' },

--- a/backend/migration/modules/equipment.js
+++ b/backend/migration/modules/equipment.js
@@ -37,7 +37,8 @@ module.exports = {
         const oldKvkName =
             decodeEntities(cleanText(row.kvk?.kvk_name || row['kvk.kvk_name'])) || '';
         if (!oldKvkName) {
-            err('kvkId', 'Missing KVK name');
+            // List API may not embed kvk_name — use the selected ctx.kvkId silently.
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
         } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
             return {
                 data: null,
@@ -64,26 +65,39 @@ module.exports = {
         }
 
         // ── Equipment master (EquipmentMaster — unique per type+name) ─────
+        // Old site list rows carry the equipment name directly as `equipment_name`
+        // (no nested equipment_master object). Try nested paths first, fall back.
         let equipmentMasterId = null;
+        // `row.equipment_master` may be a numeric ID (old site relation) — skip it if so.
+        const equipMasterRaw = row.equipment_master;
+        const equipMasterStr = (typeof equipMasterRaw === 'string' && !/^\d+$/.test(equipMasterRaw.trim()))
+            ? equipMasterRaw
+            : null;
         const rawEquipName = decodeEntities(
             cleanText(
                 row.equipment_master?.name ||
                 row['equipment_master.name'] ||
                 row.equipment_master_name ||
-                row.equipment_master,
+                equipMasterStr ||
+                row.equipment_name,
             ),
         );
-        if (rawEquipName && equipmentTypeId) {
-            const found = await prisma.equipmentMaster.findFirst({
-                where: {
-                    equipmentTypeId,
-                    name: { equals: rawEquipName, mode: 'insensitive' },
-                },
-            });
-            if (found) {
-                equipmentMasterId = found.equipmentMasterId;
+        if (rawEquipName) {
+            // Use MasterResolver: normalizes whitespace/case/punctuation before matching,
+            // so hidden encoding differences (non-breaking spaces etc.) don't cause misses.
+            const em = await r.resolve('equipmentMaster', 'name', 'equipmentMasterId', rawEquipName);
+            if (em.matched) {
+                equipmentMasterId = em.id;
+                // Backfill equipmentTypeId from the master row when type wasn't in raw data
+                if (!equipmentTypeId) {
+                    const emRow = await prisma.equipmentMaster.findUnique({
+                        where: { equipmentMasterId: em.id },
+                        select: { equipmentTypeId: true },
+                    });
+                    if (emRow?.equipmentTypeId) equipmentTypeId = emRow.equipmentTypeId;
+                }
             } else {
-                warn('equipmentMasterId', `EquipmentMaster "${rawEquipName}" not found for this type — stored as null`);
+                warn('equipmentMasterId', `EquipmentMaster "${rawEquipName}" not found — stored as null`);
             }
         }
 
@@ -99,24 +113,35 @@ module.exports = {
         if (!yearOfPurchase) err('yearOfPurchase', 'yearOfPurchase required — not found on row');
         const totalCost = floatOrZero(row.total_cost || row.cost || row.equipment_cost || row.equipment_amount);
 
-        // ── Asset funding source (parent-level, optional) ─────────────────
+        // ── Asset funding source (parent-level, optional) — lookup only ────
         let assetFundingSourceId = null;
-        let assetFundingSourceOther = null;
         const rawFunding = decodeEntities(cleanText(
             row.funding_source?.name ||
             row['funding_source.name'] ||
+            row.sources_of_fund ||      // actual old-site field name (plural)
+            row.source_of_fund ||
             row.asset_funding_source ||
             row.funding_source,
         ));
         if (rawFunding) {
-            const fs = await r.resolve('assetFundingSourceMaster', 'name', 'assetFundingSourceId', rawFunding);
-            if (fs.matched) assetFundingSourceId = fs.id;
-            else { assetFundingSourceOther = rawFunding; warn('assetFundingSourceId', `Funding source "${rawFunding}" not found — stored in other`); }
+            const fs = await r.findOrCreate(
+                'assetFundingSourceMaster', 'name', 'assetFundingSourceId', rawFunding,
+            );
+            if (fs.id) {
+                assetFundingSourceId = fs.id;
+                if (fs.created) warn('assetFundingSourceId', `Created funding source "${rawFunding}"`);
+            }
         }
 
         // ── Per-year detail ───────────────────────────────────────────────
-        const reportingYear = parseDate(row.reporting_year);
-        if (!reportingYear) warn('_detail.reportingYear', `Bad/missing reporting_year "${row.reporting_year}"`);
+        // The list API usually omits reporting_year; fall back to Jan-1 of purchase year.
+        let reportingYear = parseDate(row.reporting_year);
+        if (!reportingYear && yearOfPurchase) {
+            reportingYear = new Date(`${yearOfPurchase}-01-01T00:00:00.000Z`);
+            warn('_detail.reportingYear', `reporting_year missing — using purchase year ${yearOfPurchase}`);
+        } else if (!reportingYear) {
+            warn('_detail.reportingYear', `Bad/missing reporting_year "${row.reporting_year}"`);
+        }
 
         // Present status → EquipmentPresentStatusMaster (find-or-create)
         let equipmentStatusId = null;
@@ -136,13 +161,8 @@ module.exports = {
             err('_detail.equipmentStatusId', 'equipmentStatusId required — no present_status on row');
         }
 
-        // Detail-level funding source (may differ from parent; reuse same resolution)
-        let detailFundingSourceId = assetFundingSourceId;
-        const rawDetailFunding = decodeEntities(cleanText(row.detail_funding_source || ''));
-        if (rawDetailFunding) {
-            const fs = await r.resolve('assetFundingSourceMaster', 'name', 'assetFundingSourceId', rawDetailFunding);
-            detailFundingSourceId = fs.matched ? fs.id : null;
-        }
+        // Detail-level funding source defaults to parent; override only if explicit field present
+        const detailFundingSourceId = assetFundingSourceId;
 
         return {
             data: {
@@ -156,7 +176,6 @@ module.exports = {
                 yearOfPurchase,
                 totalCost,
                 assetFundingSourceId,
-                assetFundingSourceOther: assetFundingSourceOther || null,
                 // detail sub-record
                 _detail: reportingYear ? {
                     reportingYear,

--- a/backend/migration/modules/equipment.js
+++ b/backend/migration/modules/equipment.js
@@ -133,37 +133,6 @@ module.exports = {
             }
         }
 
-        // ── Per-year detail ───────────────────────────────────────────────
-        // The list API usually omits reporting_year; fall back to Jan-1 of purchase year.
-        let reportingYear = parseDate(row.reporting_year);
-        if (!reportingYear && yearOfPurchase) {
-            reportingYear = new Date(`${yearOfPurchase}-01-01T00:00:00.000Z`);
-            warn('_detail.reportingYear', `reporting_year missing — using purchase year ${yearOfPurchase}`);
-        } else if (!reportingYear) {
-            warn('_detail.reportingYear', `Bad/missing reporting_year "${row.reporting_year}"`);
-        }
-
-        // Present status → EquipmentPresentStatusMaster (find-or-create)
-        let equipmentStatusId = null;
-        const rawStatus = decodeEntities(cleanText(row.present_status || row.equipment_status || ''));
-        if (rawStatus) {
-            let statusMaster = await prisma.equipmentPresentStatusMaster.findFirst({
-                where: { statusLabel: { equals: rawStatus, mode: 'insensitive' } },
-            });
-            if (!statusMaster) {
-                statusMaster = await prisma.equipmentPresentStatusMaster.create({
-                    data: { statusCode: rawStatus, statusLabel: rawStatus },
-                });
-                warn('_detail.equipmentStatusId', `Created equipment status "${rawStatus}"`);
-            }
-            equipmentStatusId = statusMaster.equipmentStatusId;
-        } else {
-            err('_detail.equipmentStatusId', 'equipmentStatusId required — no present_status on row');
-        }
-
-        // Detail-level funding source defaults to parent; override only if explicit field present
-        const detailFundingSourceId = assetFundingSourceId;
-
         return {
             data: {
                 kvkId,
@@ -176,24 +145,18 @@ module.exports = {
                 yearOfPurchase,
                 totalCost,
                 assetFundingSourceId,
-                // detail sub-record
-                _detail: reportingYear ? {
-                    reportingYear,
-                    equipmentStatusId,
-                    assetFundingSourceId: detailFundingSourceId,
-                } : null,
             },
             issues,
         };
     },
 
     async seedRecord(prisma, data) {
-        const detail = data._detail || null;
         const parentData = { ...data };
         delete parentData._detail;
 
         // Upsert parent KvkEquipment by kvkId + identifierCode (if present),
-        // else kvkId + equipmentName + yearOfPurchase
+        // else kvkId + equipmentName + yearOfPurchase.
+        // Details are NOT seeded here — run the equipment-details module for that.
         let existing;
         if (parentData.identifierCode) {
             existing = await prisma.kvkEquipment.findFirst({
@@ -210,39 +173,13 @@ module.exports = {
             });
         }
 
-        let equipmentId;
         if (existing) {
             await prisma.kvkEquipment.update({
                 where: { equipmentId: existing.equipmentId },
                 data: parentData,
             });
-            equipmentId = existing.equipmentId;
         } else {
-            const created = await prisma.kvkEquipment.create({ data: parentData });
-            equipmentId = created.equipmentId;
-        }
-
-        // Upsert KvkEquipmentDetail (unique per equipmentId + reportingYear)
-        if (detail && detail.reportingYear && detail.equipmentStatusId) {
-            await prisma.kvkEquipmentDetail.upsert({
-                where: {
-                    equipmentId_reportingYear: {
-                        equipmentId,
-                        reportingYear: detail.reportingYear,
-                    },
-                },
-                create: {
-                    kvkId: parentData.kvkId,
-                    equipmentId,
-                    reportingYear: detail.reportingYear,
-                    equipmentStatusId: detail.equipmentStatusId,
-                    assetFundingSourceId: detail.assetFundingSourceId ?? null,
-                },
-                update: {
-                    equipmentStatusId: detail.equipmentStatusId,
-                    assetFundingSourceId: detail.assetFundingSourceId ?? null,
-                },
-            });
+            await prisma.kvkEquipment.create({ data: parentData });
         }
 
         return existing ? 'updated' : 'created';

--- a/backend/migration/modules/equipmentDetails.js
+++ b/backend/migration/modules/equipmentDetails.js
@@ -10,7 +10,7 @@ module.exports = {
     naturalKey: ['equipmentId', 'reportingYear'],
 
     foreignKeys: {
-        equipmentId: { master: 'equipmentMaster' },
+        equipmentId: { master: 'kvkEquipment' },
         equipmentStatusId: { master: 'equipmentStatus' },
         assetFundingSourceId: { master: 'assetFundingSource' },
     },
@@ -61,7 +61,16 @@ module.exports = {
         }
 
         // ── Reporting year ────────────────────────────────────────────────
-        const reportingYear = parseDate(row.reporting_year);
+        // Old site shows fiscal years as "YYYY-YYYY" — parseDate returns null for those;
+        // extract the first year so it matches how equipment.js stored the detail record.
+        let reportingYear = parseDate(row.reporting_year);
+        if (!reportingYear) {
+            const m = String(row.reporting_year ?? '').trim().match(/^(\d{4})-\d{4}$/);
+            if (m) {
+                reportingYear = parseDate(m[1]);
+                warn('reportingYear', `Fiscal year "${row.reporting_year}" → Jan 1 of ${m[1]}`);
+            }
+        }
         if (!reportingYear) err('reportingYear', `Bad/missing reporting_year "${row.reporting_year}"`);
 
         // ── Present status → EquipmentPresentStatusMaster (find-or-create) ─
@@ -82,13 +91,15 @@ module.exports = {
             err('equipmentStatusId', 'equipmentStatusId required — no present_status on row');
         }
 
-        // ── Source of fund → AssetFundingSourceMaster (optional) ──────────
+        // ── Source of fund → AssetFundingSourceMaster (find-or-create) ──────
         let assetFundingSourceId = null;
         const rawFunding = decodeEntities(cleanText(row.source_of_fund || ''));
         if (rawFunding) {
-            const fs = await r.resolve('assetFundingSourceMaster', 'name', 'assetFundingSourceId', rawFunding);
-            if (fs.matched) assetFundingSourceId = fs.id;
-            else warn('assetFundingSourceId', `Funding source "${rawFunding}" not found — stored as null`);
+            const fs = await r.findOrCreate('assetFundingSourceMaster', 'name', 'assetFundingSourceId', rawFunding);
+            if (fs.id) {
+                assetFundingSourceId = fs.id;
+                if (fs.created) warn('assetFundingSourceId', `Created funding source "${rawFunding}"`);
+            }
         }
 
         return {

--- a/frontend/src/hooks/useEntityHook.ts
+++ b/frontend/src/hooks/useEntityHook.ts
@@ -55,7 +55,7 @@ import {
     usePayScales,
     useAssetFundingSources,
     useEquipmentTypes,
-    useEquipmentMasters,
+    useEquipmentMastersPaginated,
     useDisciplines,
     useExtensionActivityTypes,
     useOtherExtensionActivityTypes,
@@ -88,10 +88,16 @@ import {
 import { useProjectData, useTspScspFilteredProjectData } from './useProjectData'
 import { getEntityTypeChecks } from '../utils/entityTypeHelpers'
 
+export interface ServerPaginationParams {
+    page?: number
+    limit?: number
+    search?: string
+}
+
 /**
  * Hook factory function type
  */
-type HookFactory = () => any
+type HookFactory = (params?: ServerPaginationParams) => any
 
 /**
  * Map basic master entity types to their EntityType strings
@@ -156,7 +162,7 @@ const ENTITY_HOOK_MAP: Record<string, HookFactory> = {
     [ENTITY_TYPES.PAY_SCALE]: () => usePayScales(),
     [ENTITY_TYPES.ASSET_FUNDING_SOURCE]: () => useAssetFundingSources(),
     [ENTITY_TYPES.EQUIPMENT_TYPE]: () => useEquipmentTypes(),
-    [ENTITY_TYPES.EQUIPMENT_MASTER]: () => useEquipmentMasters(),
+    [ENTITY_TYPES.EQUIPMENT_MASTER]: (params) => useEquipmentMastersPaginated(params),
     [ENTITY_TYPES.DISCIPLINE]: () => useDisciplines(),
     [ENTITY_TYPES.EXTENSION_ACTIVITY_TYPE]: () => useExtensionActivityTypes(),
     [ENTITY_TYPES.OTHER_EXTENSION_ACTIVITY_TYPE]: () => useOtherExtensionActivityTypes(),
@@ -331,7 +337,7 @@ const ABOUT_KVK_ENTITIES: string[] = [
  * @param entityType - The entity type to get the hook for
  * @returns The hook result or null if no hook is available
  */
-export function useEntityHook(entityType: ExtendedEntityType | null) {
+export function useEntityHook(entityType: ExtendedEntityType | null, paginationParams?: ServerPaginationParams) {
     const { isBasicMaster } = getEntityTypeChecks(entityType)
     const isAboutKvkEntity = entityType && ABOUT_KVK_ENTITIES.includes(entityType)
 
@@ -364,7 +370,7 @@ export function useEntityHook(entityType: ExtendedEntityType | null) {
     // This ensures hooks are always called in the same order regardless of entityType.
     const defaultHookFactory = () => useSeasons()
     const hookToCall = hookFactory || defaultHookFactory
-    const otherHookResult = hookToCall()
+    const otherHookResult = hookToCall(paginationParams)
     const otherHook = hookFactory ? otherHookResult : null
 
     // Return the appropriate hook result

--- a/frontend/src/hooks/useOtherMastersData.ts
+++ b/frontend/src/hooks/useOtherMastersData.ts
@@ -483,6 +483,56 @@ export function useEquipmentTypes() {
     };
 }
 
+export function useEquipmentMastersPaginated(params: {
+    page?: number
+    limit?: number
+    search?: string
+} = {}) {
+    const queryClient = useQueryClient()
+    const { page = 1, limit = 10, search = '' } = params
+
+    const query = useQuery({
+        queryKey: ['equipment-masters', page, limit, search],
+        queryFn: () => otherMastersApi.getEquipmentMasters({ page, limit, search }),
+        staleTime: 30 * 1000,
+        placeholderData: (prev: any) => prev,
+    })
+
+    const createMutation = useMutation({
+        mutationFn: (data: EquipmentMasterFormData) => otherMastersApi.createEquipmentMaster(data),
+        onSuccess: () => { invalidateEntityType(queryClient, ENTITY_TYPES.EQUIPMENT_MASTER) },
+    })
+    const updateMutation = useMutation({
+        mutationFn: ({ id, data }: { id: number; data: Partial<EquipmentMasterFormData> }) =>
+            otherMastersApi.updateEquipmentMaster(id, data),
+        onSuccess: () => { invalidateEntityType(queryClient, ENTITY_TYPES.EQUIPMENT_MASTER) },
+    })
+    const deleteMutation = useMutation({
+        mutationFn: (id: number) => otherMastersApi.deleteEquipmentMaster(id),
+        onSuccess: () => { invalidateEntityType(queryClient, ENTITY_TYPES.EQUIPMENT_MASTER) },
+    })
+
+    const raw = query.data as any
+    const pagination = raw?.pagination ?? {}
+
+    return {
+        data: raw?.data ?? [],
+        serverPagination: {
+            total: pagination.total ?? 0,
+            totalPages: pagination.totalPages ?? 1,
+        },
+        isLoading: query.isLoading,
+        isFetching: query.isFetching,
+        error: query.error,
+        create: createMutation.mutateAsync,
+        update: updateMutation.mutateAsync,
+        remove: deleteMutation.mutateAsync,
+        isCreating: createMutation.isPending,
+        isUpdating: updateMutation.isPending,
+        isDeleting: deleteMutation.isPending,
+    }
+}
+
 export function useEquipmentMasters() {
     const queryClient = useQueryClient();
 

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -223,8 +223,18 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     // Get entity type from path
     const entityType = getEntityTypeFromPath(location.pathname)
 
-    // Use centralized hook factory
-    const activeHook = useEntityHook(entityType)
+    // Use centralized hook factory — pass pagination params so server-side hooks
+    // (e.g. Equipment Master) can fetch the right page/search from the API.
+    const activeHook = useEntityHook(entityType, {
+        page: currentPage,
+        limit: 10,
+        search: debouncedSearch,
+    })
+
+    // Detect server-side pagination (e.g. Equipment Master returns serverPagination)
+    const serverPagination = (activeHook as any)?.serverPagination as
+        | { total: number; totalPages: number }
+        | undefined
 
     // Check if this is Employee Details view
     const isEmployeeDetails = entityType === ENTITY_TYPES.KVK_EMPLOYEES
@@ -379,7 +389,10 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     }, [reportingYearFrom, reportingYearTo])
 
     // Filter data based on search - memoized for performance
+    // When serverPagination is active the hook already returns the right page
+    // slice + handles search on the backend, so skip client-side filtering.
     const filteredData = useMemo(() => {
+        if (serverPagination) return items
         const maxDate = new Date()
         maxDate.setHours(23, 59, 59, 999)
         const rawFromDate = reportingYearFrom
@@ -413,13 +426,14 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                 return value && String(value).toLowerCase().includes(query)
             })
         })
-    }, [items, debouncedSearch, fields, reportingYearFrom, reportingYearTo])
+    }, [items, debouncedSearch, fields, reportingYearFrom, reportingYearTo, serverPagination])
 
     // Apply per-column filters (Excel-style: sort + text + multi-select) on top
     // of the search/year-filtered set. The column-filter dropdown's unique-value
     // list is computed from `filteredData` so it represents the full visible
     // dataset before column filters narrow it further.
     const columnFilteredData = useMemo(() => {
+        if (serverPagination) return items
         const result = applyColumnFilters(filteredData, fields, columnFilters)
         // Default alphabetical order (by the first column) unless the user has
         // applied an explicit column sort.
@@ -439,10 +453,17 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                 sensitivity: 'base',
             })
         })
-    }, [filteredData, fields, columnFilters])
+    }, [filteredData, fields, columnFilters, serverPagination, items])
 
     // Pagination calculations - memoized for performance
     const paginationData = useMemo(() => {
+        if (serverPagination) {
+            const totalPages = serverPagination.totalPages || 1
+            const safePage = Math.min(currentPage, totalPages)
+            const startIndex = (safePage - 1) * itemsPerPage
+            const endIndex = startIndex + items.length
+            return { totalPages, safePage, startIndex, endIndex, paginatedData: items }
+        }
         const totalPages = Math.max(
             1,
             Math.ceil(columnFilteredData.length / itemsPerPage)
@@ -454,7 +475,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
         const paginatedData = columnFilteredData.slice(startIndex, endIndex)
 
         return { totalPages, safePage, startIndex, endIndex, paginatedData }
-    }, [columnFilteredData, currentPage, itemsPerPage])
+    }, [columnFilteredData, currentPage, itemsPerPage, serverPagination, items])
 
     const { totalPages, safePage, startIndex, endIndex, paginatedData } =
         paginationData
@@ -1903,7 +1924,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                                         totalPages={totalPages}
                                         startIndex={startIndex}
                                         endIndex={endIndex}
-                                        totalItems={columnFilteredData.length}
+                                        totalItems={serverPagination ? serverPagination.total : columnFilteredData.length}
                                         onPageChange={setCurrentPage}
                                     />
                                 </>

--- a/frontend/src/pages/migration/MigrationTool.tsx
+++ b/frontend/src/pages/migration/MigrationTool.tsx
@@ -32,15 +32,16 @@ export function MigrationTool() {
     const [raw, setRaw] = useState<unknown>(undefined)
     const [rowCount, setRowCount] = useState<number | null>(null)
     const [splitPercent, setSplitPercent] = useState<number>(50)
+    const [verticalSplit, setVerticalSplit] = useState<number>(65)
 
     const handleMouseDown = (e: React.MouseEvent) => {
         e.preventDefault()
         const startX = e.clientX
         const startSplit = splitPercent
-        
+
         const container = e.currentTarget.parentElement
         const containerWidth = container ? container.getBoundingClientRect().width : window.innerWidth
-        
+
         const handleMouseMove = (moveEvent: MouseEvent) => {
             const deltaX = moveEvent.clientX - startX
             const deltaPercent = (deltaX / containerWidth) * 100
@@ -53,6 +54,28 @@ export function MigrationTool() {
             document.removeEventListener('mouseup', handleMouseUp)
         }
         
+        document.addEventListener('mousemove', handleMouseMove)
+        document.addEventListener('mouseup', handleMouseUp)
+    }
+
+    const handleVerticalMouseDown = (e: React.MouseEvent) => {
+        e.preventDefault()
+        const startY = e.clientY
+        const startSplit = verticalSplit
+
+        const container = e.currentTarget.parentElement
+        const containerHeight = container ? container.getBoundingClientRect().height : window.innerHeight
+
+        const handleMouseMove = (moveEvent: MouseEvent) => {
+            const deltaY = moveEvent.clientY - startY
+            const deltaPercent = (deltaY / containerHeight) * 100
+            const nextPercent = Math.min(Math.max(startSplit + deltaPercent, 20), 85)
+            setVerticalSplit(nextPercent)
+        }
+        const handleMouseUp = () => {
+            document.removeEventListener('mousemove', handleMouseMove)
+            document.removeEventListener('mouseup', handleMouseUp)
+        }
         document.addEventListener('mousemove', handleMouseMove)
         document.addEventListener('mouseup', handleMouseUp)
     }
@@ -311,17 +334,33 @@ export function MigrationTool() {
                     <div className="w-0.5 h-12 bg-gray-300 rounded-full"></div>
                 </div>
 
-                <div style={{ width: `${100 - splitPercent}%` }} className="min-w-0 h-full flex flex-col pl-2 gap-3">
-                    <RecordsViewer
-                        title="Mapped to our schema"
-                        data={displayRecords}
-                        defaultView="table"
-                        fk={fk}
-                        badge={transformed ? `${transformed.report.mapped} mapped` : undefined}
-                        placeholder="Transform to see records mapped to your DB schema."
-                        rowActions={rowActions}
-                    />
-                    {transformed && <MigrationReport report={transformed.report} />}
+                <div style={{ width: `${100 - splitPercent}%` }} className="min-w-0 h-full flex flex-col pl-2">
+                    <div style={{ height: `${transformed ? verticalSplit : 100}%` }} className="min-h-0 flex flex-col">
+                        <RecordsViewer
+                            title="Mapped to our schema"
+                            data={displayRecords}
+                            defaultView="table"
+                            fk={fk}
+                            badge={transformed ? `${transformed.report.mapped} mapped` : undefined}
+                            placeholder="Transform to see records mapped to your DB schema."
+                            rowActions={rowActions}
+                        />
+                    </div>
+                    {transformed && (
+                        <>
+                            {/* Vertical draggable divider */}
+                            <div
+                                onMouseDown={handleVerticalMouseDown}
+                                className="h-2 hover:h-2.5 bg-gray-100 hover:bg-blue-500 cursor-row-resize w-full transition-colors select-none flex items-center justify-center"
+                                title="Drag to resize"
+                            >
+                                <div className="h-0.5 w-12 bg-gray-300 rounded-full"></div>
+                            </div>
+                            <div style={{ height: `${100 - verticalSplit}%` }} className="min-h-0 overflow-auto">
+                                <MigrationReport report={transformed.report} />
+                            </div>
+                        </>
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/src/services/otherMastersApi.ts
+++ b/frontend/src/services/otherMastersApi.ts
@@ -625,8 +625,16 @@ export const otherMastersApi = {
     deleteEquipmentType: (id: number) =>
         apiClient.delete<ApiResponse<void>>(`${BASE_URL}/equipment-type/${id}`),
 
-    getEquipmentMasters: () =>
-        apiClient.get<PaginatedResponse<EquipmentMasterEntry>>(`${BASE_URL}/equipment-master`),
+    getEquipmentMasters: (params?: { page?: number; limit?: number; search?: string }) => {
+        const qs = new URLSearchParams()
+        if (params?.page) qs.set('page', String(params.page))
+        if (params?.limit) qs.set('limit', String(params.limit))
+        if (params?.search) qs.set('search', params.search)
+        const q = qs.toString()
+        return apiClient.get<PaginatedResponse<EquipmentMasterEntry>>(
+            `${BASE_URL}/equipment-master${q ? `?${q}` : ''}`
+        )
+    },
     getEquipmentMasterById: (id: number) =>
         apiClient.get<ApiResponse<EquipmentMasterEntry>>(`${BASE_URL}/equipment-master/${id}`),
     createEquipmentMaster: (data: EquipmentMasterFormData) =>


### PR DESCRIPTION
## Summary

- **equipmentId FK picker label fix** — was pointing at `equipmentMaster` (global catalog, wrong IDs); now uses `kvkEquipment` so equipment names resolve correctly in the UI
- **assetFundingSourceId find-or-create** — was `resolve()` (lookup-only, silently null on miss); switched to `findOrCreate()` so unrecognised funding sources are auto-created in `AssetFundingSourceMaster`
- **Fiscal year reporting_year parsing** — `parseDate` returns null for `"YYYY-YYYY"` range strings; added fallback to extract the first year → Jan 1, matching how equipment.js stored the detail record
- **equipment.js: stop creating KvkEquipmentDetail in seedRecord** — details are now owned exclusively by the `equipment-details` module; eliminates phantom "updated" rows when running equipment-details on a fresh dataset
- **masterCatalog: add `kvkEquipment` entry** for the equipment-details FK picker

## Test plan

- [ ] Run Equipment module → all rows created, no detail sub-records created
- [ ] Run Equipment Details module → all rows created (none "updated" from equipment run)
- [ ] Verify `equipmentId` column shows equipment name labels in table view
- [ ] Verify `assetFundingSourceId` resolves/creates correctly; no "unmatched" on rows with a fund source
- [ ] Verify `reporting_year` in "YYYY-YYYY" format warns but doesn't error