### PR TITLE
fix(forms): crop uniqueness, relation-key leak, conditional staff fields, beneficiary 0-handling

### DIFF
--- a/backend/repositories/all-masters/oftFldRepository.js
+++ b/backend/repositories/all-masters/oftFldRepository.js
@@ -131,6 +131,8 @@ const ENTITY_CONFIG = {
         tableName: 'crop',
         idColumn: 'crop_id',
         requiredFields: ['subCategoryId', 'categoryId', 'cropName'],
+        // cropName is unique only within a category+subcategory, not globally.
+        uniqueScopeFields: ['categoryId', 'subCategoryId'],
         includes: {
             subCategory: {
                 select: {

--- a/backend/repositories/all-masters/productionProjectsRepository.js
+++ b/backend/repositories/all-masters/productionProjectsRepository.js
@@ -267,10 +267,14 @@ async function findById(entityName, id) {
  */
 function sanitizeData(config, data) {
     const sanitized = {};
+    // Relation fields (e.g. productCategory/productType/unit) are never scalars on the
+    // Prisma write input — drop them whether they arrive as objects or null.
+    const relationKeys = config.includes ? Object.keys(config.includes) : [];
     for (const [key, value] of Object.entries(data)) {
         // Skip ID field, _count, timestamps, and nested objects
         if (key === config.idField || key === '_count' || key === 'id' || key === '_id') continue;
         if (key === 'createdAt' || key === 'updatedAt') continue;
+        if (relationKeys.includes(key)) continue;
         if (value !== null && typeof value === 'object') continue;
         if (value === undefined) continue;
         // Parse FK fields as integers

--- a/backend/services/all-masters/oftFldService.js
+++ b/backend/services/all-masters/oftFldService.js
@@ -7,6 +7,25 @@ const { ValidationError, NotFoundError, ConflictError, translatePrismaError } = 
  * Business logic layer for OFT, FLD, and CFLD master data operations
  */
 
+/**
+ * Build the additional WHERE filters that scope a uniqueness check.
+ * For entities whose nameField is unique only within a parent (e.g. a crop name
+ * is unique per category+subcategory, not globally), config.uniqueScopeFields
+ * lists the FK fields to include. Returns {} when no scoping is configured.
+ */
+function buildScopeFilters(config, data) {
+    const filters = {};
+    if (!config || !Array.isArray(config.uniqueScopeFields)) return filters;
+    for (const field of config.uniqueScopeFields) {
+        const value = data[field];
+        if (value === undefined || value === null || value === '') continue;
+        const parsed = field.endsWith('Id') ? parseInt(value, 10) : value;
+        if (typeof parsed === 'number' && isNaN(parsed)) continue;
+        filters[field] = parsed;
+    }
+    return filters;
+}
+
 class OftFldService {
     /**
      * Get all entities with pagination and filtering
@@ -96,7 +115,9 @@ class OftFldService {
             if (config && config.nameField && data[config.nameField]) {
                 const exists = await oftFldRepository.nameExists(
                     entityName,
-                    data[config.nameField]
+                    data[config.nameField],
+                    null,
+                    buildScopeFilters(config, data)
                 );
                 if (exists) {
                     throw new ConflictError(`${entityName} with this ${config.nameField} already exists`);
@@ -140,18 +161,20 @@ class OftFldService {
         
         try {
             // Check if entity exists
-            await this.getById(entityName, id);
+            const existing = await this.getById(entityName, id);
 
             // Get entity config for duplicate name check
             const { getEntityConfig } = require('../../repositories/all-masters/oftFldRepository.js');
             const config = getEntityConfig ? getEntityConfig(entityName) : null;
 
-            // Check for duplicate names (excluding current entity)
+            // Check for duplicate names (excluding current entity).
+            // Merge existing row so scope fields absent from a partial update still apply.
             if (config && config.nameField && data[config.nameField]) {
                 const exists = await oftFldRepository.nameExists(
                     entityName,
                     data[config.nameField],
-                    id
+                    id,
+                    buildScopeFilters(config, { ...existing, ...data })
                 );
                 if (exists) {
                     throw new ConflictError(`${entityName} with this ${config.nameField} already exists`);

--- a/backend/services/forms/aboutKvkService.js
+++ b/backend/services/forms/aboutKvkService.js
@@ -386,9 +386,10 @@ class AboutKvkService {
         const requiredFields = {
             'kvks': ['kvkName', 'zoneId', 'stateId', 'districtId', 'orgId', 'universityId', 'hostOrg', 'mobile', 'email', 'address', 'yearOfSanction'],
             // Note: universityId is required as per the newest form requirements
-            'kvk-bank-accounts': ['kvkId', 'bankAccountTypeMasterId', 'accountTypeOther', 'accountName', 'bankName', 'location', 'accountNumber'],
-            'kvk-employees': ['kvkId', 'staffName', 'mobile', 'dateOfBirth', 'sanctionedPostId', 'positionOrder', 'disciplineId', 'dateOfJoining', 'staffCategoryId', 'jobTypeMasterId', 'jobTypeOther'],
-            'kvk-staff-transferred': ['kvkId', 'staffName', 'mobile', 'dateOfBirth', 'sanctionedPostId', 'positionOrder', 'disciplineId', 'dateOfJoining', 'staffCategoryId', 'jobTypeMasterId', 'jobTypeOther'],
+            // *Other free-text fields are conditional (only when the chosen master isOther) — enforced on the frontend, not required here.
+            'kvk-bank-accounts': ['kvkId', 'bankAccountTypeMasterId', 'accountName', 'bankName', 'location', 'accountNumber'],
+            'kvk-employees': ['kvkId', 'staffName', 'mobile', 'dateOfBirth', 'sanctionedPostId', 'positionOrder', 'disciplineId', 'dateOfJoining', 'staffCategoryId', 'jobTypeMasterId'],
+            'kvk-staff-transferred': ['kvkId', 'staffName', 'mobile', 'dateOfBirth', 'sanctionedPostId', 'positionOrder', 'disciplineId', 'dateOfJoining', 'staffCategoryId', 'jobTypeMasterId'],
             'kvk-infrastructure': ['kvkId', 'infraMasterId', 'notYetStarted', 'completedPlinthLevel', 'completedLintelLevel', 'completedRoofLevel', 'totallyCompleted', 'plinthAreaSqM', 'underUse', 'sourceOfFunding'],
             'kvk-vehicles': ['kvkId', 'vehicleName', 'registrationNo', 'yearOfPurchase', 'totalCost'],
             'kvk-vehicle-details': ['kvkId', 'reportingYear', 'vehicleId', 'totalRun', 'vehicleStatusId'],

--- a/frontend/src/pages/dashboard/shared/forms/TrainingExtensionForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/TrainingExtensionForms.tsx
@@ -637,15 +637,15 @@ export const TrainingExtensionForms: React.FC<TrainingExtensionFormsProps> = ({
 
                     <FormSection title="Farmers Details">
                         <div className="col-span-2 grid grid-cols-2 md:grid-cols-4 gap-4">
-                            <FormInput label="General_M" required type="number" wholeNumberOnly value={formData.gen_m || ''} onChange={e => setFormData({ ...formData, gen_m: e.target.value })} />
-                            <FormInput label="General_F" required type="number" wholeNumberOnly value={formData.gen_f || ''} onChange={e => setFormData({ ...formData, gen_f: e.target.value })} />
-                            <FormInput label="OBC_M" required type="number" wholeNumberOnly value={formData.obc_m || ''} onChange={e => setFormData({ ...formData, obc_m: e.target.value })} />
-                            <FormInput label="OBC_F" required type="number" wholeNumberOnly value={formData.obc_f || ''} onChange={e => setFormData({ ...formData, obc_f: e.target.value })} />
+                            <FormInput label="General_M" required type="number" wholeNumberOnly value={formData.gen_m ?? ''} onChange={e => setFormData({ ...formData, gen_m: e.target.value })} />
+                            <FormInput label="General_F" required type="number" wholeNumberOnly value={formData.gen_f ?? ''} onChange={e => setFormData({ ...formData, gen_f: e.target.value })} />
+                            <FormInput label="OBC_M" required type="number" wholeNumberOnly value={formData.obc_m ?? ''} onChange={e => setFormData({ ...formData, obc_m: e.target.value })} />
+                            <FormInput label="OBC_F" required type="number" wholeNumberOnly value={formData.obc_f ?? ''} onChange={e => setFormData({ ...formData, obc_f: e.target.value })} />
 
-                            <FormInput label="SC_M" required type="number" wholeNumberOnly value={formData.sc_m || ''} onChange={e => setFormData({ ...formData, sc_m: e.target.value })} />
-                            <FormInput label="SC_F" required type="number" wholeNumberOnly value={formData.sc_f || ''} onChange={e => setFormData({ ...formData, sc_f: e.target.value })} />
-                            <FormInput label="ST_M" required type="number" wholeNumberOnly value={formData.st_m || ''} onChange={e => setFormData({ ...formData, st_m: e.target.value })} />
-                            <FormInput label="ST_F" required type="number" wholeNumberOnly value={formData.st_f || ''} onChange={e => setFormData({ ...formData, st_f: e.target.value })} />
+                            <FormInput label="SC_M" required type="number" wholeNumberOnly value={formData.sc_m ?? ''} onChange={e => setFormData({ ...formData, sc_m: e.target.value })} />
+                            <FormInput label="SC_F" required type="number" wholeNumberOnly value={formData.sc_f ?? ''} onChange={e => setFormData({ ...formData, sc_f: e.target.value })} />
+                            <FormInput label="ST_M" required type="number" wholeNumberOnly value={formData.st_m ?? ''} onChange={e => setFormData({ ...formData, st_m: e.target.value })} />
+                            <FormInput label="ST_F" required type="number" wholeNumberOnly value={formData.st_f ?? ''} onChange={e => setFormData({ ...formData, st_f: e.target.value })} />
                         </div>
 
                         <div className="flex flex-wrap gap-3 pt-4">
@@ -728,7 +728,7 @@ export const TrainingExtensionForms: React.FC<TrainingExtensionFormsProps> = ({
                             required
                             type="number"
                             wholeNumberOnly
-                            value={formData.activityCount || ''}
+                            value={formData.activityCount ?? ''}
                             onChange={(e) => setFormData({ ...formData, activityCount: e.target.value })}
                         />
                         <div className="hidden md:block"></div> {/* Spacer */}
@@ -799,15 +799,15 @@ export const TrainingExtensionForms: React.FC<TrainingExtensionFormsProps> = ({
 
                     <FormSection title="Extension Officials">
                         <div className="col-span-2 grid grid-cols-2 md:grid-cols-4 gap-4">
-                            <FormInput label="General_M" required type="number" wholeNumberOnly value={formData.ext_gen_m || ''} onChange={e => setFormData({ ...formData, ext_gen_m: e.target.value })} />
-                            <FormInput label="General_F" required type="number" wholeNumberOnly value={formData.ext_gen_f || ''} onChange={e => setFormData({ ...formData, ext_gen_f: e.target.value })} />
-                            <FormInput label="OBC_M" required type="number" wholeNumberOnly value={formData.ext_obc_m || ''} onChange={e => setFormData({ ...formData, ext_obc_m: e.target.value })} />
-                            <FormInput label="OBC_F" required type="number" wholeNumberOnly value={formData.ext_obc_f || ''} onChange={e => setFormData({ ...formData, ext_obc_f: e.target.value })} />
+                            <FormInput label="General_M" required type="number" wholeNumberOnly value={formData.ext_gen_m ?? ''} onChange={e => setFormData({ ...formData, ext_gen_m: e.target.value })} />
+                            <FormInput label="General_F" required type="number" wholeNumberOnly value={formData.ext_gen_f ?? ''} onChange={e => setFormData({ ...formData, ext_gen_f: e.target.value })} />
+                            <FormInput label="OBC_M" required type="number" wholeNumberOnly value={formData.ext_obc_m ?? ''} onChange={e => setFormData({ ...formData, ext_obc_m: e.target.value })} />
+                            <FormInput label="OBC_F" required type="number" wholeNumberOnly value={formData.ext_obc_f ?? ''} onChange={e => setFormData({ ...formData, ext_obc_f: e.target.value })} />
 
-                            <FormInput label="SC_M" required type="number" wholeNumberOnly value={formData.ext_sc_m || ''} onChange={e => setFormData({ ...formData, ext_sc_m: e.target.value })} />
-                            <FormInput label="SC_F" required type="number" wholeNumberOnly value={formData.ext_sc_f || ''} onChange={e => setFormData({ ...formData, ext_sc_f: e.target.value })} />
-                            <FormInput label="ST_M" required type="number" wholeNumberOnly value={formData.ext_st_m || ''} onChange={e => setFormData({ ...formData, ext_st_m: e.target.value })} />
-                            <FormInput label="ST_F" required type="number" wholeNumberOnly value={formData.ext_st_f || ''} onChange={e => setFormData({ ...formData, ext_st_f: e.target.value })} />
+                            <FormInput label="SC_M" required type="number" wholeNumberOnly value={formData.ext_sc_m ?? ''} onChange={e => setFormData({ ...formData, ext_sc_m: e.target.value })} />
+                            <FormInput label="SC_F" required type="number" wholeNumberOnly value={formData.ext_sc_f ?? ''} onChange={e => setFormData({ ...formData, ext_sc_f: e.target.value })} />
+                            <FormInput label="ST_M" required type="number" wholeNumberOnly value={formData.ext_st_m ?? ''} onChange={e => setFormData({ ...formData, ext_st_m: e.target.value })} />
+                            <FormInput label="ST_F" required type="number" wholeNumberOnly value={formData.ext_st_f ?? ''} onChange={e => setFormData({ ...formData, ext_st_f: e.target.value })} />
                         </div>
 
                         <div className="flex flex-wrap gap-3 pt-4">
@@ -890,7 +890,7 @@ export const TrainingExtensionForms: React.FC<TrainingExtensionFormsProps> = ({
                             required
                             type="number"
                             wholeNumberOnly
-                            value={formData.activityCount || ''}
+                            value={formData.activityCount ?? ''}
                             onChange={(e) => setFormData({ ...formData, activityCount: e.target.value })}
                         />
                         <div className="hidden md:block"></div> {/* Spacer */}
@@ -941,7 +941,7 @@ export const TrainingExtensionForms: React.FC<TrainingExtensionFormsProps> = ({
                             required
                             type="number"
                             wholeNumberOnly
-                            value={formData.activityCount || ''}
+                            value={formData.activityCount ?? ''}
                             onChange={(e) => setFormData({ ...formData, activityCount: e.target.value })}
                         />
                         <div className="md:col-span-2">
@@ -1092,15 +1092,15 @@ export const TrainingExtensionForms: React.FC<TrainingExtensionFormsProps> = ({
 
                     <FormSection title="Extension Officials">
                         <div className="col-span-2 grid grid-cols-2 md:grid-cols-4 gap-4">
-                            <FormInput label="General_M" required type="number" wholeNumberOnly value={formData.ext_gen_m || ''} onChange={e => setFormData({ ...formData, ext_gen_m: e.target.value })} />
-                            <FormInput label="General_F" required type="number" wholeNumberOnly value={formData.ext_gen_f || ''} onChange={e => setFormData({ ...formData, ext_gen_f: e.target.value })} />
-                            <FormInput label="OBC_M" required type="number" wholeNumberOnly value={formData.ext_obc_m || ''} onChange={e => setFormData({ ...formData, ext_obc_m: e.target.value })} />
-                            <FormInput label="OBC_F" required type="number" wholeNumberOnly value={formData.ext_obc_f || ''} onChange={e => setFormData({ ...formData, ext_obc_f: e.target.value })} />
+                            <FormInput label="General_M" required type="number" wholeNumberOnly value={formData.ext_gen_m ?? ''} onChange={e => setFormData({ ...formData, ext_gen_m: e.target.value })} />
+                            <FormInput label="General_F" required type="number" wholeNumberOnly value={formData.ext_gen_f ?? ''} onChange={e => setFormData({ ...formData, ext_gen_f: e.target.value })} />
+                            <FormInput label="OBC_M" required type="number" wholeNumberOnly value={formData.ext_obc_m ?? ''} onChange={e => setFormData({ ...formData, ext_obc_m: e.target.value })} />
+                            <FormInput label="OBC_F" required type="number" wholeNumberOnly value={formData.ext_obc_f ?? ''} onChange={e => setFormData({ ...formData, ext_obc_f: e.target.value })} />
 
-                            <FormInput label="SC_M" required type="number" wholeNumberOnly value={formData.ext_sc_m || ''} onChange={e => setFormData({ ...formData, ext_sc_m: e.target.value })} />
-                            <FormInput label="SC_F" required type="number" wholeNumberOnly value={formData.ext_sc_f || ''} onChange={e => setFormData({ ...formData, ext_sc_f: e.target.value })} />
-                            <FormInput label="ST_M" required type="number" wholeNumberOnly value={formData.ext_st_m || ''} onChange={e => setFormData({ ...formData, ext_st_m: e.target.value })} />
-                            <FormInput label="ST_F" required type="number" wholeNumberOnly value={formData.ext_st_f || ''} onChange={e => setFormData({ ...formData, ext_st_f: e.target.value })} />
+                            <FormInput label="SC_M" required type="number" wholeNumberOnly value={formData.ext_sc_m ?? ''} onChange={e => setFormData({ ...formData, ext_sc_m: e.target.value })} />
+                            <FormInput label="SC_F" required type="number" wholeNumberOnly value={formData.ext_sc_f ?? ''} onChange={e => setFormData({ ...formData, ext_sc_f: e.target.value })} />
+                            <FormInput label="ST_M" required type="number" wholeNumberOnly value={formData.ext_st_m ?? ''} onChange={e => setFormData({ ...formData, ext_st_m: e.target.value })} />
+                            <FormInput label="ST_F" required type="number" wholeNumberOnly value={formData.ext_st_f ?? ''} onChange={e => setFormData({ ...formData, ext_st_f: e.target.value })} />
                         </div>
 
                         <div className="flex flex-wrap gap-3 pt-4">

--- a/frontend/src/pages/dashboard/shared/forms/projects/AryaForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/projects/AryaForms.tsx
@@ -63,13 +63,13 @@ export const AryaForms: React.FC<AryaFormsProps> = ({
                                 label="Reporting Year"
                                 required
                                 type="date"
-                                value={formData.reportingYear || ''}
+                                value={formData.reportingYear ?? ''}
                                 onChange={(e) => setFormData((prev: any) => ({ ...prev, reportingYear: e.target.value }))}
                             />
                             <MasterDataDropdown
                                 label="Name of enterprises"
                                 required
-                                value={formData.enterpriseId || ''}
+                                value={formData.enterpriseId ?? ''}
                                 onChange={(value) => setFormData((prev: any) => ({ ...prev, enterpriseId: value, ...enterpriseResetPatch(value, 'enterpriseOther') }))}
                                 options={enterpriseOptions}
                             />
@@ -87,36 +87,36 @@ export const AryaForms: React.FC<AryaFormsProps> = ({
                     <div>
                         <h3 className="text-lg font-semibold mb-4">No. of entrepreneurial units established</h3>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <FormInput label="Male" type="number" required value={formData.unitsMale || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, unitsMale: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="Female" type="number" required value={formData.unitsFemale || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, unitsFemale: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="Viable units" type="number" required value={formData.viableUnits || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, viableUnits: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="Closed units" type="number" required value={formData.closedUnits || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, closedUnits: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="No. of Training conducted" type="number" required value={formData.trainingsConducted || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, trainingsConducted: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="Start Date" type="date" required value={formData.startDate || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, startDate: e.target.value }))} />
-                            <FormInput label="End Date" type="date" required value={formData.endDate || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, endDate: e.target.value }))} />
+                            <FormInput label="Male" type="number" required value={formData.unitsMale ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, unitsMale: e.target.value }))} />
+                            <FormInput label="Female" type="number" required value={formData.unitsFemale ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, unitsFemale: e.target.value }))} />
+                            <FormInput label="Viable units" type="number" required value={formData.viableUnits ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, viableUnits: e.target.value }))} />
+                            <FormInput label="Closed units" type="number" required value={formData.closedUnits ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, closedUnits: e.target.value }))} />
+                            <FormInput label="No. of Training conducted" type="number" required value={formData.trainingsConducted ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, trainingsConducted: e.target.value }))} />
+                            <FormInput label="Start Date" type="date" required value={formData.startDate ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, startDate: e.target.value }))} />
+                            <FormInput label="End Date" type="date" required value={formData.endDate ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, endDate: e.target.value }))} />
                         </div>
                     </div>
 
                     <div>
                         <h3 className="text-lg font-semibold mb-4">No. of rural youth trained</h3>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <FormInput label="Male" type="number" required value={formData.youthMale || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, youthMale: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="Female" type="number" required value={formData.youthFemale || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, youthFemale: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="No. of Groups Formed" type="number" required value={formData.groupsFormed || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, groupsFormed: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="No. of Groups active" type="number" required value={formData.groupsActive || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, groupsActive: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="No. of person left the group" type="number" required value={formData.personsLeftGroup || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, personsLeftGroup: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="No. of Members in each Group" type="number" required value={formData.membersPerGroup || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, membersPerGroup: parseInt(e.target.value) || 0 }))} />
+                            <FormInput label="Male" type="number" required value={formData.youthMale ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, youthMale: e.target.value }))} />
+                            <FormInput label="Female" type="number" required value={formData.youthFemale ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, youthFemale: e.target.value }))} />
+                            <FormInput label="No. of Groups Formed" type="number" required value={formData.groupsFormed ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, groupsFormed: e.target.value }))} />
+                            <FormInput label="No. of Groups active" type="number" required value={formData.groupsActive ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, groupsActive: e.target.value }))} />
+                            <FormInput label="No. of person left the group" type="number" required value={formData.personsLeftGroup ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, personsLeftGroup: e.target.value }))} />
+                            <FormInput label="No. of Members in each Group" type="number" required value={formData.membersPerGroup ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, membersPerGroup: e.target.value }))} />
                         </div>
                     </div>
 
                     <div>
                         <h3 className="text-lg font-semibold mb-4">Financial Impact</h3>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <FormInput label="Average size of each unit (agro rental unit)" type="number" required value={formData.avgSizeOfUnit || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, avgSizeOfUnit: parseFloat(e.target.value) || 0 }))} />
-                            <FormInput label="Total Production unit/year" type="number" required value={formData.totalProductionPerYear || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, totalProductionPerYear: parseFloat(e.target.value) || 0 }))} />
-                            <FormInput label="Per unit cost of Production" type="number" required value={formData.perUnitCostOfProduction || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, perUnitCostOfProduction: parseFloat(e.target.value) || 0 }))} />
-                            <FormInput label="Sale value of Produce" type="number" required value={formData.saleValueOfProduce || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, saleValueOfProduce: parseFloat(e.target.value) || 0 }))} />
-                            <FormInput label="Employment generated (man-days)" type="number" required value={formData.employmentGeneratedMandays || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, employmentGeneratedMandays: parseFloat(e.target.value) || 0 }))} />
+                            <FormInput label="Average size of each unit (agro rental unit)" type="number" required value={formData.avgSizeOfUnit ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, avgSizeOfUnit: e.target.value }))} />
+                            <FormInput label="Total Production unit/year" type="number" required value={formData.totalProductionPerYear ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, totalProductionPerYear: e.target.value }))} />
+                            <FormInput label="Per unit cost of Production" type="number" required value={formData.perUnitCostOfProduction ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, perUnitCostOfProduction: e.target.value }))} />
+                            <FormInput label="Sale value of Produce" type="number" required value={formData.saleValueOfProduce ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, saleValueOfProduce: e.target.value }))} />
+                            <FormInput label="Employment generated (man-days)" type="number" required value={formData.employmentGeneratedMandays ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, employmentGeneratedMandays: e.target.value }))} />
                         </div>
                         <div className="mt-6">{renderPhotoSection()}</div>
                     </div>
@@ -132,13 +132,13 @@ export const AryaForms: React.FC<AryaFormsProps> = ({
                                 label="Reporting Year"
                                 required
                                 type="date"
-                                value={formData.reportingYear || ''}
+                                value={formData.reportingYear ?? ''}
                                 onChange={(e) => setFormData((prev: any) => ({ ...prev, reportingYear: e.target.value }))}
                             />
                             <MasterDataDropdown
                                 label="Name of enterprises"
                                 required
-                                value={formData.enterpriseId || ''}
+                                value={formData.enterpriseId ?? ''}
                                 onChange={(value) => setFormData((prev: any) => ({ ...prev, enterpriseId: value, ...enterpriseResetPatch(value, 'enterpriseOther') }))}
                                 options={enterpriseOptions}
                             />
@@ -156,41 +156,41 @@ export const AryaForms: React.FC<AryaFormsProps> = ({
                     <div>
                         <h3 className="text-xl font-bold text-[#487749] mb-6">No. of entrepreneurial units established</h3>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <FormInput label="Male" type="number" required value={formData.unitsMale || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, unitsMale: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="Female" type="number" required value={formData.unitsFemale || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, unitsFemale: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="No. of non-functional entrepreneurial unit closed" type="number" required value={formData.nonFunctionalUnitsClosed || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, nonFunctionalUnitsClosed: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="Date of Closing" type="date" required value={formData.dateOfClosing || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, dateOfClosing: e.target.value }))} />
-                            <FormInput label="No. of non-functional entrepreneurial unit restarted (i.e. Previously closed)" type="number" required value={formData.nonFunctionalUnitsRestarted || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, nonFunctionalUnitsRestarted: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="Date of restart" type="date" required value={formData.dateOfRestart || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, dateOfRestart: e.target.value }))} />
+                            <FormInput label="Male" type="number" required value={formData.unitsMale ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, unitsMale: e.target.value }))} />
+                            <FormInput label="Female" type="number" required value={formData.unitsFemale ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, unitsFemale: e.target.value }))} />
+                            <FormInput label="No. of non-functional entrepreneurial unit closed" type="number" required value={formData.nonFunctionalUnitsClosed ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, nonFunctionalUnitsClosed: e.target.value }))} />
+                            <FormInput label="Date of Closing" type="date" required value={formData.dateOfClosing ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, dateOfClosing: e.target.value }))} />
+                            <FormInput label="No. of non-functional entrepreneurial unit restarted (i.e. Previously closed)" type="number" required value={formData.nonFunctionalUnitsRestarted ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, nonFunctionalUnitsRestarted: e.target.value }))} />
+                            <FormInput label="Date of restart" type="date" required value={formData.dateOfRestart ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, dateOfRestart: e.target.value }))} />
                         </div>
                     </div>
 
                     <div>
                         <h3 className="text-xl font-bold text-[#487749] mb-6">Entrepreneurial Unit Size related to production capacity/ year (Production (Kg/unit))</h3>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <FormInput label="No. of unit" type="number" required value={formData.numberOfUnits || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, numberOfUnits: parseInt(e.target.value) || 0 }))} />
-                            <FormInput label="Unit Capacity" type="number" required value={formData.unitCapacity || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, unitCapacity: parseFloat(e.target.value) || 0 }))} />
+                            <FormInput label="No. of unit" type="number" required value={formData.numberOfUnits ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, numberOfUnits: e.target.value }))} />
+                            <FormInput label="Unit Capacity" type="number" required value={formData.unitCapacity ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, unitCapacity: e.target.value }))} />
                         </div>
                     </div>
 
                     <div>
                         <h3 className="text-xl font-bold text-[#487749] mb-6">Entrepreneurial Establishment Cost/unit (Rs.)</h3>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <FormInput label="Fixed cost" type="number" required value={formData.fixedCost || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, fixedCost: parseFloat(e.target.value) || 0 }))} />
-                            <FormInput label="Variable cost" type="number" required value={formData.variableCost || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, variableCost: parseFloat(e.target.value) || 0 }))} />
-                            <FormInput label="total production/unit/year" type="number" required value={formData.totalProductionPerUnitYear || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, totalProductionPerUnitYear: parseFloat(e.target.value) || 0 }))} />
-                            <FormInput label="Gross cost of production/unit/ year (Rs.)" type="number" required value={formData.grossCostPerUnitYear || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, grossCostPerUnitYear: parseFloat(e.target.value) || 0 }))} />
-                            <FormInput label="gross values of production/unit/ year (Rs.)" type="number" required value={formData.grossReturnPerUnitYear || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, grossReturnPerUnitYear: parseFloat(e.target.value) || 0 }))} />
-                            <FormInput label="net benefit / unit/ year (Rs.)" type="number" required value={formData.netBenefitPerUnitYear || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, netBenefitPerUnitYear: parseFloat(e.target.value) || 0 }))} />
+                            <FormInput label="Fixed cost" type="number" required value={formData.fixedCost ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, fixedCost: e.target.value }))} />
+                            <FormInput label="Variable cost" type="number" required value={formData.variableCost ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, variableCost: e.target.value }))} />
+                            <FormInput label="total production/unit/year" type="number" required value={formData.totalProductionPerUnitYear ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, totalProductionPerUnitYear: e.target.value }))} />
+                            <FormInput label="Gross cost of production/unit/ year (Rs.)" type="number" required value={formData.grossCostPerUnitYear ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, grossCostPerUnitYear: e.target.value }))} />
+                            <FormInput label="gross values of production/unit/ year (Rs.)" type="number" required value={formData.grossReturnPerUnitYear ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, grossReturnPerUnitYear: e.target.value }))} />
+                            <FormInput label="net benefit / unit/ year (Rs.)" type="number" required value={formData.netBenefitPerUnitYear ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, netBenefitPerUnitYear: e.target.value }))} />
                         </div>
                     </div>
 
                     <div>
                         <h3 className="text-xl font-bold text-[#487749] mb-6">Employment generated/ year (man-day @ 8 hrs/ day)</h3>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <FormInput label="Family" type="number" required value={formData.employmentFamilyMandays || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, employmentFamilyMandays: parseFloat(e.target.value) || 0 }))} />
-                            <FormInput label="Other than family" type="number" required value={formData.employmentOtherMandays || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, employmentOtherMandays: parseFloat(e.target.value) || 0 }))} />
-                            <FormInput label="No. of persons visited entrepreneur unit" type="number" required value={formData.personsVisitedUnit || ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, personsVisitedUnit: parseInt(e.target.value) || 0 }))} />
+                            <FormInput label="Family" type="number" required value={formData.employmentFamilyMandays ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, employmentFamilyMandays: e.target.value }))} />
+                            <FormInput label="Other than family" type="number" required value={formData.employmentOtherMandays ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, employmentOtherMandays: e.target.value }))} />
+                            <FormInput label="No. of persons visited entrepreneur unit" type="number" required value={formData.personsVisitedUnit ?? ''} onChange={(e) => setFormData((prev: any) => ({ ...prev, personsVisitedUnit: e.target.value }))} />
                         </div>
                     </div>
                 </div>

--- a/frontend/src/pages/dashboard/shared/forms/projects/NariForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/projects/NariForms.tsx
@@ -93,14 +93,14 @@ export const NariForms: React.FC<NariFormsProps> = ({
                             required
                             type="number"
                             value={formData.number ?? ''}
-                            onChange={(e) => setFormData({ ...formData, number: parseInt(e.target.value) || 0 })}
+                            onChange={(e) => setFormData({ ...formData, number: e.target.value })}
                         />
                         <FormInput
                             label="Area (sqm)"
                             required
                             type="number"
                             value={formData.areaSqm ?? ''}
-                            onChange={(e) => setFormData({ ...formData, areaSqm: parseFloat(e.target.value) || 0 })}
+                            onChange={(e) => setFormData({ ...formData, areaSqm: e.target.value })}
                         />
                     </div>
 
@@ -114,32 +114,32 @@ export const NariForms: React.FC<NariFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genMale || ''}
-                                onChange={(e) => setFormData({ ...formData, genMale: parseInt(e.target.value) || 0 })}
+                                value={formData.generalM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, generalM: e.target.value })}
                             />
                             <FormInput
                                 label="General_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, genFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.generalF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, generalF: e.target.value })}
                             />
                             <FormInput
                                 label="OBC_M"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcMale || ''}
-                                onChange={(e) => setFormData({ ...formData, obcMale: parseInt(e.target.value) || 0 })}
+                                value={formData.obcM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, obcM: e.target.value })}
                             />
                             <FormInput
                                 label="OBC_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, obcFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.obcF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, obcF: e.target.value })}
                             />
                         </div>
 
@@ -149,38 +149,38 @@ export const NariForms: React.FC<NariFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.scMale || ''}
-                                onChange={(e) => setFormData({ ...formData, scMale: parseInt(e.target.value) || 0 })}
+                                value={formData.scM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, scM: e.target.value })}
                             />
                             <FormInput
                                 label="SC_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.scFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, scFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.scF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, scF: e.target.value })}
                             />
                             <FormInput
                                 label="ST_M"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.stMale || ''}
-                                onChange={(e) => setFormData({ ...formData, stMale: parseInt(e.target.value) || 0 })}
+                                value={formData.stM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, stM: e.target.value })}
                             />
                             <FormInput
                                 label="ST_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.stFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, stFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.stF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, stF: e.target.value })}
                             />
                         </div>
                         <CasteGenderTotals
                             values={formData}
-                            maleFields={['genMale', 'obcMale', 'scMale', 'stMale']}
-                            femaleFields={['genFemale', 'obcFemale', 'scFemale', 'stFemale']}
+                            maleFields={['generalM', 'obcM', 'scM', 'stM']}
+                            femaleFields={['generalF', 'obcF', 'scF', 'stF']}
                         />
                     </div>
                 </div>
@@ -245,7 +245,7 @@ export const NariForms: React.FC<NariFormsProps> = ({
                             type="number"
                             step="0.01"
                             value={formData.areaHa ?? ''}
-                            onChange={(e) => setFormData({ ...formData, areaHa: parseFloat(e.target.value) || 0 })}
+                            onChange={(e) => setFormData({ ...formData, areaHa: e.target.value })}
                         />
                     </div>
 
@@ -259,32 +259,32 @@ export const NariForms: React.FC<NariFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genMale || ''}
-                                onChange={(e) => setFormData({ ...formData, genMale: parseInt(e.target.value) || 0 })}
+                                value={formData.generalM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, generalM: e.target.value })}
                             />
                             <FormInput
                                 label="General_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, genFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.generalF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, generalF: e.target.value })}
                             />
                             <FormInput
                                 label="OBC_M"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcMale || ''}
-                                onChange={(e) => setFormData({ ...formData, obcMale: parseInt(e.target.value) || 0 })}
+                                value={formData.obcM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, obcM: e.target.value })}
                             />
                             <FormInput
                                 label="OBC_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, obcFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.obcF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, obcF: e.target.value })}
                             />
                         </div>
 
@@ -294,38 +294,38 @@ export const NariForms: React.FC<NariFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.scMale || ''}
-                                onChange={(e) => setFormData({ ...formData, scMale: parseInt(e.target.value) || 0 })}
+                                value={formData.scM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, scM: e.target.value })}
                             />
                             <FormInput
                                 label="SC_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.scFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, scFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.scF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, scF: e.target.value })}
                             />
                             <FormInput
                                 label="ST_M"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.stMale || ''}
-                                onChange={(e) => setFormData({ ...formData, stMale: parseInt(e.target.value) || 0 })}
+                                value={formData.stM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, stM: e.target.value })}
                             />
                             <FormInput
                                 label="ST_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.stFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, stFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.stF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, stF: e.target.value })}
                             />
                         </div>
                         <CasteGenderTotals
                             values={formData}
-                            maleFields={['genMale', 'obcMale', 'scMale', 'stMale']}
-                            femaleFields={['genFemale', 'obcFemale', 'scFemale', 'stFemale']}
+                            maleFields={['generalM', 'obcM', 'scM', 'stM']}
+                            femaleFields={['generalF', 'obcF', 'scF', 'stF']}
                         />
                     </div>
                 </div>
@@ -380,32 +380,32 @@ export const NariForms: React.FC<NariFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genMale || ''}
-                                onChange={(e) => setFormData({ ...formData, genMale: parseInt(e.target.value) || 0 })}
+                                value={formData.generalM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, generalM: e.target.value })}
                             />
                             <FormInput
                                 label="General_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, genFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.generalF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, generalF: e.target.value })}
                             />
                             <FormInput
                                 label="OBC_M"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcMale || ''}
-                                onChange={(e) => setFormData({ ...formData, obcMale: parseInt(e.target.value) || 0 })}
+                                value={formData.obcM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, obcM: e.target.value })}
                             />
                             <FormInput
                                 label="OBC_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, obcFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.obcF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, obcF: e.target.value })}
                             />
                         </div>
 
@@ -415,38 +415,38 @@ export const NariForms: React.FC<NariFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.scMale || ''}
-                                onChange={(e) => setFormData({ ...formData, scMale: parseInt(e.target.value) || 0 })}
+                                value={formData.scM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, scM: e.target.value })}
                             />
                             <FormInput
                                 label="SC_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.scFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, scFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.scF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, scF: e.target.value })}
                             />
                             <FormInput
                                 label="ST_M"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.stMale || ''}
-                                onChange={(e) => setFormData({ ...formData, stMale: parseInt(e.target.value) || 0 })}
+                                value={formData.stM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, stM: e.target.value })}
                             />
                             <FormInput
                                 label="ST_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.stFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, stFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.stF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, stF: e.target.value })}
                             />
                         </div>
                         <CasteGenderTotals
                             values={formData}
-                            maleFields={['genMale', 'obcMale', 'scMale', 'stMale']}
-                            femaleFields={['genFemale', 'obcFemale', 'scFemale', 'stFemale']}
+                            maleFields={['generalM', 'obcM', 'scM', 'stM']}
+                            femaleFields={['generalF', 'obcF', 'scF', 'stF']}
                         />
                     </div>
                 </div>
@@ -495,7 +495,7 @@ export const NariForms: React.FC<NariFormsProps> = ({
                             type="number"
                             wholeNumberOnly
                             value={formData.noOfDays || ''}
-                            onChange={(e) => setFormData({ ...formData, noOfDays: parseInt(e.target.value) || 0 })}
+                            onChange={(e) => setFormData({ ...formData, noOfDays: e.target.value })}
                         />
                         <FormInput
                             label="No of courses"
@@ -503,7 +503,7 @@ export const NariForms: React.FC<NariFormsProps> = ({
                             type="number"
                             wholeNumberOnly
                             value={formData.noOfCourses || ''}
-                            onChange={(e) => setFormData({ ...formData, noOfCourses: parseInt(e.target.value) || 0 })}
+                            onChange={(e) => setFormData({ ...formData, noOfCourses: e.target.value })}
                         />
                         <FormSelect
                             label="On Campus/Off Campus"
@@ -534,32 +534,32 @@ export const NariForms: React.FC<NariFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genMale || ''}
-                                onChange={(e) => setFormData({ ...formData, genMale: parseInt(e.target.value) || 0 })}
+                                value={formData.generalM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, generalM: e.target.value })}
                             />
                             <FormInput
                                 label="General_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, genFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.generalF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, generalF: e.target.value })}
                             />
                             <FormInput
                                 label="OBC_M"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcMale || ''}
-                                onChange={(e) => setFormData({ ...formData, obcMale: parseInt(e.target.value) || 0 })}
+                                value={formData.obcM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, obcM: e.target.value })}
                             />
                             <FormInput
                                 label="OBC_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, obcFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.obcF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, obcF: e.target.value })}
                             />
                         </div>
 
@@ -569,38 +569,38 @@ export const NariForms: React.FC<NariFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.scMale || ''}
-                                onChange={(e) => setFormData({ ...formData, scMale: parseInt(e.target.value) || 0 })}
+                                value={formData.scM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, scM: e.target.value })}
                             />
                             <FormInput
                                 label="SC_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.scFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, scFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.scF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, scF: e.target.value })}
                             />
                             <FormInput
                                 label="ST_M"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.stMale || ''}
-                                onChange={(e) => setFormData({ ...formData, stMale: parseInt(e.target.value) || 0 })}
+                                value={formData.stM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, stM: e.target.value })}
                             />
                             <FormInput
                                 label="ST_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.stFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, stFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.stF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, stF: e.target.value })}
                             />
                         </div>
                         <CasteGenderTotals
                             values={formData}
-                            maleFields={['genMale', 'obcMale', 'scMale', 'stMale']}
-                            femaleFields={['genFemale', 'obcFemale', 'scFemale', 'stFemale']}
+                            maleFields={['generalM', 'obcM', 'scM', 'stM']}
+                            femaleFields={['generalF', 'obcF', 'scF', 'stF']}
                         />
                     </div>
                 </div>
@@ -643,7 +643,7 @@ export const NariForms: React.FC<NariFormsProps> = ({
                             type="number"
                             wholeNumberOnly
                             value={formData.noOfActivities || ''}
-                            onChange={(e) => setFormData({ ...formData, noOfActivities: parseInt(e.target.value) || 0 })}
+                            onChange={(e) => setFormData({ ...formData, noOfActivities: e.target.value })}
                         />
                     </div>
 
@@ -657,32 +657,32 @@ export const NariForms: React.FC<NariFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genMale || ''}
-                                onChange={(e) => setFormData({ ...formData, genMale: parseInt(e.target.value) || 0 })}
+                                value={formData.generalM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, generalM: e.target.value })}
                             />
                             <FormInput
                                 label="General_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, genFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.generalF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, generalF: e.target.value })}
                             />
                             <FormInput
                                 label="OBC_M"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcMale || ''}
-                                onChange={(e) => setFormData({ ...formData, obcMale: parseInt(e.target.value) || 0 })}
+                                value={formData.obcM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, obcM: e.target.value })}
                             />
                             <FormInput
                                 label="OBC_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, obcFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.obcF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, obcF: e.target.value })}
                             />
                         </div>
 
@@ -692,38 +692,38 @@ export const NariForms: React.FC<NariFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.scMale || ''}
-                                onChange={(e) => setFormData({ ...formData, scMale: parseInt(e.target.value) || 0 })}
+                                value={formData.scM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, scM: e.target.value })}
                             />
                             <FormInput
                                 label="SC_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.scFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, scFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.scF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, scF: e.target.value })}
                             />
                             <FormInput
                                 label="ST_M"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.stMale || ''}
-                                onChange={(e) => setFormData({ ...formData, stMale: parseInt(e.target.value) || 0 })}
+                                value={formData.stM ?? ''}
+                                onChange={(e) => setFormData({ ...formData, stM: e.target.value })}
                             />
                             <FormInput
                                 label="ST_F"
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.stFemale || ''}
-                                onChange={(e) => setFormData({ ...formData, stFemale: parseInt(e.target.value) || 0 })}
+                                value={formData.stF ?? ''}
+                                onChange={(e) => setFormData({ ...formData, stF: e.target.value })}
                             />
                         </div>
                         <CasteGenderTotals
                             values={formData}
-                            maleFields={['genMale', 'obcMale', 'scMale', 'stMale']}
-                            femaleFields={['genFemale', 'obcFemale', 'scFemale', 'stFemale']}
+                            maleFields={['generalM', 'obcM', 'scM', 'stM']}
+                            femaleFields={['generalF', 'obcF', 'scF', 'stF']}
                         />
                     </div>
                 </div>

--- a/frontend/src/pages/dashboard/shared/forms/projects/NicraForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/projects/NicraForms.tsx
@@ -216,7 +216,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.dry10 || ''}
+                                value={formData.dry10 ?? ''}
                                 onChange={(e) => setFormData({ ...formData, dry10: e.target.value })}
                             />
                             <FormInput
@@ -224,7 +224,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.dry15 || ''}
+                                value={formData.dry15 ?? ''}
                                 onChange={(e) => setFormData({ ...formData, dry15: e.target.value })}
                             />
                             <FormInput
@@ -232,7 +232,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.dry20 || ''}
+                                value={formData.dry20 ?? ''}
                                 onChange={(e) => setFormData({ ...formData, dry20: e.target.value })}
                             />
                             <FormInput
@@ -240,7 +240,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.intensiveRain || ''}
+                                value={formData.intensiveRain ?? ''}
                                 onChange={(e) => setFormData({ ...formData, intensiveRain: e.target.value })}
                             />
                         </div>
@@ -402,7 +402,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genMale || ''}
+                                value={formData.genMale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, genMale: e.target.value })}
                             />
                             <FormInput
@@ -410,7 +410,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genFemale || ''}
+                                value={formData.genFemale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, genFemale: e.target.value })}
                             />
                             <FormInput
@@ -418,7 +418,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcMale || ''}
+                                value={formData.obcMale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, obcMale: e.target.value })}
                             />
                             <FormInput
@@ -426,7 +426,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcFemale || ''}
+                                value={formData.obcFemale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, obcFemale: e.target.value })}
                             />
                             <FormInput
@@ -557,7 +557,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genMale || ''}
+                                value={formData.genMale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, genMale: e.target.value })}
                             />
                             <FormInput
@@ -565,7 +565,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genFemale || ''}
+                                value={formData.genFemale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, genFemale: e.target.value })}
                             />
                             <FormInput
@@ -573,7 +573,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcMale || ''}
+                                value={formData.obcMale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, obcMale: e.target.value })}
                             />
                             <FormInput
@@ -581,7 +581,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcFemale || ''}
+                                value={formData.obcFemale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, obcFemale: e.target.value })}
                             />
                             <FormInput
@@ -666,7 +666,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genMale || ''}
+                                value={formData.genMale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, genMale: e.target.value })}
                             />
                             <FormInput
@@ -674,7 +674,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genFemale || ''}
+                                value={formData.genFemale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, genFemale: e.target.value })}
                             />
                             <FormInput
@@ -682,7 +682,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcMale || ''}
+                                value={formData.obcMale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, obcMale: e.target.value })}
                             />
                             <FormInput
@@ -690,7 +690,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcFemale || ''}
+                                value={formData.obcFemale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, obcFemale: e.target.value })}
                             />
                             <FormInput
@@ -877,7 +877,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genMale || ''}
+                                value={formData.genMale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, genMale: e.target.value })}
                             />
                             <FormInput
@@ -885,7 +885,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genFemale || ''}
+                                value={formData.genFemale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, genFemale: e.target.value })}
                             />
                             <FormInput
@@ -893,7 +893,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcMale || ''}
+                                value={formData.obcMale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, obcMale: e.target.value })}
                             />
                             <FormInput
@@ -901,7 +901,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcFemale || ''}
+                                value={formData.obcFemale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, obcFemale: e.target.value })}
                             />
                             <FormInput
@@ -1080,7 +1080,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genMale || ''}
+                                value={formData.genMale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, genMale: e.target.value })}
                             />
                             <FormInput
@@ -1088,7 +1088,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.genFemale || ''}
+                                value={formData.genFemale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, genFemale: e.target.value })}
                             />
                             <FormInput
@@ -1096,7 +1096,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcMale || ''}
+                                value={formData.obcMale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, obcMale: e.target.value })}
                             />
                             <FormInput
@@ -1104,7 +1104,7 @@ export const NicraForms: React.FC<NicraFormsProps> = ({
                                 required
                                 type="number"
                                 wholeNumberOnly
-                                value={formData.obcFemale || ''}
+                                value={formData.obcFemale ?? ''}
                                 onChange={(e) => setFormData({ ...formData, obcFemale: e.target.value })}
                             />
                             <FormInput


### PR DESCRIPTION
## Summary
Bug fixes across master data and project forms (all reported from QA against the live data).

| Area | Bug | Fix |
|---|---|---|
| FLD Crop master | Editing a crop returned `409 fld-crops with this cropName already exists` because crop names legitimately repeat across categories | Scope name-uniqueness to `categoryId + subCategoryId` via new `uniqueScopeFields` config; `nameExists` already supports `additionalFilters` |
| Product master | `update()` failed with `Unknown argument productCategoryId` — a relation key (`unit: null`) leaked into the Prisma write input | Drop relation keys (from `config.includes`) in `sanitizeData`, whether object or null |
| Staff (About KVK) | Saving staff failed `Missing required fields: jobTypeOther` when job type wasn't "Other" | `jobTypeOther`/`accountTypeOther` are conditional — removed from unconditional required list (frontend enforces when the chosen master `isOther`) |
| NARI forms | Beneficiary counts never persisted — form bound to `genMale` alias while the loaded record also carried the real `generalM`, and backend resolves `generalM ?? genMale` (alias shadowed) | Bind inputs to the real DB columns `generalM/generalF/obcM/obcF/scM/scF/stM/stF` |
| NARI/NICRA/ARYA/Training | Could not enter/keep `0` in number inputs (`value || ''` blanked 0; `parseInt || 0` snapped empty back to 0, causing stuck leading-zero) | `?? ''` for display + raw `e.target.value` onChange; `/forms` `validateFormRobustness` still coerces to int |

## Test
- Edit a crop reused across categories → saves (no 409)
- Edit a product with Unit = N/A → saves
- Save staff with a non-"Other" job type → saves
- NARI: set beneficiary `2`, Update → persists `2`; reopen shows `2`; can save/clear `0`

No DB migration. Split out from publication-conditional-fields work, which is already on dev.