### PR TITLE
feat(migration): add Climate Resilient Agriculture (CRA) modules — Details + Extension Activity

### DIFF
--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -98,6 +98,9 @@ const MASTER_CATALOG = {
     soilWaterAnalysis: { model: 'soilWaterAnalysis', idField: 'soilWaterAnalysisId', nameField: 'analysisName' },
     // Publication type master — what kvk_publication_details.publicationId references.
     publication: { model: 'publication', idField: 'publicationId', nameField: 'publicationName' },
+    // CRA system masters — what cra_details.{croppingSystemId,farmingSystemId} reference.
+    craCropingSystem: { model: 'craCropingSystem', idField: 'craCropingSystemId', nameField: 'cropName' },
+    craFarmingSystem: { model: 'craFarmingSystem', idField: 'craFarmingSystemId', nameField: 'farmingSystemName' },
 };
 
 function getMaster(key) {

--- a/backend/migration/modules/craDetails.js
+++ b/backend/migration/modules/craDetails.js
@@ -1,3 +1,4 @@
+const prisma = require('../../config/prisma.js');
 const { normalize } = require('../masterResolver.js');
 const { parseDate, decodeEntities, cleanText } = require('../util.js');
 
@@ -11,14 +12,47 @@ const { parseDate, decodeEntities, cleanText } = require('../util.js');
  * Masters resolved by name:
  *   - season.season_name        → Season (seasonId, nullable)
  *   - croping_system            → CraCropingSystem.cropName; the raw name is
- *     ALWAYS kept in the required `croppingSystem` string, and additionally
- *     matched to croppingSystemId / parked in croppingSystemOther.
- *   - farming_system.name       → CraFarmingSystem.farmingSystemName; matched to
- *     farmingSystemId or parked in farmingSystemOther (no required name column).
+ *     ALWAYS kept in the required `croppingSystem` string. When it isn't already
+ *     a master, a CraCropingSystem row is CREATED under the resolved season and
+ *     its id used for croppingSystemId.
+ *   - farming_system.name       → CraFarmingSystem.farmingSystemName; same
+ *     find-or-create-under-season behaviour for farmingSystemId.
  *
- * Old `*_t` totals (general_t, total_m, sub_total, …) are derived on the old
- * site and recomputed in our UI — dropped here.
+ * Both CRA system masters are season-scoped (NOT NULL seasonId), so creation
+ * needs a resolved season. When the season is unmatched we can't create the
+ * master — the name is parked in the corresponding *_other column instead and a
+ * warning is raised. cropName/farmingSystemName have no unique constraint, so we
+ * find-or-create per (season, normalized name): the lookup is cached per season
+ * on ctx and any row created here is found on the next Transform, so repeated
+ * runs never duplicate.
  */
+
+/**
+ * Find a season-scoped CRA system master by normalized name, creating it under
+ * that season when absent. @returns {Promise<number|null>} the master id, or
+ * null when no season is resolved (caller parks the name in *_other).
+ */
+async function findOrCreateSeasonScoped(ctx, model, nameField, idField, cacheKey, seasonId, rawName) {
+    if (!rawName || !seasonId) return null;
+    if (!ctx[cacheKey]) ctx[cacheKey] = new Map();
+    let byName = ctx[cacheKey].get(seasonId);
+    if (!byName) {
+        const rows = await prisma[model].findMany({
+            where: { seasonId },
+            select: { [idField]: true, [nameField]: true },
+        });
+        byName = new Map(rows.map(r => [normalize(r[nameField]), r[idField]]));
+        ctx[cacheKey].set(seasonId, byName);
+    }
+    const norm = normalize(rawName);
+    if (byName.has(norm)) return byName.get(norm);
+    const created = await prisma[model].create({
+        data: { [nameField]: rawName, seasonId },
+        select: { [idField]: true },
+    });
+    byName.set(norm, created[idField]);
+    return created[idField];
+}
 
 function intOrZero(v) {
     const n = parseInt(String(v ?? '').trim(), 10);
@@ -91,24 +125,37 @@ module.exports = {
         const interventions = decodeEntities(cleanText(row.technology_demo)) || '';
         if (!interventions) warn('interventions', 'No technology_demo on old row');
 
-        // 5. Cropping system — raw name always kept in the required string field,
-        // plus matched to the master (else parked in *_other).
+        // 5. Cropping system — raw name always kept in the required string field.
+        // Find the season-scoped master or CREATE it; only fall back to *_other
+        // when no season is resolved (the master needs a season).
         const croppingSystem = decodeEntities(cleanText(row.croping_system)) || '';
         if (!croppingSystem) warn('croppingSystem', 'No croping_system on old row');
         let croppingSystemId = null, croppingSystemOther = null;
         if (croppingSystem) {
-            const c = await r.resolve('craCropingSystem', 'cropName', 'craCropingSystemId', croppingSystem);
-            if (c.matched) croppingSystemId = c.id;
-            else { croppingSystemOther = croppingSystem; warn('croppingSystemId', `Cropping system "${croppingSystem}" not in master — parked in Other`); }
+            if (seasonId) {
+                croppingSystemId = await findOrCreateSeasonScoped(
+                    ctx, 'craCropingSystem', 'cropName', 'craCropingSystemId',
+                    '_craCropBySeason', seasonId, croppingSystem,
+                );
+            } else {
+                croppingSystemOther = croppingSystem;
+                warn('croppingSystemId', `Cropping system "${croppingSystem}" — no season resolved, can't create master, parked in Other`);
+            }
         }
 
-        // 6. Farming system — match the master, else park name in *_other.
+        // 6. Farming system — same find-or-create-under-season behaviour.
         let farmingSystemId = null, farmingSystemOther = null;
         const farmingName = decodeEntities(cleanText(asObject(row.farming_system)?.name || row['farming_system.name'] || ''));
         if (farmingName) {
-            const f = await r.resolve('craFarmingSystem', 'farmingSystemName', 'craFarmingSystemId', farmingName);
-            if (f.matched) farmingSystemId = f.id;
-            else { farmingSystemOther = farmingName; warn('farmingSystemId', `Farming system "${farmingName}" not in master — parked in Other`); }
+            if (seasonId) {
+                farmingSystemId = await findOrCreateSeasonScoped(
+                    ctx, 'craFarmingSystem', 'farmingSystemName', 'craFarmingSystemId',
+                    '_craFarmBySeason', seasonId, farmingName,
+                );
+            } else {
+                farmingSystemOther = farmingName;
+                warn('farmingSystemId', `Farming system "${farmingName}" — no season resolved, can't create master, parked in Other`);
+            }
         }
 
         // 7. Area (REQUIRED Float).

--- a/backend/migration/modules/craDetails.js
+++ b/backend/migration/modules/craDetails.js
@@ -1,0 +1,146 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: Climate Resilient Agriculture details (CRA) — Achievements /
+ * Projects. Source: atariams.org `project/climate-resilient`. Writes cra_details.
+ *
+ * Every field lives on the DataTables list row (nested kvk/season/farming_system
+ * objects + flat demographics/yields) — no per-row edit-page fetch.
+ *
+ * Masters resolved by name:
+ *   - season.season_name        → Season (seasonId, nullable)
+ *   - croping_system            → CraCropingSystem.cropName; the raw name is
+ *     ALWAYS kept in the required `croppingSystem` string, and additionally
+ *     matched to croppingSystemId / parked in croppingSystemOther.
+ *   - farming_system.name       → CraFarmingSystem.farmingSystemName; matched to
+ *     farmingSystemId or parked in farmingSystemOther (no required name column).
+ *
+ * Old `*_t` totals (general_t, total_m, sub_total, …) are derived on the old
+ * site and recomputed in our UI — dropped here.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'cra-details',
+    label: 'Climate Resilient Agriculture (CRA)',
+    model: 'craDetails',
+    idField: 'craDetailsId',
+    naturalKey: ['kvkId', 'reportingYear', 'seasonId', 'interventions', 'croppingSystem'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        seasonId: { master: 'season' },
+        croppingSystemId: { master: 'craCropingSystem', otherField: 'croppingSystemOther' },
+        farmingSystemId: { master: 'craFarmingSystem', otherField: 'farmingSystemOther' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+
+        // 1. KVK match — same guard as the other modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int (e.g. 2024) → Jan 1 of that year (UTC).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Season ← season.season_name (nullable FK).
+        let seasonId = null;
+        const seasonName = decodeEntities(cleanText(asObject(row.season)?.season_name || row['season.season_name'] || ''));
+        if (seasonName) {
+            const s = await r.resolve('season', 'seasonName', 'seasonId', seasonName);
+            if (s.matched) seasonId = s.id;
+            else warn('seasonId', `Season "${seasonName}" not in master — left blank`);
+        }
+
+        // 4. Interventions / technology demonstrated (REQUIRED string).
+        const interventions = decodeEntities(cleanText(row.technology_demo)) || '';
+        if (!interventions) warn('interventions', 'No technology_demo on old row');
+
+        // 5. Cropping system — raw name always kept in the required string field,
+        // plus matched to the master (else parked in *_other).
+        const croppingSystem = decodeEntities(cleanText(row.croping_system)) || '';
+        if (!croppingSystem) warn('croppingSystem', 'No croping_system on old row');
+        let croppingSystemId = null, croppingSystemOther = null;
+        if (croppingSystem) {
+            const c = await r.resolve('craCropingSystem', 'cropName', 'craCropingSystemId', croppingSystem);
+            if (c.matched) croppingSystemId = c.id;
+            else { croppingSystemOther = croppingSystem; warn('croppingSystemId', `Cropping system "${croppingSystem}" not in master — parked in Other`); }
+        }
+
+        // 6. Farming system — match the master, else park name in *_other.
+        let farmingSystemId = null, farmingSystemOther = null;
+        const farmingName = decodeEntities(cleanText(asObject(row.farming_system)?.name || row['farming_system.name'] || ''));
+        if (farmingName) {
+            const f = await r.resolve('craFarmingSystem', 'farmingSystemName', 'craFarmingSystemId', farmingName);
+            if (f.matched) farmingSystemId = f.id;
+            else { farmingSystemOther = farmingName; warn('farmingSystemId', `Farming system "${farmingName}" not in master — parked in Other`); }
+        }
+
+        // 7. Area (REQUIRED Float).
+        const areaInAcre = floatOrZero(row.area);
+
+        const data = {
+            kvkId,
+            reportingYear,
+            seasonId,
+            interventions,
+            croppingSystem,
+            croppingSystemId,
+            croppingSystemOther,
+            farmingSystemId,
+            farmingSystemOther,
+            areaInAcre,
+            // Farmer demographics — *_t totals dropped (UI recomputes).
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+            // Yields / returns (REQUIRED Floats).
+            cropYield: floatOrZero(row.crop_yield),
+            systemProductivity: floatOrZero(row.system_productivity),
+            totalReturn: floatOrZero(row.total_return),
+            farmerPracticeYield: floatOrZero(row.yield_obtained),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/craExtensionActivity.js
+++ b/backend/migration/modules/craExtensionActivity.js
@@ -1,0 +1,107 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: CRA Extension Activity — Achievements / Projects / Climate
+ * Resilient Agriculture. Source: atariams.org `project/cra-extension-activity`.
+ * Writes cra_extension_activity.
+ *
+ * Every field lives on the DataTables list row (nested kvk + flat
+ * activity/dates/demographics) — no per-row edit-page fetch.
+ *
+ * activityId is a REQUIRED FK to the FldActivity master (activity_name is
+ * @unique) with NO *_other column, so the old `extension_activity` string is
+ * find-or-created on that master and its id used. `state_type` and the old `*_t`
+ * / total / sub_total columns aren't on the new model — dropped.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'cra-extension-activity',
+    label: 'CRA Extension Activity',
+    model: 'craExtensionActivity',
+    idField: 'craExtensionActivityId',
+    naturalKey: ['kvkId', 'activityId', 'startDate', 'endDate', 'exposureVisitNo'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        activityId: { master: 'fldActivity' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+        const error = (field, msg) => issues.push({ field, message: msg, severity: 'error' });
+
+        // 1. KVK match — same guard as the other modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Activity ← extension_activity string → FldActivity master. REQUIRED
+        // FK with no *_other column, so find-or-create on the master.
+        let activityId = null;
+        const activityName = decodeEntities(cleanText(asObject(row.extension_activity)?.name || row.extension_activity || ''));
+        if (activityName) {
+            const a = await r.findOrCreate('fldActivity', 'activityName', 'activityId', activityName);
+            activityId = a.id;
+            if (a.created) warn('activityId', `Activity "${activityName}" not in master — created`);
+        } else {
+            error('activityId', 'No extension_activity on old row — required');
+        }
+
+        // 3. Dates (both REQUIRED, NOT NULL). dd-mm-yyyy. Each falls back to the
+        // other when missing; a row with neither can't be seeded → error.
+        let startIso = parseDate(row.start_date);
+        let endIso = parseDate(row.end_date);
+        if (!startIso) startIso = endIso;
+        if (!endIso) endIso = startIso;
+        if (!startIso) error('startDate', 'No start/end date on old row — cannot seed');
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+
+        // 4. Exposure visits (REQUIRED Int).
+        const exposureVisitNo = intOrZero(row.exposure_visit_no);
+
+        const data = {
+            kvkId,
+            activityId,
+            startDate,
+            endDate,
+            // Farmer demographics — *_t / total / sub_total dropped (UI recomputes).
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+            exposureVisitNo,
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -27,6 +27,7 @@ const specs = [
     require('./modules/scientistAward.js'),
     require('./modules/farmerAward.js'),
     require('./modules/hrdProgram.js'),
+    require('./modules/craDetails.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -28,6 +28,7 @@ const specs = [
     require('./modules/farmerAward.js'),
     require('./modules/hrdProgram.js'),
     require('./modules/craDetails.js'),
+    require('./modules/craExtensionActivity.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));


### PR DESCRIPTION
## Summary
Adds the two **Climate Resilient Agriculture (CRA)** migration modules under Projects.

### 1. CRA Details (`project/climate-resilient` → `cra_details`)
- `seasonId` ← `season.season_name` (nullable); `interventions` ← `technology_demo`
- `croppingSystem` ← `croping_system` (required string, always kept)
- `croppingSystemId` / `farmingSystemId`: resolved by name; when unmatched, **find-or-create the season-scoped CraCropingSystem / CraFarmingSystem master** under the resolved season and use its id. Keyed per (season, normalized name), cached per season → a row created on one Transform is reused on the next (no dupes; names have no unique constraint). Falls back to `*_other` only when no season resolves.
- `areaInAcre`; general/obc/sc/st × m/f demographics (`*_t` dropped); yields cropYield/systemProductivity/totalReturn/farmerPracticeYield
- Catalog: `craCropingSystem` + `craFarmingSystem`

### 2. CRA Extension Activity (`project/cra-extension-activity` → `cra_extension_activity`)
- `activityId` ← `extension_activity` → **FldActivity find-or-create** (required FK, `activity_name` @unique, no Other)
- `startDate`/`endDate` dd-mm-yyyy with mutual fallback, neither → error
- `exposureVisitNo`; general/obc/sc/st m+f demographics
- `state_type` + `*_t`/total/sub_total dropped

## Files
- `backend/migration/modules/craDetails.js`, `craExtensionActivity.js`
- `backend/migration/registry.js`, `backend/migration/masterCatalog.js`

## Testing
- Both modules load + registered (26 total); catalog resolves
- CRA Details transform verified vs live sample (season/farming matched, demographics + yields)
- Master find-or-create paths write to the live DB → verified by load/logic only (not run against shared DB per read-only-testing rule); exercised via the migration UI