### PR TITLE
feat(maintenance): per-module "Delete All" for a KVK's own data

### DIFF
--- a/backend/controllers/forms/kvkModuleWipeController.js
+++ b/backend/controllers/forms/kvkModuleWipeController.js
@@ -1,0 +1,42 @@
+/**
+ * KVK Module Wipe Controller  ── TEMPORARY MIGRATION TOOL ──
+ *
+ * POST body: { entityType: string }
+ * Deletes all rows of that module for the authenticated user's own KVK.
+ */
+
+const kvkModuleWipeService = require('../../services/forms/kvkModuleWipeService.js');
+
+async function wipe(req, res) {
+    try {
+        if (!req.user || typeof req.user !== 'object') {
+            return res.status(401).json({ success: false, message: 'Unauthorized' });
+        }
+
+        const { entityType } = req.body || {};
+        if (!entityType || typeof entityType !== 'string') {
+            return res
+                .status(400)
+                .json({ success: false, message: 'entityType is required.' });
+        }
+
+        // kvkId comes ONLY from the authenticated session — never from the client.
+        const kvkId = Number(req.user.kvkId);
+
+        const result = await kvkModuleWipeService.wipeModule(entityType, kvkId);
+
+        return res.json({
+            success: true,
+            message: `Deleted ${result.total} ${result.module} record(s).`,
+            data: result,
+        });
+    } catch (err) {
+        const status = err.statusCode || 500;
+        if (status >= 500) console.error('[kvkModuleWipe] error:', err);
+        return res
+            .status(status)
+            .json({ success: false, message: err.message || 'Failed to delete data.' });
+    }
+}
+
+module.exports = { wipe };

--- a/backend/routes/forms/kvkModuleWipeRoutes.js
+++ b/backend/routes/forms/kvkModuleWipeRoutes.js
@@ -1,0 +1,30 @@
+/**
+ * KVK Module Wipe routes  ── TEMPORARY MIGRATION TOOL ──
+ *
+ * Mounted OUTSIDE the /forms tree so it does not inherit validateFormRobustness
+ * / reportingYearNormalizer (those mutate a form payload this body is not).
+ * Restricted to KVK roles: the wipe is always scoped to req.user.kvkId, which
+ * only KVK accounts have, so they can clear only their own module data.
+ */
+
+const express = require('express');
+const router = express.Router();
+const { authenticateToken, requireRole } = require('../../middleware/auth.js');
+const { ensureBody } = require('../../middleware/validateInput.js');
+const kvkModuleWipeController = require('../../controllers/forms/kvkModuleWipeController.js');
+
+router.use(authenticateToken);
+
+/**
+ * @route   POST /api/maintenance/kvk-module-wipe
+ * @desc    Delete all rows of a module for the caller's own KVK
+ * @access  KVK Role (kvk_admin / kvk_user)
+ */
+router.post(
+    '/kvk-module-wipe',
+    requireRole(['kvk_admin', 'kvk_user']),
+    ensureBody(),
+    kvkModuleWipeController.wipe
+);
+
+module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -131,6 +131,10 @@ router.use('/reports', reportRoutes);
 // Data-migration tool (old atariams.org -> this app). Admin-only, self-contained.
 router.use('/migration', require('../migration/routes.js'));
 
+// TEMPORARY migration cleanup: per-module "Delete All" for a KVK's own data.
+// Mounted outside /forms so it skips the form-payload middlewares.
+router.use('/maintenance', require('./forms/kvkModuleWipeRoutes.js'));
+
 
 
 

--- a/backend/services/forms/kvkModuleWipeRegistry.js
+++ b/backend/services/forms/kvkModuleWipeRegistry.js
@@ -1,0 +1,185 @@
+/**
+ * KVK Module Wipe Registry  ── TEMPORARY MIGRATION TOOL ──
+ *
+ * Maps a frontend `entityType` (the string DataManagementView already computes
+ * from the route) to the Prisma model(s) whose rows make up that module. The
+ * "Delete All" button on each KVK form page wipes every row of these models for
+ * the requesting user's OWN kvkId — used to clear bad data between migration
+ * re-imports. Masters are never listed here and the about-kvk `Kvk` identity
+ * row itself is intentionally excluded.
+ *
+ * Every model name is asserted against the live Prisma datamodel at load time:
+ * a typo / renamed model throws on boot instead of silently failing (or worse,
+ * touching the wrong table) at delete time. Each listed model must carry a
+ * `kvkId` scalar so the wipe can be scoped — this is also asserted.
+ *
+ * Child rows are removed via the schema's `onDelete: Cascade` relations, so a
+ * module usually needs only its primary table here. When a module's children do
+ * NOT cascade, list them child-first before the parent.
+ */
+
+const prisma = require('../../config/prisma.js');
+
+// entityType  →  { label, models: [PrismaModelName, ...] }   (child-first)
+const REGISTRY = {
+    // ── About KVK ──────────────────────────────────────────────────────
+    // NOTE: `kvks` (the Kvk identity row) is deliberately NOT wipeable.
+    'kvk-bank-accounts': { label: 'Bank Accounts', models: ['KvkBankAccount'] },
+    'kvk-employees': { label: 'Employee Details', models: ['KvkStaff'] },
+    'kvk-infrastructure': { label: 'Infrastructure', models: ['KvkInfrastructure'] },
+    'kvk-land-details': { label: 'Land Details', models: ['KvkLandDetail'] },
+    'kvk-vehicles': { label: 'Vehicles', models: ['KvkVehicle'] },
+    'kvk-vehicle-details': { label: 'Vehicle Details', models: ['KvkVehicleDetail'] },
+    'kvk-equipments': { label: 'Equipments', models: ['KvkEquipment'] },
+    'kvk-equipment-details': { label: 'Equipment Details', models: ['KvkEquipmentDetail'] },
+
+    // ── Achievements ───────────────────────────────────────────────────
+    'achievement-oft': { label: 'OFT', models: ['Kvkoft'] },
+    'achievement-fld': { label: 'FLD', models: ['KvkFldIntroduction'] },
+    'achievement-fld-extension-training': { label: 'FLD Extension Training', models: ['FldExtension'] },
+    'achievement-fld-technical-feedback': { label: 'FLD Technical Feedback', models: ['FldTechnicalFeedback'] },
+    'achievement-training': { label: 'Trainings', models: ['TrainingAchievement'] },
+    'achievement-extension': { label: 'Extension Activities', models: ['KvkExtensionActivity'] },
+    'achievement-other-extension': { label: 'Other Extension Activities', models: ['KvkOtherExtensionActivity'] },
+    'achievement-technology-week': { label: 'Technology Week', models: ['KvkTechnologyWeekCelebration'] },
+    'achievement-celebration-days': { label: 'Celebration Days', models: ['KvkImportantDayCelebration'] },
+    'achievement-production-supply': { label: 'Production & Supply', models: ['KvkProductionSupply'] },
+    'achievement-publication-details': { label: 'Publication Details', models: ['KvkPublicationDetails'] },
+    'achievement-soil-equipment': { label: 'Soil & Water Equipment', models: ['KkvSoilWaterEquipment'] },
+    'achievement-soil-analysis': { label: 'Soil & Water Analysis', models: ['KkvSoilWaterAnalysis'] },
+    'achievement-world-soil-day': { label: 'World Soil Day', models: ['KkvWorldSoilCelebration'] },
+    'achievement-hrd': { label: 'HRD', models: ['HrdProgram'] },
+    'achievement-award-kvk': { label: 'KVK Awards', models: ['KvkAward'] },
+    'achievement-award-scientist': { label: 'Scientist Awards', models: ['ScientistAward'] },
+    'achievement-award-farmer': { label: 'Farmer Awards', models: ['FarmerAward'] },
+
+    // ── Projects ───────────────────────────────────────────────────────
+    'project-cfld-technical-param': { label: 'CFLD Technical Parameters', models: ['CfldTechnicalParameter'] },
+    'project-cfld-extension-activity': { label: 'CFLD Extension Activities', models: ['ExtensionActivityOrganized'] },
+    'project-cfld-budget': { label: 'CFLD Budget Utilization', models: ['KvkBudgetUtilization'] },
+    'project-cra-details': { label: 'CRA Details', models: ['CraDetails'] },
+    'project-cra-extension-activity': { label: 'CRA Extension Activities', models: ['CraExtensionActivity'] },
+    'project-fpo-details': { label: 'FPO Details', models: ['FpoCbboDetails'] },
+    'project-fpo-management': { label: 'FPO Management', models: ['FpoManagement'] },
+    'project-drmr-details': { label: 'DRMR Details', models: ['DrmrDetails'] },
+    'project-drmr-activity': { label: 'DRMR Activities', models: ['DrmrActivity'] },
+    'project-nari-nutri-garden': { label: 'NARI Nutrition Garden', models: ['NariNutritionalGarden'] },
+    'project-nari-bio-fortified': { label: 'NARI Bio-Fortified Crops', models: ['NariBioFortifiedCrop'] },
+    'project-nari-value-addition': { label: 'NARI Value Addition', models: ['NariValueAddition'] },
+    'project-nari-training': { label: 'NARI Training', models: ['NariTrainingProgramme'] },
+    'project-nari-extension': { label: 'NARI Extension', models: ['NariExtensionActivity'] },
+    'project-arya-current': { label: 'ARYA Current Year', models: ['AryaCurrentYear'] },
+    'project-arya-evaluation': { label: 'ARYA Previous Year', models: ['AryaPrevYear'] },
+    'project-csisa': { label: 'CSISA', models: ['Csisa'] },
+    'project-tsp-scsp': { label: 'TSP/SCSP', models: ['TspScsp'] },
+    'project-nicra-basic': { label: 'NICRA Basic Info', models: ['NicraBasicInfo'] },
+    'project-nicra-details': { label: 'NICRA Details', models: ['NicraDetails'] },
+    'project-nicra-training': { label: 'NICRA Training', models: ['NicraTraining'] },
+    'project-nicra-extension': { label: 'NICRA Extension', models: ['NicraExtensionActivity'] },
+    'project-nicra-intervention': { label: 'NICRA Interventions', models: ['NicraIntervention'] },
+    'project-nicra-revenue': { label: 'NICRA Revenue Generated', models: ['NicraRevenueGenerated'] },
+    'project-nicra-custom-hiring': { label: 'NICRA Farm Implements', models: ['NicraFarmImplement'] },
+    'project-nicra-vcrmc': { label: 'NICRA VCRMC', models: ['NicraVcrmc'] },
+    'project-nicra-soil-health': { label: 'NICRA Soil Health', models: ['NicraSoilHealthCard'] },
+    'project-nicra-convergence': { label: 'NICRA Convergence', models: ['NicraConvergenceProgramme'] },
+    'project-nicra-dignitaries': { label: 'NICRA Dignitaries Visited', models: ['NicraDignitariesVisited'] },
+    'project-nicra-pi-copi': { label: 'NICRA PI/Co-PI', models: ['NicraPiCopi'] },
+    'project-natural-farming-geo': { label: 'Natural Farming Geographical', models: ['GeographicalInfo'] },
+    'project-natural-farming-physical': { label: 'Natural Farming Physical', models: ['PhysicalInfo'] },
+    'project-natural-farming-demo': { label: 'Natural Farming Demonstration', models: ['DemonstrationInfo'] },
+    'project-natural-farming-farmers': { label: 'Natural Farming Farmers', models: ['FarmersPracticingNaturalFarming'] },
+    'project-natural-farming-beneficiaries': { label: 'Natural Farming Beneficiaries', models: ['BeneficiariesDetails'] },
+    'project-natural-farming-soil': { label: 'Natural Farming Soil Data', models: ['SoilDataInformation'] },
+    'project-natural-farming-budget': { label: 'Natural Farming Financial', models: ['FinancialInformation'] },
+    'project-agri-drone': { label: 'Agri Drone', models: ['KvkAgriDrone'] },
+    'project-agri-drone-demo': { label: 'Agri Drone Demonstrations', models: ['KvkAgriDroneDemonstration'] },
+    'project-seed-hub': { label: 'Seed Hub', models: ['KvkSeedHubProgram'] },
+    'project-other': { label: 'Other KVK Programmes', models: ['KvkOtherProgramme'] },
+
+    // ── Miscellaneous ──────────────────────────────────────────────────
+    'misc-prevalent-diseases-crops': { label: 'Prevalent Diseases (Crops)', models: ['PrevalentDiseasesInCrop'] },
+    'misc-prevalent-diseases-livestock': { label: 'Prevalent Diseases (Livestock)', models: ['PrevalentDiseasesOnLivestock'] },
+    'misc-nyk-training': { label: 'NYK Training', models: ['NykTraining'] },
+    'misc-ppv-fra-training': { label: 'PPV & FRA Training', models: ['PpvFraTraining'] },
+    'misc-ppv-fra-plant-varieties': { label: 'PPV & FRA Plant Varieties', models: ['PpvFraPlantVarieties'] },
+    'misc-rawe-fet': { label: 'RAWE / FET', models: ['RaweFetFitProgramme'] },
+    'misc-vip-visitors': { label: 'VIP Visitors', models: ['VipVisitor'] },
+
+    // ── Performance Indicators ─────────────────────────────────────────
+    'performance-impact-kvk-activities': { label: 'Impact: KVK Activities', models: ['KvkImpactActivity'] },
+    'performance-impact-entrepreneurship': { label: 'Impact: Entrepreneurship', models: ['Entrepreneurship'] },
+    'performance-impact-success-stories': { label: 'Impact: Success Stories', models: ['SuccessStory'] },
+    'performance-district-level': { label: 'District Level Data', models: ['DistrictLevelData'] },
+    'performance-operational-area': { label: 'Operational Area', models: ['OperationalArea'] },
+    'performance-village-adoption': { label: 'Village Adoption', models: ['VillageAdoption'] },
+    'performance-priority-thrust': { label: 'Priority Thrust Areas', models: ['PriorityThrustArea'] },
+    'performance-demonstration-units': { label: 'Demonstration Units', models: ['DemonstrationUnit'] },
+    'performance-instructional-farm-crops': { label: 'Instructional Farm (Crops)', models: ['InstructionalFarmCrop'] },
+    'performance-production-units': { label: 'Production Units', models: ['ProductionUnit'] },
+    'performance-instructional-farm-livestock': { label: 'Instructional Farm (Livestock)', models: ['InstructionalFarmLivestock'] },
+    'performance-hostel': { label: 'Hostel Utilization', models: ['HostelUtilization'] },
+    'performance-staff-quarters': { label: 'Staff Quarters Utilization', models: ['StaffQuartersUtilization'] },
+    'performance-rainwater-harvesting': { label: 'Rainwater Harvesting', models: ['RainwaterHarvesting'] },
+    'performance-budget-details': { label: 'Budget Details', models: ['BudgetDetail'] },
+    'performance-project-budget': { label: 'Project Budget', models: ['ProjectBudget'] },
+    'performance-revolving-fund': { label: 'Revolving Fund', models: ['RevolvingFund'] },
+    'performance-revenue-generation': { label: 'Revenue Generation', models: ['RevenueGeneration'] },
+    'performance-resource-generation': { label: 'Resource Generation', models: ['ResourceGeneration'] },
+    'performance-functional-linkage': { label: 'Functional Linkages', models: ['FunctionalLinkage'] },
+
+    // ── Digital Information ────────────────────────────────────────────
+    'misc-digital-mobile-app': { label: 'Mobile App', models: ['MobileApp'] },
+    'misc-digital-web-portal': { label: 'Web Portal', models: ['WebPortal'] },
+    'misc-digital-kisan-sarathi': { label: 'Kisan Sarathi', models: ['KisanSarathi'] },
+    'misc-digital-kisan-mobile-advisory': { label: 'Kisan Mobile Advisory', models: ['Kmas'] },
+    'misc-digital-other-channels': { label: 'Other Channels', models: ['MsgDetails'] },
+
+    // ── Swachhta Bharat Abhiyaan ───────────────────────────────────────
+    'misc-swachhta-sewa': { label: 'Swachhta Hi Sewa', models: ['SwachhtaHiSewa'] },
+    'misc-swachhta-pakhwada': { label: 'Swachhta Pakhwada', models: ['SwachhtaPakhwada'] },
+    'misc-swachhta-budget': { label: 'Swachhta Quarterly Expenditure', models: ['SwachhQuarterlyExpenditure'] },
+
+    // ── Meetings ───────────────────────────────────────────────────────
+    'misc-meetings-sac': { label: 'SAC Meetings', models: ['SacMeeting'] },
+    'misc-meetings-other': { label: 'Other Meetings', models: ['AtariMeeting'] },
+};
+
+// Lowercase-first-letter Prisma client accessor, e.g. KvkBankAccount → kvkBankAccount
+function toAccessor(modelName) {
+    return modelName.charAt(0).toLowerCase() + modelName.slice(1);
+}
+
+// ── Boot-time integrity check ─────────────────────────────────────────
+// Fail loudly if any registry model is unknown or not kvk-scoped.
+(function assertRegistry() {
+    const dm = prisma._runtimeDataModel;
+    if (!dm || !dm.models) {
+        console.warn('[kvkModuleWipeRegistry] could not access Prisma datamodel; skipping integrity check');
+        return;
+    }
+    const problems = [];
+    for (const [entityType, def] of Object.entries(REGISTRY)) {
+        for (const modelName of def.models) {
+            const model = dm.models[modelName];
+            if (!model) {
+                problems.push(`${entityType}: unknown model "${modelName}"`);
+                continue;
+            }
+            const hasKvkId = (model.fields || []).some((f) => f.name === 'kvkId');
+            if (!hasKvkId) {
+                problems.push(`${entityType}: model "${modelName}" has no kvkId field`);
+            }
+        }
+    }
+    if (problems.length) {
+        throw new Error(
+            '[kvkModuleWipeRegistry] invalid entries:\n  ' + problems.join('\n  ')
+        );
+    }
+})();
+
+function getWipeSpec(entityType) {
+    return REGISTRY[entityType] || null;
+}
+
+module.exports = { REGISTRY, getWipeSpec, toAccessor };

--- a/backend/services/forms/kvkModuleWipeService.js
+++ b/backend/services/forms/kvkModuleWipeService.js
@@ -1,0 +1,45 @@
+/**
+ * KVK Module Wipe Service  ── TEMPORARY MIGRATION TOOL ──
+ *
+ * Deletes every row of a module's table(s) for ONE kvkId. The kvkId is always
+ * supplied by the controller from the authenticated user (req.user.kvkId) and
+ * never taken from the client, so a KVK user can only ever clear their own data.
+ */
+
+const prisma = require('../../config/prisma.js');
+const { getWipeSpec, toAccessor } = require('./kvkModuleWipeRegistry.js');
+
+/**
+ * @param {string} entityType  registry key (the frontend's entityType)
+ * @param {number} kvkId       authenticated user's KVK id
+ * @returns {Promise<{ module: string, kvkId: number, deleted: Record<string, number>, total: number }>}
+ */
+async function wipeModule(entityType, kvkId) {
+    const spec = getWipeSpec(entityType);
+    if (!spec) {
+        const err = new Error(`Delete-all is not available for "${entityType}".`);
+        err.statusCode = 400;
+        throw err;
+    }
+    if (!Number.isInteger(kvkId) || kvkId <= 0) {
+        const err = new Error('No KVK is linked to your account.');
+        err.statusCode = 403;
+        throw err;
+    }
+
+    const deleted = {};
+    // Models are listed child-first; delete in order inside one transaction so a
+    // partial failure rolls back rather than leaving the module half-wiped.
+    await prisma.$transaction(async (tx) => {
+        for (const modelName of spec.models) {
+            const accessor = toAccessor(modelName);
+            const res = await tx[accessor].deleteMany({ where: { kvkId } });
+            deleted[modelName] = res.count;
+        }
+    });
+
+    const total = Object.values(deleted).reduce((a, b) => a + b, 0);
+    return { module: spec.label, entityType, kvkId, deleted, total };
+}
+
+module.exports = { wipeModule };

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -11,6 +11,7 @@ import {
     ChevronDown,
     RotateCcw,
     FilterX,
+    Trash2,
 } from 'lucide-react'
 import { Breadcrumbs } from '@/components/common/Breadcrumbs'
 import { TabNavigation } from '@/components/common/TabNavigation'
@@ -53,6 +54,7 @@ import { useDeleteHandler } from '@/hooks/useDeleteHandler'
 import { useEditHandler } from '@/hooks/useEditHandler'
 import { useExportHandler } from '@/hooks/useExportHandler'
 import { useToast } from '@/hooks/useToast'
+import { wipeKvkModule, WIPEABLE_ENTITY_TYPES } from '@/services/maintenanceApi'
 import {
     useTransferOftToNextYear,
     useRevokeOftTransfer,
@@ -277,6 +279,56 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
         return routeConfig.canCreate.includes(user.role)
     }
     const showAddButton = canUserCreate()
+
+    // ── TEMPORARY migration cleanup: per-module "Delete All" ─────────────
+    // Only for KVK accounts (scoped to their own kvkId on the backend), only on
+    // modules the backend registry supports, and only with DELETE permission.
+    const canWipeModule =
+        !!entityType &&
+        WIPEABLE_ENTITY_TYPES.has(entityType) &&
+        !!user &&
+        (user.role === 'kvk_admin' || user.role === 'kvk_user') &&
+        !!user.kvkId &&
+        (!moduleCode || hasPermission('DELETE', moduleCode))
+
+    const handleWipeAll = () => {
+        if (!entityType) return
+        const label = title.replace(/ Master$/, '')
+        confirm(
+            {
+                title: `Delete ALL ${label} data?`,
+                message:
+                    `This permanently deletes EVERY ${label} record for your KVK ` +
+                    `(not just this page). This migration-cleanup action cannot be ` +
+                    `undone. Are you sure you want to continue?`,
+                variant: 'danger',
+                confirmText: 'Delete All',
+                cancelText: 'Cancel',
+            },
+            async () => {
+                try {
+                    const res = await wipeKvkModule(entityType)
+                    if (activeHook && 'refetch' in activeHook) {
+                        await (activeHook as any).refetch()
+                    }
+                    queryClient.invalidateQueries()
+                    setCurrentPage(1)
+                    alert({
+                        title: 'Deleted',
+                        message: res?.message || 'All records deleted.',
+                        variant: 'success',
+                        autoClose: true,
+                    })
+                } catch (err: any) {
+                    alert({
+                        title: 'Delete failed',
+                        message: err?.message || 'Failed to delete records.',
+                        variant: 'error',
+                    })
+                }
+            }
+        )
+    }
 
     // Determine if Edit button should be shown for a given item
     const canEditItem = (item: any) => {
@@ -1761,6 +1813,17 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                                         >
                                             <Plus className="w-4 h-4" />
                                             Add New
+                                        </button>
+                                    )}
+
+                                    {canWipeModule && (
+                                        <button
+                                            onClick={handleWipeAll}
+                                            title="Delete ALL records of this module for your KVK (migration cleanup)"
+                                            className="h-10 flex items-center gap-2 px-4 bg-white text-[#C62828] border border-[#E57373] rounded-xl text-sm font-medium hover:bg-[#FFEBEE] transition-all duration-200"
+                                        >
+                                            <Trash2 className="w-4 h-4" />
+                                            Delete All
                                         </button>
                                     )}
                                 </div>

--- a/frontend/src/services/maintenanceApi.ts
+++ b/frontend/src/services/maintenanceApi.ts
@@ -1,0 +1,145 @@
+/**
+ * Maintenance API — TEMPORARY migration cleanup helpers.
+ *
+ * `wipeKvkModule` deletes every row of a module for the logged-in user's own
+ * KVK (the backend scopes by the authenticated session's kvkId; the client
+ * cannot target another KVK). Used to clear bad data between migration imports.
+ */
+
+import { apiClient } from './api'
+
+export interface WipeKvkModuleResult {
+    success: boolean
+    message: string
+    data: {
+        module: string
+        entityType: string
+        kvkId: number
+        deleted: Record<string, number>
+        total: number
+    }
+}
+
+export const wipeKvkModule = (entityType: string) =>
+    apiClient.post<WipeKvkModuleResult>('/maintenance/kvk-module-wipe', {
+        entityType,
+    })
+
+/**
+ * entityTypes that support "Delete All". Mirrors the backend registry keys —
+ * keep in sync. The button only renders for entityTypes listed here.
+ */
+export const WIPEABLE_ENTITY_TYPES = new Set<string>([
+    // About KVK
+    'kvk-bank-accounts',
+    'kvk-employees',
+    'kvk-infrastructure',
+    'kvk-land-details',
+    'kvk-vehicles',
+    'kvk-vehicle-details',
+    'kvk-equipments',
+    'kvk-equipment-details',
+    // Achievements
+    'achievement-oft',
+    'achievement-fld',
+    'achievement-fld-extension-training',
+    'achievement-fld-technical-feedback',
+    'achievement-training',
+    'achievement-extension',
+    'achievement-other-extension',
+    'achievement-technology-week',
+    'achievement-celebration-days',
+    'achievement-production-supply',
+    'achievement-publication-details',
+    'achievement-soil-equipment',
+    'achievement-soil-analysis',
+    'achievement-world-soil-day',
+    'achievement-hrd',
+    'achievement-award-kvk',
+    'achievement-award-scientist',
+    'achievement-award-farmer',
+    // Projects
+    'project-cfld-technical-param',
+    'project-cfld-extension-activity',
+    'project-cfld-budget',
+    'project-cra-details',
+    'project-cra-extension-activity',
+    'project-fpo-details',
+    'project-fpo-management',
+    'project-drmr-details',
+    'project-drmr-activity',
+    'project-nari-nutri-garden',
+    'project-nari-bio-fortified',
+    'project-nari-value-addition',
+    'project-nari-training',
+    'project-nari-extension',
+    'project-arya-current',
+    'project-arya-evaluation',
+    'project-csisa',
+    'project-tsp-scsp',
+    'project-nicra-basic',
+    'project-nicra-details',
+    'project-nicra-training',
+    'project-nicra-extension',
+    'project-nicra-intervention',
+    'project-nicra-revenue',
+    'project-nicra-custom-hiring',
+    'project-nicra-vcrmc',
+    'project-nicra-soil-health',
+    'project-nicra-convergence',
+    'project-nicra-dignitaries',
+    'project-nicra-pi-copi',
+    'project-natural-farming-geo',
+    'project-natural-farming-physical',
+    'project-natural-farming-demo',
+    'project-natural-farming-farmers',
+    'project-natural-farming-beneficiaries',
+    'project-natural-farming-soil',
+    'project-natural-farming-budget',
+    'project-agri-drone',
+    'project-agri-drone-demo',
+    'project-seed-hub',
+    'project-other',
+    // Miscellaneous
+    'misc-prevalent-diseases-crops',
+    'misc-prevalent-diseases-livestock',
+    'misc-nyk-training',
+    'misc-ppv-fra-training',
+    'misc-ppv-fra-plant-varieties',
+    'misc-rawe-fet',
+    'misc-vip-visitors',
+    // Performance Indicators
+    'performance-impact-kvk-activities',
+    'performance-impact-entrepreneurship',
+    'performance-impact-success-stories',
+    'performance-district-level',
+    'performance-operational-area',
+    'performance-village-adoption',
+    'performance-priority-thrust',
+    'performance-demonstration-units',
+    'performance-instructional-farm-crops',
+    'performance-production-units',
+    'performance-instructional-farm-livestock',
+    'performance-hostel',
+    'performance-staff-quarters',
+    'performance-rainwater-harvesting',
+    'performance-budget-details',
+    'performance-project-budget',
+    'performance-revolving-fund',
+    'performance-revenue-generation',
+    'performance-resource-generation',
+    'performance-functional-linkage',
+    // Digital Information
+    'misc-digital-mobile-app',
+    'misc-digital-web-portal',
+    'misc-digital-kisan-sarathi',
+    'misc-digital-kisan-mobile-advisory',
+    'misc-digital-other-channels',
+    // Swachhta Bharat Abhiyaan
+    'misc-swachhta-sewa',
+    'misc-swachhta-pakhwada',
+    'misc-swachhta-budget',
+    // Meetings
+    'misc-meetings-sac',
+    'misc-meetings-other',
+])


### PR DESCRIPTION
## What

Temporary **migration-cleanup** tool. A red **Delete All** button on every KVK form page wipes all rows of that module for the logged-in user's **own KVK**. DB rows only — masters and the KVK identity row are never touched.

Built for clearing bad data between migration re-imports (bulk delete instead of slow per-row deletes).

## Backend — `POST /api/maintenance/kvk-module-wipe` `{ entityType }`
- `kvkModuleWipeRegistry.js` — maps `entityType` → Prisma model(s) for **104** KVK modules. Every model is **asserted against the live Prisma datamodel at boot** (unknown/renamed model or one lacking `kvkId` throws on load, not at delete time).
- `kvkModuleWipeService.js` — `deleteMany({ where: { kvkId } })` per model inside a transaction; children cleaned via schema `onDelete: Cascade`.
- `kvkModuleWipeController.js` — `kvkId` read **only** from `req.user`, never the client.
- `kvkModuleWipeRoutes.js` — `authenticateToken` + `requireRole(['kvk_admin','kvk_user'])`; mounted under `/maintenance` so it skips the form-payload middlewares.

## Frontend
- `maintenanceApi.ts` — `wipeKvkModule()` + `WIPEABLE_ENTITY_TYPES` (mirrors registry).
- `DataManagementView.tsx` — button gated by registry membership + KVK role + linked `kvkId` + DELETE permission; danger confirm dialog → wipe → refetch + invalidate.

## Safety
- Scoped server-side to the caller's own `kvkId` — a KVK user cannot target another KVK.
- `kvks` (KVK identity) and `kvk-staff-transferred` (transfer view) deliberately excluded.
- Modules not safely mappable (e.g. `project-tsp-activity`) get no button — fail-safe.
- Action is irreversible; the confirm dialog states it deletes EVERY record, not just the page.

## Notes
- Temporary tool for the migration window — intended for later removal.
- `frontend` type-check passes. No destructive DB test run.