### PR TITLE
feat(migration): Production & Supply of Technological Products module

### DIFF
--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -90,6 +90,10 @@ const MASTER_CATALOG = {
     otherExtensionActivity: { model: 'otherExtensionActivity', idField: 'otherExtensionActivityId', nameField: 'otherExtensionName' },
     // ImportantDay master — what kvk_important_day_celebration.importantDayId references.
     importantDay: { model: 'importantDay', idField: 'importantDayId', nameField: 'dayName' },
+    // Product hierarchy — what kvk_production_supply.{category,type,product} reference.
+    productCategory: { model: 'productCategory', idField: 'productCategoryId', nameField: 'productCategoryName' },
+    productType: { model: 'productType', idField: 'productTypeId', nameField: 'productCategoryType' },
+    product: { model: 'product', idField: 'productId', nameField: 'productName' },
 };
 
 function getMaster(key) {

--- a/backend/migration/modules/productionSupply.js
+++ b/backend/migration/modules/productionSupply.js
@@ -12,9 +12,15 @@ const { parseDate, decodeEntities, cleanText } = require('../util.js');
  * Product hierarchy: category.name → ProductCategory, type.name → ProductType,
  * product.name → Product. Each is resolved by name and parked in its *_other
  * column when unmatched (all three FKs are nullable). `variety` is the new
- * `speciesName`. `unit` is not on the old row — it's derived from the resolved
- * Product's unit master (the new form keeps it read-only). The old `*_t` totals
- * are derived on the old site and recomputed in our UI — dropped here.
+ * `speciesName`. The old `*_t` totals are derived on the old site and recomputed
+ * in our UI — dropped here.
+ *
+ * Unit: kvk_production_supply no longer stores a unit — it derives from the
+ * linked Product's master unit. Old rows never carry one, and many Products lack
+ * a unit link. The grid exposes an editable `unitId` picker (prefilled from the
+ * Product's current link); on seed it's back-filled onto the Product master
+ * (only when the Product has no unit yet — existing links are never overwritten)
+ * so the app's production-supply form shows that unit read-only off the Product.
  */
 
 function intOrZero(v) {
@@ -37,19 +43,19 @@ function asObject(value) {
     return null;
 }
 
-/** Derive the read-only unit string from the resolved Product's unit master. */
-async function unitForProduct(productId) {
-    if (!productId) return '';
+/** The resolved Product's currently-linked unit, if any. */
+async function unitInfoForProduct(productId) {
+    if (!productId) return { unitId: null, unitName: '' };
     const product = await prisma.product.findUnique({
         where: { productId },
         select: { unitId: true },
     });
-    if (!product?.unitId) return '';
+    if (!product?.unitId) return { unitId: null, unitName: '' };
     const unit = await prisma.unit.findUnique({
         where: { unitId: product.unitId },
         select: { unitName: true },
     });
-    return unit?.unitName || '';
+    return { unitId: product.unitId, unitName: unit?.unitName || '' };
 }
 
 module.exports = {
@@ -64,6 +70,9 @@ module.exports = {
         productCategoryId: { master: 'productCategory', otherField: 'productCategoryOther' },
         productTypeId: { master: 'productType', otherField: 'productTypeOther' },
         productId: { master: 'product', otherField: 'productOther' },
+        // Editable unit picker. Not a kvk_production_supply column — seedRecord
+        // turns it into the `unit` string AND back-fills the Product's unitId.
+        unitId: { master: 'unit' },
     },
 
     async transform(row, ctx) {
@@ -119,10 +128,12 @@ module.exports = {
         const speciesName = decodeEntities(cleanText(row.variety || ''));
         if (!speciesName) warn('speciesName', 'No variety on old row');
 
-        // 5. Unit (REQUIRED string) — derived from the resolved Product's unit master.
-        let unit = '';
-        if (productId) unit = await unitForProduct(productId);
-        if (!unit) warn('unit', 'Unit not derivable — set manually after migrate');
+        // 5. Unit — not stored on the record; derives from the Product master.
+        // Prefill the editable unitId picker from the Product's current link (if
+        // any); the operator sets it in the grid for products that still lack a
+        // unit, and seedRecord back-fills the Product master.
+        const { unitId } = await unitInfoForProduct(productId);
+        if (!unitId) warn('unitId', 'Product has no unit in master — pick one to back-fill it');
 
         // 6. Quantity / value (both REQUIRED numbers). Non-numeric quantity is
         // parked in quantityText (matches the string/boolean datatype path).
@@ -146,7 +157,9 @@ module.exports = {
             productId,
             productOther,
             speciesName,
-            unit,
+            // Virtual — editable in the grid, consumed/stripped by seedRecord.
+            // Not a kvk_production_supply column; only back-fills Product.unitId.
+            unitId,
             quantity,
             quantityText,
             value,
@@ -165,9 +178,29 @@ module.exports = {
     },
 
     async seedRecord(prisma, data) {
+        // `unitId` is a virtual grid field, not a kvk_production_supply column.
+        // Unit isn't stored on the record — it's only back-filled onto the Product.
+        const { unitId, ...record } = data;
+
         // Always insert — the old site holds genuine duplicate rows that are
         // distinct records. No dedupe.
-        await prisma.kvkProductionSupply.create({ data });
+        await prisma.kvkProductionSupply.create({ data: record });
+
+        // Back-fill the Product master's unit when it's missing one. Never
+        // overwrite an existing link — curated units win.
+        if (record.productId && unitId) {
+            const product = await prisma.product.findUnique({
+                where: { productId: record.productId },
+                select: { unitId: true },
+            });
+            if (product && product.unitId == null) {
+                await prisma.product.update({
+                    where: { productId: record.productId },
+                    data: { unitId: Number(unitId) },
+                });
+            }
+        }
+
         return 'created';
     },
 };

--- a/backend/migration/modules/productionSupply.js
+++ b/backend/migration/modules/productionSupply.js
@@ -1,0 +1,173 @@
+const prisma = require('../../config/prisma.js');
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: KVK Production & Supply of Technological Products (Achievements).
+ * Source: atariams.org `production-and-supply`. Writes kvk_production_supply.
+ *
+ * Every field lives on the DataTables list row (nested kvk/category/type/product
+ * objects) — no per-row edit-page fetch.
+ *
+ * Product hierarchy: category.name → ProductCategory, type.name → ProductType,
+ * product.name → Product. Each is resolved by name and parked in its *_other
+ * column when unmatched (all three FKs are nullable). `variety` is the new
+ * `speciesName`. `unit` is not on the old row — it's derived from the resolved
+ * Product's unit master (the new form keeps it read-only). The old `*_t` totals
+ * are derived on the old site and recomputed in our UI — dropped here.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrNull(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return null;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : null;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+/** Derive the read-only unit string from the resolved Product's unit master. */
+async function unitForProduct(productId) {
+    if (!productId) return '';
+    const product = await prisma.product.findUnique({
+        where: { productId },
+        select: { unitId: true },
+    });
+    if (!product?.unitId) return '';
+    const unit = await prisma.unit.findUnique({
+        where: { unitId: product.unitId },
+        select: { unitName: true },
+    });
+    return unit?.unitName || '';
+}
+
+module.exports = {
+    key: 'production-supply',
+    label: 'Production & Supply of Technological Products',
+    model: 'kvkProductionSupply',
+    idField: 'productionSupplyId',
+    naturalKey: ['kvkId', 'reportingYear', 'productId', 'speciesName', 'quantity', 'value'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        productCategoryId: { master: 'productCategory', otherField: 'productCategoryOther' },
+        productTypeId: { master: 'productType', otherField: 'productTypeOther' },
+        productId: { master: 'product', otherField: 'productOther' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+
+        // 1. KVK match — same guard as the other achievement modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int (e.g. 2024) → Jan 1 of that year (UTC),
+        // which falls inside the calendar-year report filter. Nullable.
+        const reportingYear = row.reporting_year != null
+            ? (() => { const iso = parseDate(String(row.reporting_year)); return iso ? new Date(iso) : null; })()
+            : null;
+
+        // 3. Product hierarchy — resolve each by name, park unmatched in *_other.
+        let productCategoryId = null, productCategoryOther = null;
+        const catName = decodeEntities(cleanText(asObject(row.category)?.name || row['category.name'] || ''));
+        if (catName) {
+            const c = await r.resolve('productCategory', 'productCategoryName', 'productCategoryId', catName);
+            if (c.matched) productCategoryId = c.id;
+            else { productCategoryOther = catName; warn('productCategoryId', `Category "${catName}" not in master — parked in Other`); }
+        }
+
+        let productTypeId = null, productTypeOther = null;
+        const typeName = decodeEntities(cleanText(asObject(row.type)?.name || row['type.name'] || ''));
+        if (typeName) {
+            const t = await r.resolve('productType', 'productCategoryType', 'productTypeId', typeName);
+            if (t.matched) productTypeId = t.id;
+            else { productTypeOther = typeName; warn('productTypeId', `Type "${typeName}" not in master — parked in Other`); }
+        }
+
+        let productId = null, productOther = null;
+        const prodName = decodeEntities(cleanText(asObject(row.product)?.name || row['product.name'] || ''));
+        if (prodName) {
+            const p = await r.resolve('product', 'productName', 'productId', prodName);
+            if (p.matched) productId = p.id;
+            else { productOther = prodName; warn('productId', `Product "${prodName}" not in master — parked in Other`); }
+        }
+
+        // 4. Species / breed / variety (REQUIRED string) ← old `variety`.
+        const speciesName = decodeEntities(cleanText(row.variety || ''));
+        if (!speciesName) warn('speciesName', 'No variety on old row');
+
+        // 5. Unit (REQUIRED string) — derived from the resolved Product's unit master.
+        let unit = '';
+        if (productId) unit = await unitForProduct(productId);
+        if (!unit) warn('unit', 'Unit not derivable — set manually after migrate');
+
+        // 6. Quantity / value (both REQUIRED numbers). Non-numeric quantity is
+        // parked in quantityText (matches the string/boolean datatype path).
+        let quantity = floatOrNull(row.quantity);
+        let quantityText = null;
+        if (quantity === null && row.quantity != null && String(row.quantity).trim() !== '') {
+            quantityText = String(row.quantity).trim();
+            quantity = 0;
+            warn('quantity', `Non-numeric quantity "${quantityText}" — parked in quantityText`);
+        }
+        if (quantity === null) quantity = 0;
+        const value = floatOrNull(row.value) ?? 0;
+
+        const data = {
+            kvkId,
+            reportingYear,
+            productCategoryId,
+            productCategoryOther,
+            productTypeId,
+            productTypeOther,
+            productId,
+            productOther,
+            speciesName,
+            unit,
+            quantity,
+            quantityText,
+            value,
+            // Farmer demographics — *_t totals dropped (UI recomputes).
+            farmersGeneralM: intOrZero(row.general_m),
+            farmersGeneralF: intOrZero(row.general_f),
+            farmersObcM: intOrZero(row.obc_m),
+            farmersObcF: intOrZero(row.obc_f),
+            farmersScM: intOrZero(row.sc_m),
+            farmersScF: intOrZero(row.sc_f),
+            farmersStM: intOrZero(row.st_m),
+            farmersStF: intOrZero(row.st_f),
+        };
+
+        return { data, issues };
+    },
+
+    async seedRecord(prisma, data) {
+        // Always insert — the old site holds genuine duplicate rows that are
+        // distinct records. No dedupe.
+        await prisma.kvkProductionSupply.create({ data });
+        return 'created';
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -20,6 +20,7 @@ const specs = [
     require('./modules/otherExtensionActivity.js'),
     require('./modules/technologyWeek.js'),
     require('./modules/celebrationDay.js'),
+    require('./modules/productionSupply.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));

--- a/backend/prisma/kvk/achievements/production_supply_schema.prisma
+++ b/backend/prisma/kvk/achievements/production_supply_schema.prisma
@@ -9,7 +9,8 @@ productCategoryId  Int?             @map("product_category_id")
   productId          Int?             @map("product_id")
   productOther       String?          @map("product_other")
   speciesName        String           @map("species_name")
-  unit               String
+  // Unit is no longer stored here — it derives from the linked Product's master
+  // unit (Product.unit). Edit the product's unit to change it everywhere.
   quantity           Float
   // Used when the product's quantity data type is string/boolean (e.g. "N/A");
   // numeric types continue to use `quantity`.

--- a/backend/prisma/migrations/20260616120000_drop_production_supply_unit/migration.sql
+++ b/backend/prisma/migrations/20260616120000_drop_production_supply_unit/migration.sql
@@ -1,0 +1,4 @@
+-- Production & Supply of Technological Products: drop the stored `unit` column.
+-- Unit now derives from the linked Product's master unit (Product.unit_id -> unit).
+-- Editing a product's unit updates it across all production-supply records.
+ALTER TABLE "kvk_production_supply" DROP COLUMN "unit";

--- a/backend/repositories/forms/productionSupplyRepository.js
+++ b/backend/repositories/forms/productionSupplyRepository.js
@@ -118,7 +118,8 @@ const _mapResponse = (r) => {
         product: r.productOther || r.product?.productName,
         productOther: r.productOther ?? '',
         speciesBreedVariety: r.speciesName,
-        unit: r.unit,
+        // Unit derives from the linked product's master unit (no stored column).
+        unit: r.product?.unit?.unitName || '',
         quantity: r.quantity,
         quantityText: r.quantityText,
         valueRs: r.value,
@@ -181,11 +182,9 @@ const productionSupplyRepository = {
                 await _validateForeignKey(productId, 'product', 'productId', 'Product', false);
             }
 
-            // Validate required fields. Unit now comes from the product's master
-            // (read-only in the form), so accept any non-empty value instead of a
-            // hardcoded list.
+            // Validate required fields. Unit is no longer stored — it derives from
+            // the linked product's master unit at read time.
             const speciesName = _normalizeString(data.speciesName, 'Species / Breed / Variety', false);
-            const unit = _normalizeString(data.unit, 'Unit', false);
             const quantity = _parseFloat(data.quantity, 'Quantity', false);
             const value = _parseFloat(data.value, 'Value', false);
             // Free-text quantity for products whose master quantity data type is
@@ -204,7 +203,6 @@ const productionSupplyRepository = {
                 productId: productId ? parseInteger(productId, 'productId', false) : null,
                 productOther: _normalizeString(data.productOther, 'productOther', true),
                 speciesName,
-                unit,
                 quantity,
                 quantityText,
                 value,
@@ -218,7 +216,7 @@ const productionSupplyRepository = {
                     kvk: { select: { kvkName: true } },
                     productCategory: { select: { productCategoryName: true } },
                     productType: { select: { productCategoryType: true } },
-                    product: { select: { productName: true } },
+                    product: { select: { productName: true, unit: { select: { unitName: true } } } },
                 }
             });
 
@@ -286,7 +284,7 @@ const productionSupplyRepository = {
                     kvk: { select: { kvkName: true } },
                     productCategory: { select: { productCategoryName: true } },
                     productType: { select: { productCategoryType: true } },
-                    product: { select: { productName: true } },
+                    product: { select: { productName: true, unit: { select: { unitName: true } } } },
                 },
                 orderBy: { createdAt: 'desc' },
             });
@@ -320,7 +318,7 @@ const productionSupplyRepository = {
                     kvk: { select: { kvkName: true } },
                     productCategory: { select: { productCategoryName: true } },
                     productType: { select: { productCategoryType: true } },
-                    product: { select: { productName: true } },
+                    product: { select: { productName: true, unit: { select: { unitName: true } } } },
                 },
             });
 
@@ -423,10 +421,7 @@ const productionSupplyRepository = {
                 updateData.speciesName = _normalizeString(data.speciesName, 'Species / Breed / Variety', false);
             }
 
-            if (data.unit !== undefined) {
-                // Unit comes from the product master (read-only) — accept any value.
-                updateData.unit = _normalizeString(data.unit, 'Unit', false);
-            }
+            // Unit is derived from the product master — never stored/updated here.
 
             if (data.quantity !== undefined) {
                 updateData.quantity = _parseFloat(data.quantity, 'Quantity', false);
@@ -452,7 +447,7 @@ const productionSupplyRepository = {
                     kvk: { select: { kvkName: true } },
                     productCategory: { select: { productCategoryName: true } },
                     productType: { select: { productCategoryType: true } },
-                    product: { select: { productName: true } },
+                    product: { select: { productName: true, unit: { select: { unitName: true } } } },
                 },
             });
 

--- a/backend/repositories/reports/productionSupplyPageReport/productionSupplyPageReportRepository.js
+++ b/backend/repositories/reports/productionSupplyPageReport/productionSupplyPageReportRepository.js
@@ -200,7 +200,8 @@ function mapPrismaRowToReportRow(r) {
         productType: r.productTypeOther || r.productType?.productCategoryType,
         product: r.productOther || r.product?.productName,
         speciesName: r.speciesName,
-        unit: r.unit,
+        // Unit derives from the linked product's master unit (no stored column).
+        unit: r.product?.unit?.unitName || '',
         quantity: r.quantity,
         value: r.value,
         valueRs: r.value,
@@ -235,7 +236,7 @@ async function fetchProductionSupplyRecordsForReport(kvkId, filters = {}) {
             kvk: { select: { kvkName: true } },
             productCategory: { select: { productCategoryName: true } },
             productType: { select: { productCategoryType: true } },
-            product: { select: { productName: true } },
+            product: { select: { productName: true, unit: { select: { unitName: true } } } },
         },
         orderBy: { createdAt: 'desc' },
     });

--- a/frontend/src/pages/dashboard/shared/forms/ProductionProjectForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/ProductionProjectForms.tsx
@@ -140,17 +140,15 @@ export const ProductionProjectForms: React.FC<ProductionProjectFormsProps> = ({
 
     const handleProductChange = useCallback((value: string | number) => {
         // Species / Breed / Variety is free text now — don't overwrite it.
-        // Pull the product's master-defined unit; reset quantity inputs.
-        const selProduct: any = products.find((p: any) => Number(p.productId) === Number(value))
+        // Unit derives from the product master (read-only) — not tracked here.
         setFormData({
             ...formData,
             productId: value,
-            unit: selProduct?.unit?.unitName ?? '',
             quantity: '',
             quantityText: '',
             ...productResetPatch(value, 'productOther'),
         })
-    }, [formData, setFormData, productResetPatch, products])
+    }, [formData, setFormData, productResetPatch])
 
     const handleSpeciesNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         setFormData({ ...formData, speciesName: e.target.value })
@@ -495,13 +493,14 @@ export const ProductionProjectForms: React.FC<ProductionProjectFormsProps> = ({
                         {(() => {
                             const selectedProduct: any = products.find((p: any) => Number(p.productId) === Number(formData.productId))
                             const dataType = selectedProduct?.quantityDataType || 'decimal'
-                            const masterUnit = selectedProduct?.unit?.unitName || formData.unit || ''
+                            // Unit is read-only, sourced from the product master.
+                            const masterUnit = selectedProduct?.unit?.unitName || ''
                             const required = Boolean(selectedProduct?.quantityRequired)
                             const setText = (v: string) =>
-                                setFormData({ ...formData, quantityText: v, quantity: 0, unit: masterUnit })
+                                setFormData({ ...formData, quantityText: v, quantity: 0 })
                             const setNumber = (raw: string) => {
                                 const v = dataType === 'number' ? raw.replace(/[^0-9]/g, '') : raw
-                                setFormData({ ...formData, quantity: v, quantityText: null, unit: masterUnit })
+                                setFormData({ ...formData, quantity: v, quantityText: null })
                             }
                             return (
                                 <div className="grid grid-cols-2 gap-4">

--- a/frontend/src/types/productionSupply.ts
+++ b/frontend/src/types/productionSupply.ts
@@ -66,7 +66,8 @@ export interface ProductionSupplyFormData {
     productId?: number;
     prodType?: string | number;
     speciesName: string;
-    unit: string;
+    // Unit is derived from the product master (read-only) — not submitted.
+    unit?: string;
     quantity: number | string;
     value: number | string;
     // Participant fields (frontend format)


### PR DESCRIPTION
## What

Adds a migration module for **Production & Supply of Technological Products** (Achievements).

- `backend/migration/modules/productionSupply.js` — new module spec
- `backend/migration/registry.js` — registers it
- `backend/migration/masterCatalog.js` — whitelists the 3 product masters for the FK option pickers

## Mapping

Source: atariams.org `production-and-supply` → `kvk_production_supply`

| Old field | New column |
|---|---|
| `kvk.kvk_name` | `kvkId` (resolved vs selected target KVK) |
| `reporting_year` (int) | `reportingYear` (Jan 1 of that year, UTC) |
| `category.name` | `productCategoryId` (else `productCategoryOther`) |
| `type.name` | `productTypeId` (else `productTypeOther`) |
| `product.name` | `productId` (else `productOther`) |
| `variety` | `speciesName` |
| — (derived) | `unit` (from resolved Product's unit master) |
| `quantity` | `quantity` (non-numeric → `quantityText`) |
| `value` | `value` (value_rs) |
| `general/obc/sc/st_m/f` | `farmersGeneral/Obc/Sc/St M/F` |

## Notes

- All fields are on the DataTables list row — no per-row edit-page fetch.
- Product hierarchy (Category → Type → Product) resolved by name; unmatched names parked in the matching `*_other` column (all three FKs nullable).
- `unit` isn't on the old row — derived from the resolved Product's unit master, matching the form's read-only unit behaviour. Warns when not derivable.
- Reporting year stored as Jan 1 of the old fiscal int so it lands inside the calendar-year report filter.
- `*_t` totals dropped — UI recomputes.
- Insert-only seeding, no dedupe.