### PR TITLE
feat(migration): insert-only seeding + editable mapped grid

### DIFF
--- a/backend/migration/engine.js
+++ b/backend/migration/engine.js
@@ -132,8 +132,10 @@ async function transform(moduleKey, kvkId, raw) {
 }
 
 /**
- * Idempotent seed: find-or-update by the spec's naturalKey, so re-running the
- * same data never duplicates. Skips rows that failed to map (null).
+ * Insert-only seed: every mapped row is created as a new record. The old site
+ * has genuine duplicate-looking rows that differ only in fields not covered by a
+ * naturalKey, so matching/updating would collapse distinct records into one.
+ * Never dedupe — always insert. Skips rows that failed to map (null).
  */
 async function seed(moduleKey, kvkId, records) {
     const spec = getModule(moduleKey);
@@ -157,19 +159,9 @@ async function seed(moduleKey, kvkId, records) {
                 result.actions.push(resolved);
                 continue;
             }
-            const where = {};
-            for (const k of spec.naturalKey) where[k] = data[k];
-            const existing = await model.findFirst({ where });
-            if (existing) {
-                const idField = spec.idField || Object.keys(existing).find(k => /Id$/.test(k));
-                await model.update({ where: { [idField]: existing[idField] }, data });
-                result.updated++;
-                result.actions.push('updated');
-            } else {
-                await model.create({ data });
-                result.created++;
-                result.actions.push('created');
-            }
+            await model.create({ data });
+            result.created++;
+            result.actions.push('created');
         } catch (err) {
             result.failed.push({ index, message: err.message });
             result.actions.push('failed');

--- a/backend/migration/modules/cfldBudgetUtilization.js
+++ b/backend/migration/modules/cfldBudgetUtilization.js
@@ -269,26 +269,11 @@ module.exports = {
         const mainData = { ...data };
         delete mainData._budgetItems;
 
-        // Upsert main record
-        const where = {
-            kvkId: mainData.kvkId,
-            year: mainData.year,
-            cropId: mainData.cropId ?? null,
-            seasonId: mainData.seasonId ?? null,
-        };
-        const existing = await prisma.kvkBudgetUtilization.findFirst({ where });
-
-        let budgetId;
-        if (existing) {
-            await prisma.kvkBudgetUtilization.update({
-                where: { budgetId: existing.budgetId },
-                data: mainData,
-            });
-            budgetId = existing.budgetId;
-        } else {
-            const created = await prisma.kvkBudgetUtilization.create({ data: mainData });
-            budgetId = created.budgetId;
-        }
+        // Always insert a new main record — distinct source rows can share kvk +
+        // year + crop + season but are separate records. Matching/updating would
+        // collapse them.
+        const created = await prisma.kvkBudgetUtilization.create({ data: mainData });
+        const budgetId = created.budgetId;
 
         // Upsert each budget line item (find-or-create BudgetItem by name)
         for (const item of budgetItems) {
@@ -315,6 +300,6 @@ module.exports = {
             });
         }
 
-        return existing ? 'updated' : 'created';
+        return 'created';
     },
 };

--- a/backend/migration/modules/cfldTechnicalParameter.js
+++ b/backend/migration/modules/cfldTechnicalParameter.js
@@ -709,26 +709,11 @@ module.exports = {
         delete mainData._socioEconomicParameters;
         delete mainData._farmersPerceptionParameters;
 
-        const where = {
-            kvkId: mainData.kvkId,
-            cropId: mainData.cropId,
-            technologyDemonstrated: mainData.technologyDemonstrated,
-            month: mainData.month,
-            status: mainData.status,
-        };
-        const existing = await prisma.cfldTechnicalParameter.findFirst({ where });
-
-        let cfldTechId;
-        if (existing) {
-            await prisma.cfldTechnicalParameter.update({
-                where: { cfldTechId: existing.cfldTechId },
-                data: mainData,
-            });
-            cfldTechId = existing.cfldTechId;
-        } else {
-            const created = await prisma.cfldTechnicalParameter.create({ data: mainData });
-            cfldTechId = created.cfldTechId;
-        }
+        // Always insert a new technical-parameter record — distinct source rows can
+        // share kvk + crop + technology + month + status but are separate records.
+        // Matching/updating would collapse them.
+        const created = await prisma.cfldTechnicalParameter.create({ data: mainData });
+        const cfldTechId = created.cfldTechId;
 
         if (ep) {
             await prisma.cfldEconomicParameters.upsert({
@@ -752,6 +737,6 @@ module.exports = {
             });
         }
 
-        return existing ? 'updated' : 'created';
+        return 'created';
     },
 };

--- a/backend/migration/modules/equipment.js
+++ b/backend/migration/modules/equipment.js
@@ -154,34 +154,10 @@ module.exports = {
         const parentData = { ...data };
         delete parentData._detail;
 
-        // Upsert parent KvkEquipment by kvkId + identifierCode (if present),
-        // else kvkId + equipmentName + yearOfPurchase.
-        // Details are NOT seeded here — run the equipment-details module for that.
-        let existing;
-        if (parentData.identifierCode) {
-            existing = await prisma.kvkEquipment.findFirst({
-                where: { kvkId: parentData.kvkId, identifierCode: parentData.identifierCode },
-            });
-        }
-        if (!existing && parentData.equipmentName && parentData.yearOfPurchase) {
-            existing = await prisma.kvkEquipment.findFirst({
-                where: {
-                    kvkId: parentData.kvkId,
-                    equipmentName: parentData.equipmentName,
-                    yearOfPurchase: parentData.yearOfPurchase,
-                },
-            });
-        }
-
-        if (existing) {
-            await prisma.kvkEquipment.update({
-                where: { equipmentId: existing.equipmentId },
-                data: parentData,
-            });
-        } else {
-            await prisma.kvkEquipment.create({ data: parentData });
-        }
-
-        return existing ? 'updated' : 'created';
+        // Always insert a new KvkEquipment — distinct source rows can share name /
+        // year / identifier but are separate records. Matching/updating would
+        // collapse them. Details are NOT seeded here — run equipment-details for that.
+        await prisma.kvkEquipment.create({ data: parentData });
+        return 'created';
     },
 };

--- a/backend/migration/modules/fld.js
+++ b/backend/migration/modules/fld.js
@@ -599,54 +599,24 @@ module.exports = {
     },
 
     async seedRecord(prisma, data, { kvkId }) {
-        const existing = await prisma.kvkFldIntroduction.findFirst({
-            where: {
-                kvkId: data.kvkId,
-                fldName: data.fldName,
-                ...(data.startDate ? { startDate: data.startDate } : {}),
-            }
-        });
-        
         const fldResult = data.fldResult;
         const fldData = { ...data };
         delete fldData.fldResult;
-        
-        if (existing) {
-            await prisma.kvkFldIntroduction.update({
-                where: { kvkFldId: existing.kvkFldId },
-                data: fldData,
-            });
-            
-            if (fldResult) {
-                await prisma.kvkFldResult.upsert({
-                    where: { kvkFldId: existing.kvkFldId },
-                    update: fldResult,
-                    create: {
-                        kvkFldId: existing.kvkFldId,
-                        ...fldResult,
-                    }
-                });
-            } else {
-                if (fldData.ongoingCompleted === 'ONGOING') {
-                    await prisma.kvkFldResult.deleteMany({
-                        where: { kvkFldId: existing.kvkFldId }
-                    });
+
+        // Always insert a new FLD record — distinct source rows can share kvk +
+        // name + start date but are separate records. Matching/updating would
+        // collapse them.
+        const created = await prisma.kvkFldIntroduction.create({
+            data: fldData,
+        });
+        if (fldResult) {
+            await prisma.kvkFldResult.create({
+                data: {
+                    kvkFldId: created.kvkFldId,
+                    ...fldResult,
                 }
-            }
-            return 'updated';
-        } else {
-            const created = await prisma.kvkFldIntroduction.create({
-                data: fldData,
             });
-            if (fldResult) {
-                await prisma.kvkFldResult.create({
-                    data: {
-                        kvkFldId: created.kvkFldId,
-                        ...fldResult,
-                    }
-                });
-            }
-            return 'created';
         }
+        return 'created';
     }
 };

--- a/backend/migration/modules/oft.js
+++ b/backend/migration/modules/oft.js
@@ -619,74 +619,14 @@ module.exports = {
         const { technologies, resultReport, ...oftData } = data;
         void kvkId;
 
-        const where = {
-            kvkId: oftData.kvkId,
-            title: oftData.title,
-            oftStartDate: oftData.oftStartDate,
-        };
-        const existing = await prisma.kvkoft.findFirst({ where });
-
         const techCreate = (technologies || []).map((t, index) => ({
             optionKey: t.optionKey || `opt_${index + 1}`,
             optionName: t.optionName,
             details: t.details || null,
         }));
 
-        let savedReportId = null;
-
-        if (existing) {
-            await prisma.kvkoftTechnology.deleteMany({ where: { kvkOftId: existing.kvkOftId } });
-            
-            const updatePayload = {
-                ...oftData,
-                technologies: { create: techCreate },
-            };
-            
-            if (resultReport) {
-                const existingReport = await prisma.oftResultReport.findFirst({
-                    where: { kvkOftId: existing.kvkOftId }
-                });
-                if (existingReport) {
-                    const updatedReport = await prisma.oftResultReport.update({
-                        where: { oftResultReportId: existingReport.oftResultReportId },
-                        data: {
-                            finalRecommendation: resultReport.finalRecommendation,
-                            constraintsFeedback: resultReport.constraintsFeedback,
-                            farmersParticipationProcess: resultReport.farmersParticipationProcess,
-                            resultText: resultReport.resultText,
-                            remark: resultReport.remark || '',
-                            photographName: resultReport.photographName || null,
-                        }
-                    });
-                    savedReportId = updatedReport.oftResultReportId;
-                } else {
-                    const createdReport = await prisma.oftResultReport.create({
-                        data: {
-                            kvkOftId: existing.kvkOftId,
-                            finalRecommendation: resultReport.finalRecommendation,
-                            constraintsFeedback: resultReport.constraintsFeedback,
-                            farmersParticipationProcess: resultReport.farmersParticipationProcess,
-                            resultText: resultReport.resultText,
-                            remark: resultReport.remark || '',
-                            photographName: resultReport.photographName || null,
-                        }
-                    });
-                    savedReportId = createdReport.oftResultReportId;
-                }
-            }
-
-            await prisma.kvkoft.update({
-                where: { kvkOftId: existing.kvkOftId },
-                data: updatePayload,
-            });
-
-            if (resultReport && savedReportId && resultReport.tables) {
-                await saveResultReportTables(prisma, savedReportId, resultReport.tables);
-            }
-
-            return 'updated';
-        }
-
+        // Always insert a new OFT — distinct source rows can share kvk + title +
+        // start date but are separate records. Matching/updating would collapse them.
         const createPayload = {
             ...oftData,
             technologies: { create: techCreate },

--- a/backend/migration/modules/training.js
+++ b/backend/migration/modules/training.js
@@ -267,21 +267,8 @@ module.exports = {
     },
 
     async seedRecord(prisma, data) {
-        const existing = await prisma.trainingAchievement.findFirst({
-            where: {
-                kvkId: data.kvkId,
-                titleOfTraining: data.titleOfTraining,
-                ...(data.startDate ? { startDate: data.startDate } : {}),
-            },
-        });
-
-        if (existing) {
-            await prisma.trainingAchievement.update({
-                where: { trainingAchievementId: existing.trainingAchievementId },
-                data,
-            });
-            return 'updated';
-        }
+        // Always insert — distinct source rows can share kvk + title + start date
+        // but differ in other fields. Matching/updating would collapse them.
         await prisma.trainingAchievement.create({ data });
         return 'created';
     },

--- a/frontend/src/pages/migration/MigrationTool.tsx
+++ b/frontend/src/pages/migration/MigrationTool.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from 'react'
 import { Button } from '../../components/ui/button'
 import {
     migrationApi,
@@ -33,8 +33,9 @@ export function MigrationTool() {
     const [rowCount, setRowCount] = useState<number | null>(null)
     const [splitPercent, setSplitPercent] = useState<number>(50)
     const [verticalSplit, setVerticalSplit] = useState<number>(65)
+    const [showErrorsOnly, setShowErrorsOnly] = useState<boolean>(false)
 
-    const handleMouseDown = (e: React.MouseEvent) => {
+    const handleMouseDown = (e: ReactMouseEvent) => {
         e.preventDefault()
         const startX = e.clientX
         const startSplit = splitPercent
@@ -58,7 +59,7 @@ export function MigrationTool() {
         document.addEventListener('mouseup', handleMouseUp)
     }
 
-    const handleVerticalMouseDown = (e: React.MouseEvent) => {
+    const handleVerticalMouseDown = (e: ReactMouseEvent) => {
         e.preventDefault()
         const startY = e.clientY
         const startSplit = verticalSplit
@@ -200,6 +201,72 @@ export function MigrationTool() {
         )
     }
 
+    // Free-form edit of any non-FK cell. Persists in `records`, which is what we
+    // push to the DB (Push sends the edited records, not the transform output).
+    const onEditField = (rowIndex: number, field: string, value: unknown) => {
+        setRecords(prev =>
+            prev.map((r, i) => (i !== rowIndex || !r ? r : { ...r, [field]: value })),
+        )
+    }
+
+    // Copy an FK pick into every still-unmatched row in the same column — one
+    // click to fill all the empty cells of that column.
+    const onFillUnmatched = (field: string, value: number) => {
+        const meta = activeModule?.foreignKeys[field]
+        setRecords(prev =>
+            prev.map(r => {
+                if (!r) return r
+                const cur = r[field]
+                if (cur !== null && cur !== undefined && cur !== '') return r
+                const next: Row = { ...r, [field]: value }
+                if (meta?.otherField) next[meta.otherField] = null
+                return next
+            }),
+        )
+    }
+
+    // Recompute the report against the CURRENT records so manual fixes clear in
+    // real time: an error issue is dropped once its field now has a value, which
+    // re-enables Push without a re-Transform. Warnings are left untouched.
+    const liveReport = useMemo(() => {
+        if (!transformed) return null
+        const errorResolved = (field: string, rec: Row | null) => {
+            if (!rec) return false
+            const v = rec[field]
+            return v !== null && v !== undefined && v !== ''
+        }
+        const rows = transformed.report.rows
+            .map(r => {
+                const rec = records[r.index] ?? null
+                const issues = r.issues.filter(
+                    it => !(it.severity === 'error' && errorResolved(it.field, rec)),
+                )
+                return { index: r.index, issues }
+            })
+            .filter(r => r.issues.length > 0)
+        const errorCount = rows.reduce(
+            (n, r) => n + r.issues.filter(i => i.severity === 'error').length,
+            0,
+        )
+        const warnCount = rows.reduce(
+            (n, r) => n + r.issues.filter(i => i.severity === 'warn').length,
+            0,
+        )
+        return { ...transformed.report, rows, errorCount, warnCount, seedable: errorCount === 0 }
+    }, [transformed, records])
+
+    // Original indices of rows that still carry an unresolved error — drives the
+    // "show only errors" filter.
+    const errorIndices = useMemo(() => {
+        const s = new Set<number>()
+        liveReport?.rows.forEach(r => {
+            if (r.issues.some(i => i.severity === 'error')) s.add(r.index)
+        })
+        return s
+    }, [liveReport])
+
+    const visibleIndices = showErrorsOnly ? errorIndices : undefined
+
     const displayRecords = useMemo(() => {
         const source = records.length > 0 ? records : transformed?.records
         if (!source) return undefined
@@ -215,11 +282,11 @@ export function MigrationTool() {
     }, [records, transformed])
 
     const fk: FkEditing | undefined = activeModule
-        ? { foreignKeys: activeModule.foreignKeys, fkOptions, onEditCell }
+        ? { foreignKeys: activeModule.foreignKeys, fkOptions, onEditCell, onEditField, onFillUnmatched }
         : undefined
 
     const canTransform = raw !== undefined && kvkId !== '' && moduleKey !== ''
-    const canSeed = !!transformed && transformed.report.seedable
+    const canSeed = !!liveReport && liveReport.seedable
 
     return (
         <div className="flex h-[calc(100vh-4rem)] flex-col gap-4 p-4">
@@ -289,29 +356,6 @@ export function MigrationTool() {
                 </div>
             )}
 
-            {/* Split Sizer Control */}
-            <div className="flex items-center gap-2 border-t border-gray-100 pt-2 text-xs text-gray-500">
-                <span className="font-semibold text-gray-700">Resize Panels:</span>
-                <input
-                    type="range"
-                    min="20"
-                    max="80"
-                    value={splitPercent}
-                    onChange={e => setSplitPercent(Number(e.target.value))}
-                    className="h-2 w-40 cursor-pointer appearance-none rounded-lg bg-gray-200 accent-blue-600 focus:outline-none"
-                    title="Slide to resize the panels left/right"
-                />
-                <span className="font-mono bg-gray-100 px-1.5 py-0.5 rounded text-gray-600">
-                    {splitPercent}% / {100 - splitPercent}%
-                </span>
-                <button
-                    type="button"
-                    onClick={() => setSplitPercent(50)}
-                    className="rounded border border-gray-300 bg-white px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-50 active:bg-gray-100 font-medium transition-colors"
-                >
-                    Reset Split
-                </button>
-            </div>
 
             {/* Panes */}
             <div className="flex min-h-0 flex-1 gap-0 overflow-hidden relative">
@@ -344,6 +388,26 @@ export function MigrationTool() {
                             badge={transformed ? `${transformed.report.mapped} mapped` : undefined}
                             placeholder="Transform to see records mapped to your DB schema."
                             rowActions={rowActions}
+                            visibleIndices={visibleIndices}
+                            headerExtra={
+                                transformed ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowErrorsOnly(v => !v)}
+                                        disabled={!showErrorsOnly && errorIndices.size === 0}
+                                        title="Show only rows that still have unresolved errors"
+                                        className={`rounded border px-2 py-1 text-xs font-medium transition-colors ${
+                                            showErrorsOnly
+                                                ? 'border-red-300 bg-red-50 text-red-700 hover:bg-red-100'
+                                                : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50 disabled:opacity-50'
+                                        }`}
+                                    >
+                                        {showErrorsOnly
+                                            ? 'Show all rows'
+                                            : `Errors only (${errorIndices.size})`}
+                                    </button>
+                                ) : undefined
+                            }
                         />
                     </div>
                     {transformed && (
@@ -357,7 +421,7 @@ export function MigrationTool() {
                                 <div className="h-0.5 w-12 bg-gray-300 rounded-full"></div>
                             </div>
                             <div style={{ height: `${100 - verticalSplit}%` }} className="min-h-0 overflow-auto">
-                                <MigrationReport report={transformed.report} />
+                                <MigrationReport report={liveReport ?? transformed.report} />
                             </div>
                         </>
                     )}

--- a/frontend/src/pages/migration/components/CellRenderers.tsx
+++ b/frontend/src/pages/migration/components/CellRenderers.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react'
+import { formatCell, isEmpty } from '../views/tableUtils'
+
+/** Render one cell value compactly; long strings get an expand/collapse toggle. */
+export function CollapsibleCell({ value }: { value: unknown }) {
+    const [expanded, setExpanded] = useState(false)
+    const formatted = formatCell(value)
+    const isLongText = typeof value === 'string' && value.length > 40
+
+    if (!isLongText) {
+        return (
+            <span className={isEmpty(value) ? 'text-gray-300' : 'text-gray-800'}>
+                {formatted}
+            </span>
+        )
+    }
+
+    const text = String(value)
+
+    return (
+        <div className="flex flex-col gap-1 max-w-[320px]">
+            <div
+                className={`text-gray-800 transition-all text-xs font-mono break-words ${
+                    expanded ? 'whitespace-normal' : 'truncate'
+                }`}
+                title={text}
+            >
+                {expanded ? text : text.slice(0, 40) + '...'}
+            </div>
+            <button
+                type="button"
+                onClick={(e) => {
+                    e.stopPropagation()
+                    setExpanded(!expanded)
+                }}
+                className="text-[10px] font-semibold text-blue-600 hover:text-blue-800 self-start mt-0.5 select-none"
+            >
+                {expanded ? 'Collapse' : 'Expand'}
+            </button>
+        </div>
+    )
+}
+
+/** Coerce edited text back toward the original cell's type so the DB gets a sane value. */
+function coerce(draft: string, original: unknown): unknown {
+    if (draft === '') return null
+    if (typeof original === 'number') {
+        const n = Number(draft)
+        return Number.isFinite(n) ? n : draft
+    }
+    if (typeof original === 'boolean') return draft === 'true' || draft === '1'
+    return draft
+}
+
+/**
+ * Editable cell: shows the value (via CollapsibleCell) with a hover pencil. Click
+ * to edit inline; Enter/blur commits, Escape cancels. Object cells stay read-only
+ * (editing JSON inline is error-prone). Commits flow up via onCommit into the
+ * shared records state, so edits persist across view switches.
+ */
+export function EditableCell({
+    value,
+    onCommit,
+}: {
+    value: unknown
+    onCommit: (v: unknown) => void
+}) {
+    const [editing, setEditing] = useState(false)
+    const [draft, setDraft] = useState('')
+    const isObject = value !== null && typeof value === 'object'
+
+    const start = () => {
+        setDraft(value == null ? '' : String(value))
+        setEditing(true)
+    }
+    const commit = () => {
+        onCommit(coerce(draft, value))
+        setEditing(false)
+    }
+
+    if (editing) {
+        return (
+            <input
+                autoFocus
+                value={draft}
+                onChange={e => setDraft(e.target.value)}
+                onBlur={commit}
+                onKeyDown={e => {
+                    if (e.key === 'Enter') {
+                        e.preventDefault()
+                        commit()
+                    }
+                    if (e.key === 'Escape') setEditing(false)
+                }}
+                className="w-full min-w-[120px] rounded border border-blue-400 px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+        )
+    }
+
+    return (
+        <div className="flex items-start gap-1">
+            <div className="min-w-0 flex-1">
+                <CollapsibleCell value={value} />
+            </div>
+            {!isObject && (
+                <button
+                    type="button"
+                    onClick={start}
+                    title="Edit cell"
+                    className="shrink-0 rounded border border-gray-200 bg-white px-1 text-[11px] leading-tight text-gray-400 transition-colors hover:border-blue-300 hover:text-blue-600"
+                >
+                    ✎
+                </button>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/pages/migration/components/FkCell.tsx
+++ b/frontend/src/pages/migration/components/FkCell.tsx
@@ -6,6 +6,8 @@ interface FkCellProps {
     options: Option[]
     otherText?: string | null
     onChange: (id: number | null) => void
+    /** When provided, shows an "apply to all unmatched" button once a value is picked. */
+    onFillUnmatched?: (value: number) => void
 }
 
 /**
@@ -14,7 +16,7 @@ interface FkCellProps {
  * the id back into the record — reflected across every view via shared state.
  * Falls back to the *Other free-text when no master matched.
  */
-export function FkCell({ value, options, otherText, onChange }: FkCellProps) {
+export function FkCell({ value, options, otherText, onChange, onFillUnmatched }: FkCellProps) {
     // Always keep the current id visible: if it isn't in the loaded options
     // (master list still loading, or an id with no master row), inject a
     // synthetic "#<id>" entry so the cell shows the id instead of a blank.
@@ -33,6 +35,16 @@ export function FkCell({ value, options, otherText, onChange }: FkCellProps) {
                 placeholder={otherText ? `other: ${otherText}` : 'unmatched — pick…'}
                 onChange={v => onChange(v === '' ? null : Number(v))}
             />
+            {value != null && onFillUnmatched && (
+                <button
+                    type="button"
+                    onClick={() => onFillUnmatched(value)}
+                    title="Set this value on every still-unmatched row in this column"
+                    className="mt-1 text-[10px] font-semibold text-blue-600 hover:text-blue-800 select-none"
+                >
+                    ⇊ apply to all unmatched
+                </button>
+            )}
         </div>
     )
 }

--- a/frontend/src/pages/migration/components/RecordsViewer.tsx
+++ b/frontend/src/pages/migration/components/RecordsViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, type ReactNode } from 'react'
 import { TableView } from '../views/TableView'
 import { MatrixView } from '../views/MatrixView'
 import {
@@ -25,6 +25,9 @@ interface RecordsViewerProps {
     defaultView?: ViewMode
     fk?: FkEditing
     rowActions?: RowAction[]
+    visibleIndices?: Set<number>
+    /** Extra controls rendered in the header, before the Jump selector. */
+    headerExtra?: ReactNode
 }
 
 /**
@@ -42,6 +45,8 @@ export function RecordsViewer({
     defaultView = 'table',
     fk,
     rowActions,
+    visibleIndices,
+    headerExtra,
 }: RecordsViewerProps) {
     const [view, setView] = useState<ViewMode>(defaultView)
     const containerRef = useRef<HTMLDivElement>(null)
@@ -78,6 +83,7 @@ export function RecordsViewer({
                     )}
                 </div>
                 <div className="flex items-center gap-3">
+                    {headerExtra}
                     {/* Quick-Jump Selector */}
                     {hasData && view !== 'json' && cols.length > 0 && (
                         <div className="flex items-center gap-1.5 text-xs">
@@ -174,9 +180,9 @@ export function RecordsViewer({
                         {JSON.stringify(data, null, 2)}
                     </pre>
                 ) : view === 'table' ? (
-                    <TableView data={data} fk={fk} idPrefix={idPrefix} rowActions={rowActions} />
+                    <TableView data={data} fk={fk} idPrefix={idPrefix} rowActions={rowActions} visibleIndices={visibleIndices} />
                 ) : (
-                    <MatrixView data={data} fk={fk} idPrefix={idPrefix} />
+                    <MatrixView data={data} fk={fk} idPrefix={idPrefix} visibleIndices={visibleIndices} />
                 )}
             </div>
         </div>

--- a/frontend/src/pages/migration/views/MatrixView.tsx
+++ b/frontend/src/pages/migration/views/MatrixView.tsx
@@ -1,56 +1,13 @@
-import { useState } from 'react'
 import { FkCell } from '../components/FkCell'
-import {
-    collectColumns,
-    formatCell,
-    isEmpty,
-    toIndexedRows,
-    type FkEditing,
-} from './tableUtils'
+import { CollapsibleCell, EditableCell } from '../components/CellRenderers'
+import { collectColumns, toIndexedRows, type FkEditing } from './tableUtils'
 
 interface MatrixViewProps {
     data: unknown
     fk?: FkEditing
     idPrefix?: string
-}
-
-function CollapsibleCell({ value }: { value: unknown }) {
-    const [expanded, setExpanded] = useState(false)
-    const formatted = formatCell(value)
-    const isLongText = typeof value === 'string' && value.length > 40
-
-    if (!isLongText) {
-        return (
-            <span className={isEmpty(value) ? 'text-gray-300' : 'text-gray-800'}>
-                {formatted}
-            </span>
-        )
-    }
-
-    const text = String(value)
-
-    return (
-        <div className="flex flex-col gap-1 max-w-[320px]">
-            <div
-                className={`text-gray-800 transition-all text-xs font-mono break-words ${
-                    expanded ? 'whitespace-normal' : 'truncate'
-                }`}
-                title={text}
-            >
-                {expanded ? text : text.slice(0, 40) + '...'}
-            </div>
-            <button
-                type="button"
-                onClick={(e) => {
-                    e.stopPropagation()
-                    setExpanded(!expanded)
-                }}
-                className="text-[10px] font-semibold text-blue-600 hover:text-blue-800 self-start mt-0.5 select-none"
-            >
-                {expanded ? 'Collapse' : 'Expand'}
-            </button>
-        </div>
-    )
+    /** When set, only record columns whose original index is in the set are rendered. */
+    visibleIndices?: Set<number>
 }
 
 /**
@@ -58,12 +15,16 @@ function CollapsibleCell({ value }: { value: unknown }) {
  * how each field mapped across a handful of records (the common migration case:
  * few rows, many fields) — scan a single field down the page.
  */
-export function MatrixView({ data, fk, idPrefix = 'raw' }: MatrixViewProps) {
-    const rows = toIndexedRows(data)
-    if (rows.length === 0) {
+export function MatrixView({ data, fk, idPrefix = 'raw', visibleIndices }: MatrixViewProps) {
+    const allRows = toIndexedRows(data)
+    if (allRows.length === 0) {
         return <p className="p-3 text-sm text-gray-400">No rows to pivot.</p>
     }
-    const fields = collectColumns(rows.map(r => r.row))
+    const fields = collectColumns(allRows.map(r => r.row))
+    const rows = visibleIndices ? allRows.filter(r => visibleIndices.has(r.index)) : allRows
+    if (rows.length === 0) {
+        return <p className="p-3 text-sm text-gray-400">No records match the current filter.</p>
+    }
     const fkMeta = (f: string) => fk?.foreignKeys[f]
 
     return (
@@ -109,16 +70,30 @@ export function MatrixView({ data, fk, idPrefix = 'raw' }: MatrixViewProps) {
                                                         : null
                                                 }
                                                 onChange={v => fk.onEditCell(index, f, v)}
+                                                onFillUnmatched={
+                                                    fk.onFillUnmatched
+                                                        ? v => fk.onFillUnmatched!(f, v)
+                                                        : undefined
+                                                }
                                             />
                                         </td>
                                     )
                                 }
+                                const isPlaceholder = row._status != null
+                                const canEdit = !!fk?.onEditField && !isPlaceholder
                                 return (
                                     <td
                                         key={index}
                                         className="border-b border-r border-gray-200 px-3 py-2"
                                     >
-                                        <CollapsibleCell value={row[f]} />
+                                        {canEdit ? (
+                                            <EditableCell
+                                                value={row[f]}
+                                                onCommit={v => fk!.onEditField!(index, f, v)}
+                                            />
+                                        ) : (
+                                            <CollapsibleCell value={row[f]} />
+                                        )}
                                     </td>
                                 )
                             })}

--- a/frontend/src/pages/migration/views/TableView.tsx
+++ b/frontend/src/pages/migration/views/TableView.tsx
@@ -1,12 +1,6 @@
-import { useState } from 'react'
 import { FkCell } from '../components/FkCell'
-import {
-    collectColumns,
-    formatCell,
-    isEmpty,
-    toIndexedRows,
-    type FkEditing,
-} from './tableUtils'
+import { CollapsibleCell, EditableCell } from '../components/CellRenderers'
+import { collectColumns, toIndexedRows, type FkEditing } from './tableUtils'
 import type { RowAction } from '../../../services/migrationApi'
 
 const ACTION_STYLES: Record<RowAction, { bg: string; text: string; label: string }> = {
@@ -21,54 +15,22 @@ interface TableViewProps {
     fk?: FkEditing
     idPrefix?: string
     rowActions?: RowAction[]
-}
-
-function CollapsibleCell({ value }: { value: unknown }) {
-    const [expanded, setExpanded] = useState(false)
-    const formatted = formatCell(value)
-    const isLongText = typeof value === 'string' && value.length > 40
-
-    if (!isLongText) {
-        return (
-            <span className={isEmpty(value) ? 'text-gray-300' : 'text-gray-800'}>
-                {formatted}
-            </span>
-        )
-    }
-
-    const text = String(value)
-
-    return (
-        <div className="flex flex-col gap-1 max-w-[320px]">
-            <div
-                className={`text-gray-800 transition-all text-xs font-mono break-words ${
-                    expanded ? 'whitespace-normal' : 'truncate'
-                }`}
-                title={text}
-            >
-                {expanded ? text : text.slice(0, 40) + '...'}
-            </div>
-            <button
-                type="button"
-                onClick={(e) => {
-                    e.stopPropagation()
-                    setExpanded(!expanded)
-                }}
-                className="text-[10px] font-semibold text-blue-600 hover:text-blue-800 self-start mt-0.5 select-none"
-            >
-                {expanded ? 'Collapse' : 'Expand'}
-            </button>
-        </div>
-    )
+    /** When set, only rows whose original index is in the set are rendered. */
+    visibleIndices?: Set<number>
 }
 
 /** Spreadsheet view: one record per row, one field per column. */
-export function TableView({ data, fk, idPrefix = 'raw', rowActions }: TableViewProps) {
-    const rows = toIndexedRows(data)
-    if (rows.length === 0) {
+export function TableView({ data, fk, idPrefix = 'raw', rowActions, visibleIndices }: TableViewProps) {
+    const allRows = toIndexedRows(data)
+    if (allRows.length === 0) {
         return <p className="p-3 text-sm text-gray-400">No tabular rows.</p>
     }
-    const cols = collectColumns(rows.map(r => r.row))
+    // Columns from the full set so they stay stable when filtering rows.
+    const cols = collectColumns(allRows.map(r => r.row))
+    const rows = visibleIndices ? allRows.filter(r => visibleIndices.has(r.index)) : allRows
+    if (rows.length === 0) {
+        return <p className="p-3 text-sm text-gray-400">No rows match the current filter.</p>
+    }
     const fkMeta = (c: string) => fk?.foreignKeys[c]
 
     return (
@@ -131,16 +93,29 @@ export function TableView({ data, fk, idPrefix = 'raw', rowActions }: TableViewP
                                                         : null
                                                 }
                                                 onChange={v => fk.onEditCell(index, c, v)}
+                                                onFillUnmatched={
+                                                    fk.onFillUnmatched
+                                                        ? v => fk.onFillUnmatched!(c, v)
+                                                        : undefined
+                                                }
                                             />
                                         </td>
                                     )
                                 }
+                                const canEdit = !!fk?.onEditField && !isPlaceholder
                                 return (
                                     <td
                                         key={c}
                                         className="border-b border-r border-gray-200 px-3 py-2"
                                     >
-                                        <CollapsibleCell value={row[c]} />
+                                        {canEdit ? (
+                                            <EditableCell
+                                                value={row[c]}
+                                                onCommit={v => fk!.onEditField!(index, c, v)}
+                                            />
+                                        ) : (
+                                            <CollapsibleCell value={row[c]} />
+                                        )}
                                     </td>
                                 )
                             })}

--- a/frontend/src/pages/migration/views/tableUtils.ts
+++ b/frontend/src/pages/migration/views/tableUtils.ts
@@ -150,7 +150,12 @@ export function collectColumns(rows: Row[]): string[] {
 export interface FkEditing {
     foreignKeys: Record<string, { master: string; otherField?: string }>
     fkOptions: Record<string, { value: number; label: string }[]>
+    /** Pick an FK master id for one cell. */
     onEditCell: (rowIndex: number, field: string, value: number | null) => void
+    /** Edit any non-FK scalar cell (writes into the shared records state). */
+    onEditField?: (rowIndex: number, field: string, value: unknown) => void
+    /** Copy an FK value into every still-unmatched row in the same column. */
+    onFillUnmatched?: (field: string, value: number) => void
 }
 
 /** Render one cell value compactly: nested objects collapse to JSON, null shows ·. */


### PR DESCRIPTION
## What
Migration tool: stop collapsing distinct rows on seed, and make the mapped grid fully fixable inline.

### Seeding — insert-only
The old site has genuine duplicate-looking rows that differ only in fields outside the natural key. Find-or-update was merging them into one. Now **every mapped row is inserted**, never updated/deduped — engine generic path + all per-module `seedRecord`s (training, equipment, oft, fld, cfld technical/budget; extension activities already done).

### Migration UI
- **Push re-enables live** — report recomputed against current `records`; a manual FK pick/edit clears its error in real time, no re-Transform needed.
- **"Errors only (N)" toggle** in the mapped pane header (before Jump) filters to rows that still error.
- **Editable cells** — ✎ on every non-FK cell (Table + Matrix); edits persist in `records` across view switches and are what gets pushed to the DB.
- **"apply to all unmatched"** — copy an FK pick into every empty cell in that column.
- Removed the panel-size slider; drag dividers remain.

## Test
- backend: `node --check` on all touched modules; registry loads all 15 modules, prisma models resolve.
- frontend: `bun run type-check` + `bun run lint` clean.