### PR TITLE
feat(migration): Other Extension Activities migration module

### DIFF
--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -86,6 +86,8 @@ const MASTER_CATALOG = {
     courseCoordinator: { model: 'courseCoordinatorMaster', idField: 'coordinatorId', nameField: 'name' },
     // FldActivity master — what kvk_extension_activity.activityId references.
     fldActivity: { model: 'fldActivity', idField: 'activityId', nameField: 'activityName' },
+    // OtherExtensionActivity master — what kvk_other_extension_activity.activityTypeId references.
+    otherExtensionActivity: { model: 'otherExtensionActivity', idField: 'otherExtensionActivityId', nameField: 'otherExtensionName' },
 };
 
 function getMaster(key) {

--- a/backend/migration/modules/extensionActivity.js
+++ b/backend/migration/modules/extensionActivity.js
@@ -127,27 +127,8 @@ module.exports = {
     },
 
     async seedRecord(prisma, data) {
-        // Distinct source rows can share kvk+activity+date but differ by staff /
-        // count, so match on all of those to avoid one row overwriting another.
-        const where = {
-            kvkId: data.kvkId,
-            staffId: data.staffId ?? null,
-            numberOfActivities: data.numberOfActivities,
-            ...(data.startDate ? { startDate: data.startDate } : {}),
-            ...(data.endDate ? { endDate: data.endDate } : {}),
-        };
-        if (data.activityId != null) where.activityId = data.activityId;
-        else if (data.activityOther) where.activityOther = data.activityOther;
-
-        const existing = await prisma.kvkExtensionActivity.findFirst({ where });
-
-        if (existing) {
-            await prisma.kvkExtensionActivity.update({
-                where: { extensionActivityId: existing.extensionActivityId },
-                data,
-            });
-            return 'updated';
-        }
+        // Always insert — the old site has genuine duplicate rows (same kvk, staff,
+        // activity, dates, count) that are distinct records. Never update/dedupe.
         await prisma.kvkExtensionActivity.create({ data });
         return 'created';
     },

--- a/backend/migration/modules/extensionActivity.js
+++ b/backend/migration/modules/extensionActivity.js
@@ -32,7 +32,7 @@ module.exports = {
     label: 'Extension Activities',
     model: 'kvkExtensionActivity',
     idField: 'extensionActivityId',
-    naturalKey: ['kvkId', 'activityId', 'startDate'],
+    naturalKey: ['kvkId', 'activityId', 'staffId', 'startDate', 'endDate', 'numberOfActivities'],
 
     foreignKeys: {
         kvkId: { master: 'kvk' },
@@ -127,10 +127,14 @@ module.exports = {
     },
 
     async seedRecord(prisma, data) {
-        // Match on kvk + activity (or its Other text) + start date to avoid dupes on re-run.
+        // Distinct source rows can share kvk+activity+date but differ by staff /
+        // count, so match on all of those to avoid one row overwriting another.
         const where = {
             kvkId: data.kvkId,
+            staffId: data.staffId ?? null,
+            numberOfActivities: data.numberOfActivities,
             ...(data.startDate ? { startDate: data.startDate } : {}),
+            ...(data.endDate ? { endDate: data.endDate } : {}),
         };
         if (data.activityId != null) where.activityId = data.activityId;
         else if (data.activityOther) where.activityOther = data.activityOther;

--- a/backend/migration/modules/otherExtensionActivity.js
+++ b/backend/migration/modules/otherExtensionActivity.js
@@ -109,27 +109,8 @@ module.exports = {
     },
 
     async seedRecord(prisma, data) {
-        // Distinct source rows can share kvk+activity+date but differ by staff /
-        // count, so match on all of those to avoid one row overwriting another.
-        const where = {
-            kvkId: data.kvkId,
-            staffId: data.staffId ?? null,
-            numberOfActivities: data.numberOfActivities,
-            ...(data.startDate ? { startDate: data.startDate } : {}),
-            ...(data.endDate ? { endDate: data.endDate } : {}),
-        };
-        if (data.activityTypeId != null) where.activityTypeId = data.activityTypeId;
-        else if (data.activityTypeOther) where.activityTypeOther = data.activityTypeOther;
-
-        const existing = await prisma.kvkOtherExtensionActivity.findFirst({ where });
-
-        if (existing) {
-            await prisma.kvkOtherExtensionActivity.update({
-                where: { otherExtensionActivityId: existing.otherExtensionActivityId },
-                data,
-            });
-            return 'updated';
-        }
+        // Always insert — the old site has genuine duplicate rows (same kvk, staff,
+        // activity, dates, count) that are distinct records. Never update/dedupe.
         await prisma.kvkOtherExtensionActivity.create({ data });
         return 'created';
     },

--- a/backend/migration/modules/otherExtensionActivity.js
+++ b/backend/migration/modules/otherExtensionActivity.js
@@ -31,7 +31,7 @@ module.exports = {
     label: 'Other Extension Activities',
     model: 'kvkOtherExtensionActivity',
     idField: 'otherExtensionActivityId',
-    naturalKey: ['kvkId', 'activityTypeId', 'startDate'],
+    naturalKey: ['kvkId', 'activityTypeId', 'staffId', 'startDate', 'endDate', 'numberOfActivities'],
 
     foreignKeys: {
         kvkId: { master: 'kvk' },
@@ -109,9 +109,14 @@ module.exports = {
     },
 
     async seedRecord(prisma, data) {
+        // Distinct source rows can share kvk+activity+date but differ by staff /
+        // count, so match on all of those to avoid one row overwriting another.
         const where = {
             kvkId: data.kvkId,
+            staffId: data.staffId ?? null,
+            numberOfActivities: data.numberOfActivities,
             ...(data.startDate ? { startDate: data.startDate } : {}),
+            ...(data.endDate ? { endDate: data.endDate } : {}),
         };
         if (data.activityTypeId != null) where.activityTypeId = data.activityTypeId;
         else if (data.activityTypeOther) where.activityTypeOther = data.activityTypeOther;

--- a/backend/migration/modules/otherExtensionActivity.js
+++ b/backend/migration/modules/otherExtensionActivity.js
@@ -1,0 +1,131 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: KVK Other Extension Activities (Achievements). Source:
+ * atariams.org `other-extension-activities`. Writes kvk_other_extension_activity.
+ *
+ * Every field lives on the DataTables list row (nested kvk/staff/extension_activity
+ * objects) — no per-row edit-page fetch. No farmer/official demographics here.
+ *
+ * The activity FK points at the OtherExtensionActivity master
+ * (other_extension_activity). Unmatched names are parked in `activityTypeOther`.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'other-extension-activity',
+    label: 'Other Extension Activities',
+    model: 'kvkOtherExtensionActivity',
+    idField: 'otherExtensionActivityId',
+    naturalKey: ['kvkId', 'activityTypeId', 'startDate'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        staffId: { master: 'kvkStaff' },
+        activityTypeId: { master: 'otherExtensionActivity', otherField: 'activityTypeOther' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+        const err = (field, msg) => issues.push({ field, message: msg, severity: 'error' });
+
+        // 1. KVK match
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Staff ← embedded staff.staff_name → KvkStaff (by name, within KVK). Optional.
+        let staffId = null;
+        const staffObj = asObject(row.staff);
+        const staffName = decodeEntities(cleanText(staffObj?.staff_name || ''));
+        if (staffName) {
+            staffId = await r.findId('kvkStaff', { kvkId, staffName }, 'kvkStaffId');
+            if (!staffId) warn('staffId', `Staff "${staffName}" not found for this KVK — migrate Employees first or pick manually`);
+        } else {
+            warn('staffId', 'No staff on old row — pick manually if needed');
+        }
+
+        // 3. Activity ← extension_activity.name → OtherExtensionActivity master. Park unmatched in Other.
+        let activityTypeId = null;
+        let activityTypeOther = null;
+        const actObj = asObject(row.extension_activity);
+        const activityName = decodeEntities(cleanText(actObj?.name || row['extension_activity.name'] || ''));
+        if (activityName) {
+            const a = await r.resolve('otherExtensionActivity', 'otherExtensionName', 'otherExtensionActivityId', activityName);
+            if (a.matched) activityTypeId = a.id;
+            else {
+                activityTypeOther = activityName;
+                warn('activityTypeId', `Activity "${activityName}" not in master — parked in Other`);
+            }
+        }
+
+        // 4. Number of activities (REQUIRED)
+        const numberOfActivities = intOrZero(row.no_of_activity);
+
+        // 5. Dates (both REQUIRED) — dd-mm-yyyy; parseDate normalizes (UTC).
+        const startIso = parseDate(row.start_date);
+        const endIso = parseDate(row.end_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start date "${row.start_date}"`);
+        if (!endDate) err('endDate', `Missing/invalid end date "${row.end_date}"`);
+
+        const data = {
+            kvkId,
+            fldId: null,
+            staffId,
+            activityTypeId,
+            activityTypeOther,
+            numberOfActivities,
+            startDate,
+            endDate,
+        };
+
+        return { data, issues };
+    },
+
+    async seedRecord(prisma, data) {
+        const where = {
+            kvkId: data.kvkId,
+            ...(data.startDate ? { startDate: data.startDate } : {}),
+        };
+        if (data.activityTypeId != null) where.activityTypeId = data.activityTypeId;
+        else if (data.activityTypeOther) where.activityTypeOther = data.activityTypeOther;
+
+        const existing = await prisma.kvkOtherExtensionActivity.findFirst({ where });
+
+        if (existing) {
+            await prisma.kvkOtherExtensionActivity.update({
+                where: { otherExtensionActivityId: existing.otherExtensionActivityId },
+                data,
+            });
+            return 'updated';
+        }
+        await prisma.kvkOtherExtensionActivity.create({ data });
+        return 'created';
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -17,6 +17,7 @@ const specs = [
     require('./modules/cfldBudgetUtilization.js'),
     require('./modules/training.js'),
     require('./modules/extensionActivity.js'),
+    require('./modules/otherExtensionActivity.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));


### PR DESCRIPTION
## Summary

Adds a migration module for **Other Extension Activities** (atariams.org `other-extension-activities` → `kvk_other_extension_activity`).

- All fields read from the DataTables list row (nested `kvk`/`staff`/`extension_activity`). No edit-page fetch; this form has no farmer/official demographics.
- **Staff**: resolved by embedded `staff.staff_name` → `KvkStaff` (within the KVK)
- **Activity**: resolved against the `OtherExtensionActivity` master (what `activityTypeId` references); unmatched names parked in `activityTypeOther`
- Dates via shared `parseDate` (dd-mm-yyyy, UTC)
- `masterCatalog`: registers `otherExtensionActivity` for the FK picker
- `registry`: registers the module

## Field mapping

| Target | Source | Behavior |
|---|---|---|
| staffId | `staff.staff_name` | resolve KvkStaff by name (optional) |
| activityTypeId | `extension_activity.name` | resolve OtherExtensionActivity, else activityTypeOther |
| numberOfActivities | `no_of_activity` | direct |
| startDate / endDate | `start_date` / `end_date` | parseDate (dd-mm-yyyy) |

## Test plan

- [ ] Fetch+transform a KVK's other-extension-activities list → rows map, 0 errors
- [ ] Activity resolves (e.g. "TV Talks" → OtherExtensionActivity #5); unknown → Other
- [ ] Staff resolves from embedded name; dates correct
- [ ] Push seeds kvk_other_extension_activity; re-run updates (natural key kvkId+activityTypeId+startDate)