### PR TITLE
fix(forms): sidebar Digital Information grouping + CRA farmer totals layout

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -515,6 +515,9 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, onToggle }) => {
         { pattern: /^\/all-master\/(training-type|training-area|training-thematic|training-clientele|funding-source|extension-activity|other-extension-activity|events|training-extension)/, parentPath: '/all-master/training' },
         { pattern: /^\/all-master\/(product-category|product-type|product|cra-croping-system|cra-farming-system|arya-enterprise|natural-farming-activity|natural-farming-soil-parameter|agri-drone-demonstrations-on)/, parentPath: '/all-master/production-projects' },
         { pattern: /^\/forms\/(about-kvk|achievements|success-stories)/, parentPath: '/forms' },
+        // Digital Information forms live under the Miscellaneous group in the sidebar,
+        // but their URLs sit on a separate /forms/digital-information tree.
+        { pattern: /^\/forms\/digital-information/, parentPath: '/forms/miscellaneous' },
         // Staff Quarters lives under the performance URL tree but belongs to the About KVK group in the sidebar.
         { pattern: /^\/forms\/performance\/infrastructure\/staff-quarters/, parentPath: '/forms/about-kvk' },
         { pattern: /^\/all-master\/(publications|publication-item)/, parentPath: '/all-master/publications' },

--- a/frontend/src/pages/dashboard/shared/forms/projects/CraForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/projects/CraForms.tsx
@@ -181,22 +181,24 @@ export const CraForms: React.FC<CraFormsProps> = ({
                     </div>
 
                     <FormSection title="Farmers Details">
-                        <div className="col-span-2 grid grid-cols-2 md:grid-cols-4 gap-4">
-                            <FormInput label="General_M" required type="number" value={formData.genM ?? ''} onChange={e => setFormData({ ...formData, genM: e.target.value })} />
-                            <FormInput label="General_F" required type="number" value={formData.genF ?? ''} onChange={e => setFormData({ ...formData, genF: e.target.value })} />
-                            <FormInput label="OBC_M" required type="number" value={formData.obcM ?? ''} onChange={e => setFormData({ ...formData, obcM: e.target.value })} />
-                            <FormInput label="OBC_F" required type="number" value={formData.obcF ?? ''} onChange={e => setFormData({ ...formData, obcF: e.target.value })} />
+                        <div className="col-span-2 space-y-6">
+                            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                                <FormInput label="General_M" required type="number" value={formData.genM ?? ''} onChange={e => setFormData({ ...formData, genM: e.target.value })} />
+                                <FormInput label="General_F" required type="number" value={formData.genF ?? ''} onChange={e => setFormData({ ...formData, genF: e.target.value })} />
+                                <FormInput label="OBC_M" required type="number" value={formData.obcM ?? ''} onChange={e => setFormData({ ...formData, obcM: e.target.value })} />
+                                <FormInput label="OBC_F" required type="number" value={formData.obcF ?? ''} onChange={e => setFormData({ ...formData, obcF: e.target.value })} />
 
-                            <FormInput label="SC_M" required type="number" value={formData.scM ?? ''} onChange={e => setFormData({ ...formData, scM: e.target.value })} />
-                            <FormInput label="SC_F" required type="number" value={formData.scF ?? ''} onChange={e => setFormData({ ...formData, scF: e.target.value })} />
-                            <FormInput label="ST_M" required type="number" value={formData.stM ?? ''} onChange={e => setFormData({ ...formData, stM: e.target.value })} />
-                            <FormInput label="ST_F" required type="number" value={formData.stF ?? ''} onChange={e => setFormData({ ...formData, stF: e.target.value })} />
+                                <FormInput label="SC_M" required type="number" value={formData.scM ?? ''} onChange={e => setFormData({ ...formData, scM: e.target.value })} />
+                                <FormInput label="SC_F" required type="number" value={formData.scF ?? ''} onChange={e => setFormData({ ...formData, scF: e.target.value })} />
+                                <FormInput label="ST_M" required type="number" value={formData.stM ?? ''} onChange={e => setFormData({ ...formData, stM: e.target.value })} />
+                                <FormInput label="ST_F" required type="number" value={formData.stF ?? ''} onChange={e => setFormData({ ...formData, stF: e.target.value })} />
+                            </div>
+                            <CasteGenderTotals
+                                values={formData}
+                                maleFields={['genM', 'obcM', 'scM', 'stM']}
+                                femaleFields={['genF', 'obcF', 'scF', 'stF']}
+                            />
                         </div>
-                        <CasteGenderTotals
-                            values={formData}
-                            maleFields={['genM', 'obcM', 'scM', 'stM']}
-                            femaleFields={['genF', 'obcF', 'scF', 'stF']}
-                        />
                     </FormSection>
 
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -279,22 +281,24 @@ export const CraForms: React.FC<CraFormsProps> = ({
                     </div>
 
                     <FormSection title="Farmers Details">
-                        <div className="col-span-2 grid grid-cols-2 md:grid-cols-4 gap-4">
-                            <FormInput label="General_M" required type="number" wholeNumberOnly value={formData.genM || ''} onChange={e => setFormData({ ...formData, genM: e.target.value })} />
-                            <FormInput label="General_F" required type="number" wholeNumberOnly value={formData.genF || ''} onChange={e => setFormData({ ...formData, genF: e.target.value })} />
-                            <FormInput label="OBC_M" required type="number" wholeNumberOnly value={formData.obcM || ''} onChange={e => setFormData({ ...formData, obcM: e.target.value })} />
-                            <FormInput label="OBC_F" required type="number" wholeNumberOnly value={formData.obcF || ''} onChange={e => setFormData({ ...formData, obcF: e.target.value })} />
+                        <div className="col-span-2 space-y-6">
+                            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                                <FormInput label="General_M" required type="number" wholeNumberOnly value={formData.genM || ''} onChange={e => setFormData({ ...formData, genM: e.target.value })} />
+                                <FormInput label="General_F" required type="number" wholeNumberOnly value={formData.genF || ''} onChange={e => setFormData({ ...formData, genF: e.target.value })} />
+                                <FormInput label="OBC_M" required type="number" wholeNumberOnly value={formData.obcM || ''} onChange={e => setFormData({ ...formData, obcM: e.target.value })} />
+                                <FormInput label="OBC_F" required type="number" wholeNumberOnly value={formData.obcF || ''} onChange={e => setFormData({ ...formData, obcF: e.target.value })} />
 
-                            <FormInput label="SC_M" required type="number" wholeNumberOnly value={formData.scM || ''} onChange={e => setFormData({ ...formData, scM: e.target.value })} />
-                            <FormInput label="SC_F" required type="number" wholeNumberOnly value={formData.scF || ''} onChange={e => setFormData({ ...formData, scF: e.target.value })} />
-                            <FormInput label="ST_M" required type="number" wholeNumberOnly value={formData.stM || ''} onChange={e => setFormData({ ...formData, stM: e.target.value })} />
-                            <FormInput label="ST_F" required type="number" wholeNumberOnly value={formData.stF || ''} onChange={e => setFormData({ ...formData, stF: e.target.value })} />
+                                <FormInput label="SC_M" required type="number" wholeNumberOnly value={formData.scM || ''} onChange={e => setFormData({ ...formData, scM: e.target.value })} />
+                                <FormInput label="SC_F" required type="number" wholeNumberOnly value={formData.scF || ''} onChange={e => setFormData({ ...formData, scF: e.target.value })} />
+                                <FormInput label="ST_M" required type="number" wholeNumberOnly value={formData.stM || ''} onChange={e => setFormData({ ...formData, stM: e.target.value })} />
+                                <FormInput label="ST_F" required type="number" wholeNumberOnly value={formData.stF || ''} onChange={e => setFormData({ ...formData, stF: e.target.value })} />
+                            </div>
+                            <CasteGenderTotals
+                                values={formData}
+                                maleFields={['genM', 'obcM', 'scM', 'stM']}
+                                femaleFields={['genF', 'obcF', 'scF', 'stF']}
+                            />
                         </div>
-                        <CasteGenderTotals
-                            values={formData}
-                            maleFields={['genM', 'obcM', 'scM', 'stM']}
-                            femaleFields={['genF', 'obcF', 'scF', 'stF']}
-                        />
                     </FormSection>
 
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">


### PR DESCRIPTION
## What

- **Sidebar**: `/forms/digital-information/*` routes now map to the **Miscellaneous** sidebar group, so the correct parent stays highlighted while on those pages.
- **CraForms**: wrapped the *Farmers Details* caste/gender grid and `CasteGenderTotals` in a shared `space-y-6` container (both OFT and FLD sections) so the totals render directly under the inputs.

## Notes

- Pure UI/layout change. No data-shape or behaviour change.
- Second CRA block keeps its existing `|| ''` value props; the separate 0-value fix branch converts those to `?? ''`.

## Test
- `bun run type-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)