### PR TITLE
feat(migration): Soil, Water & Plant Analysis module

### DIFF
--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -94,6 +94,8 @@ const MASTER_CATALOG = {
     productCategory: { model: 'productCategory', idField: 'productCategoryId', nameField: 'productCategoryName' },
     productType: { model: 'productType', idField: 'productTypeId', nameField: 'productCategoryType' },
     product: { model: 'product', idField: 'productId', nameField: 'productName' },
+    // SoilWaterAnalysis master — what kvk_soil_water_analysis.analysisId references.
+    soilWaterAnalysis: { model: 'soilWaterAnalysis', idField: 'soilWaterAnalysisId', nameField: 'analysisName' },
 };
 
 function getMaster(key) {

--- a/backend/migration/modules/soilWaterAnalysis.js
+++ b/backend/migration/modules/soilWaterAnalysis.js
@@ -1,0 +1,152 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: KVK Soil, Water & Plant Analysis (Achievements). Source:
+ * atariams.org `soil-water-testing/analysis-details`. Writes
+ * kvk_soil_water_analysis (model KkvSoilWaterAnalysis).
+ *
+ * Every field lives on the DataTables list row (nested kvk/analysis_data
+ * objects, flat demographics) — no per-row edit-page fetch. The old `_t` totals
+ * (general_t, total_*) are derived on the old site and recomputed in our UI —
+ * dropped here.
+ *
+ * analysis_data.name → SoilWaterAnalysis master (analysis_name @unique, global,
+ * no kvkId). It's a REQUIRED non-null FK with no `_other` escape column, so an
+ * unmatched name is findOrCreate'd into the master (mirrors the celebration-day
+ * ImportantDay path) rather than dropping the row.
+ *
+ * samples_analysed_through is a REQUIRED string; the new form restricts it to a
+ * fixed list ('Mini soil testing kit' / 'Soil testing laboratory' / 'Other').
+ * The old `testing_through` is a slug (e.g. "testing_laboratory") canonicalised
+ * onto that list, falling back to 'Other'.
+ *
+ * reporting_year is nullable; the old row carries it as a bare year int (e.g.
+ * 2026) → parseDate turns it into Jan 1 of that year (UTC), which lands inside
+ * the calendar-year report filter.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+/** Canonicalise the old `testing_through` slug onto the form's fixed list. */
+function canonicalMode(raw) {
+    const t = normalize(raw || '');
+    if (!t) return null;
+    if (t.includes('kit')) return 'Mini soil testing kit';
+    if (t.includes('lab')) return 'Soil testing laboratory';
+    return 'Other';
+}
+
+module.exports = {
+    key: 'soilWaterAnalysis',
+    label: 'Soil, Water & Plant Analysis',
+    model: 'kkvSoilWaterAnalysis',
+    idField: 'soilWaterAnalysisId',
+    naturalKey: ['kvkId', 'startDate', 'endDate', 'analysisId', 'samplesAnalysed'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        analysisId: { master: 'soilWaterAnalysis' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // ── KVK ───────────────────────────────────────────────────────────
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // ── Dates (both REQUIRED) — old format is DD-MM-YYYY ───────────────
+        const startIso = parseDate(row.start_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start_date "${row.start_date}"`);
+
+        const endIso = parseDate(row.end_date);
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!endDate) err('endDate', `Missing/invalid end_date "${row.end_date}"`);
+
+        // ── Analysis type ← analysis_data.name → SoilWaterAnalysis master ──
+        // REQUIRED non-null FK, no `_other` column → findOrCreate when unmatched.
+        let analysisId = null;
+        const analysisObj = asObject(row.analysis_data);
+        const analysisName = decodeEntities(cleanText(analysisObj?.name || row['analysis_data.name'] || ''));
+        if (analysisName) {
+            const hit = await r.findOrCreate('soilWaterAnalysis', 'analysisName', 'soilWaterAnalysisId', analysisName);
+            analysisId = hit.id;
+            if (hit.created) warn('analysisId', `Analysis "${analysisName}" not in master — created`);
+        } else {
+            err('analysisId', 'No analysis type on old row — required');
+        }
+
+        // ── Samples analysed through (REQUIRED string, fixed list) ─────────
+        let samplesAnalysedThrough = canonicalMode(row.testing_through);
+        if (!samplesAnalysedThrough) {
+            samplesAnalysedThrough = 'Other';
+            warn('samplesAnalysedThrough', `No/unknown testing_through "${row.testing_through}" — defaulted to "Other"`);
+        }
+
+        // ── Counts / amount (REQUIRED ints) ────────────────────────────────
+        const samplesAnalysed = intOrZero(row.no_of_sample);
+        const villagesNumber = intOrZero(row.no_of_village);
+        const amountRealized = intOrZero(row.amount);
+
+        // ── Reporting year (nullable) — old bare year int → Jan 1 (UTC) ────
+        const reportingYear = row.reporting_year != null
+            ? (() => { const iso = parseDate(String(row.reporting_year)); return iso ? new Date(iso) : null; })()
+            : null;
+
+        const data = {
+            kvkId,
+            startDate,
+            endDate,
+            analysisId,
+            samplesAnalysedThrough,
+            samplesAnalysed,
+            villagesNumber,
+            amountRealized,
+            reportingYear,
+            // Demographics ← flat list columns (*_t totals dropped, UI recomputes).
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+        };
+
+        return { data, issues };
+    },
+
+    async seedRecord(prisma, data) {
+        // Always insert — the old site holds genuine duplicate analysis rows
+        // (same kvk, dates, type, counts) that are distinct records. No dedupe.
+        await prisma.kkvSoilWaterAnalysis.create({ data });
+        return 'created';
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -21,6 +21,7 @@ const specs = [
     require('./modules/technologyWeek.js'),
     require('./modules/celebrationDay.js'),
     require('./modules/productionSupply.js'),
+    require('./modules/soilWaterAnalysis.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));


### PR DESCRIPTION
## Summary
Adds a data-migration module for **Soil, Water & Plant Analysis** — migrates `atariams.org` `soil-water-testing/analysis-details` rows into `kvk_soil_water_analysis` (`KkvSoilWaterAnalysis`).

## Mapping
- `kvk.kvk_name` → matched by name (old id ≠ our id; e.g. old 29 "Ranchi" → our 11)
- `start_date` / `end_date` (DD-MM-YYYY) → `startDate` / `endDate`
- `analysis_data.name` → `analysisId` via global `SoilWaterAnalysis` master. Required non-null FK with no `_other` column → `findOrCreate` when unmatched (mirrors celebration-day ImportantDay path)
- `testing_through` slug (e.g. `testing_laboratory`) → canonicalised onto the form's fixed mode list (`Mini soil testing kit` / `Soil testing laboratory` / `Other`)
- `no_of_sample` / `no_of_village` / `amount` → counts
- flat `general_m`…`st_f` → demographics (old `*_t` totals dropped; UI recomputes)
- `reporting_year` (bare year int) → Jan 1 UTC of that year

All fields live on the DataTables list row — no per-row edit-page enrichment.

## Files
- `backend/migration/modules/soilWaterAnalysis.js` — new module spec
- `backend/migration/registry.js` — register module
- `backend/migration/masterCatalog.js` — `soilWaterAnalysis` master entry for the FK picker

Frontend MigrationTool is data-driven (dropdown + FK labels from the API) — no frontend change needed.

## Verification
Live fetch + transform against KVK Ranchi (our id 11): **15/15 rows mapped, 0 errors, 0 warnings, seedable**. Dates, analysis FK, mode slug→label, demographics, and reporting year all correct. No seed run against the live DB (read-only check).