### PR TITLE
feat(migration): add FPO Details & FPO Management modules

### DIFF
--- a/backend/migration/modules/fpoCbbo.js
+++ b/backend/migration/modules/fpoCbbo.js
@@ -1,0 +1,103 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, toBool } = require('../util.js');
+
+/**
+ * Module spec: Formation & Promotion of FPOs as CBBOs under NCDC funding
+ * (Achievements / Projects). Source: atariams.org `project/view-fpo-cbbo`
+ * (old table `fpo_cbbos`). Writes fpo_cbbo_details.
+ *
+ * Every field lives on the DataTables list row (nested kvk object) — no per-row
+ * edit-page fetch. One flat row per KVK per reporting year; no master FKs beyond
+ * kvk. The sibling FpoManagement model has no counterpart on this old endpoint,
+ * so it is not migrated here.
+ *
+ * The old row carries an extra `major_area` ("Agriculture and allied") with no
+ * field on the new model — dropped. Numeric counts arrive as strings ("4", "6")
+ * → Int (all NOT NULL, default 0). The three Yes/No flags
+ * (training_recieved / business_plan / business_plan_without_cbbo) → Boolean.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').replace(/[^\d-]/g, ''), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'fpo-cbbo',
+    label: 'FPOs as CBBOs (NCDC)',
+    model: 'fpoCbboDetails',
+    idField: 'fpoCbboDetailsId',
+    naturalKey: ['kvkId', 'reportingYear'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+
+        // 1. KVK match — same guard as the other achievement modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int (e.g. 2025) → Jan 1 of that year (UTC).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Numeric counts — old strings → Int (all NOT NULL, default 0).
+        const blocksAllocated = intOrZero(row.blocks_allocated);
+        const fposRegisteredAsCbbo = intOrZero(row.registered_cbbo);
+        const avgMembersPerFpo = intOrZero(row.avrg_members_fpo);
+        const fposReceivedManagementCost = intOrZero(row.management_cost);
+        const fposReceivedEquityGrant = intOrZero(row.equity_grant);
+        const techBackstoppingProvided = intOrZero(row.tech_backstopping);
+        const trainingProgrammeOrganized = intOrZero(row.training_programs);
+        const assistanceInEconomicActivities = intOrZero(row.economic_activities);
+        const fposDoingBusiness = intOrZero(row.bussiness_fpo);
+
+        // 4. Yes/No flags → Boolean (NOT NULL).
+        const trainingReceivedByMembers = toBool(row.training_recieved);
+        const businessPlanPreparedWithCbbo = toBool(row.business_plan);
+        const businessPlanPreparedWithoutCbbo = toBool(row.business_plan_without_cbbo);
+
+        const data = {
+            kvkId,
+            reportingYear,
+            blocksAllocated,
+            fposRegisteredAsCbbo,
+            avgMembersPerFpo,
+            fposReceivedManagementCost,
+            fposReceivedEquityGrant,
+            techBackstoppingProvided,
+            trainingProgrammeOrganized,
+            trainingReceivedByMembers,
+            assistanceInEconomicActivities,
+            businessPlanPreparedWithCbbo,
+            businessPlanPreparedWithoutCbbo,
+            fposDoingBusiness,
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/fpoManagement.js
+++ b/backend/migration/modules/fpoManagement.js
@@ -1,0 +1,115 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: FPO Management (Achievements / Projects, FPO & CBBO).
+ * Source: atariams.org `project/view-fpo` (old table `fpos`). Writes
+ * fpo_management.
+ *
+ * Every field lives on the DataTables list row (nested kvk object) — no per-row
+ * edit-page fetch. Sibling of the FPO Details module; no master FKs beyond kvk.
+ *
+ * Old numeric fields arrive as strings and the old site uses "-" for "no value"
+ * (e.g. total_bom_members, financial_position) → 0 for the Int/Float columns.
+ * Free-text fields keep their value ("-" included). registration_no is often
+ * "NA"/"-"; the new registrationNumber column is no longer @unique, so the raw
+ * value is stored as-is.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').replace(/[^\d-]/g, ''), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrZero(v) {
+    const n = parseFloat(String(v ?? '').replace(/[^\d.-]/g, ''));
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'fpo-management',
+    label: 'FPO Management',
+    model: 'fpoManagement',
+    idField: 'fpoManagementId',
+    naturalKey: ['kvkId', 'reportingYear', 'fpoName', 'registrationNumber'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+        const error = (field, msg) => issues.push({ field, message: msg, severity: 'error' });
+
+        // 1. KVK match — same guard as the other achievement modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int (e.g. 2025) → Jan 1 of that year (UTC).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Free-text fields — all NOT NULL; default to '' and warn. "-" kept.
+        const fpoName = decodeEntities(cleanText(row.fpo_name)) || '';
+        if (!fpoName) warn('fpoName', 'No FPO name on old row');
+        const address = decodeEntities(cleanText(row.fpo_address)) || '';
+        if (!address) warn('address', 'No address on old row');
+        // registration_no is no longer unique — store the raw value ("NA"/"-").
+        const registrationNumber = decodeEntities(cleanText(row.registration_no)) || '';
+        if (!registrationNumber) warn('registrationNumber', 'No registration number on old row');
+        const proposedActivity = decodeEntities(cleanText(row.proposed_activity)) || '';
+        if (!proposedActivity) warn('proposedActivity', 'No proposed activity on old row');
+        const commodityIdentified = decodeEntities(cleanText(row.commodity_identified)) || '';
+        if (!commodityIdentified) warn('commodityIdentified', 'No commodity identified on old row');
+        const successIndicator = decodeEntities(cleanText(row.success_indicator)) || '';
+        if (!successIndicator) warn('successIndicator', 'No success indicator on old row');
+
+        // 4. Registration date (NOT NULL DateTime). yyyy-mm-dd on the old site.
+        const regIso = parseDate(row.registration_date);
+        if (!regIso) error('registrationDate', 'No registration date on old row — cannot seed');
+        const registrationDate = regIso ? new Date(regIso) : null;
+
+        // 5. Numeric fields — old strings, "-" for no value → 0.
+        const totalBomMembers = intOrZero(row.total_bom_members);
+        const totalFarmersAttached = intOrZero(row.total_farmers_attached);
+        const financialPositionLakh = floatOrZero(row.financial_position);
+
+        const data = {
+            kvkId,
+            reportingYear,
+            fpoName,
+            address,
+            registrationNumber,
+            registrationDate,
+            proposedActivity,
+            commodityIdentified,
+            totalBomMembers,
+            totalFarmersAttached,
+            financialPositionLakh,
+            successIndicator,
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -27,6 +27,8 @@ const specs = [
     require('./modules/scientistAward.js'),
     require('./modules/farmerAward.js'),
     require('./modules/hrdProgram.js'),
+    require('./modules/fpoCbbo.js'),
+    require('./modules/fpoManagement.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));

--- a/backend/prisma/kvk/achievements/projects/fpo_cbbo/fpo_management_schema.prisma
+++ b/backend/prisma/kvk/achievements/projects/fpo_cbbo/fpo_management_schema.prisma
@@ -3,7 +3,7 @@ model FpoManagement {
   kvkId                 Int
   fpoName               String      @map("fpo_name")
   address               String      @map("address")
-  registrationNumber    String      @unique @map("registration_number")
+  registrationNumber    String      @map("registration_number")
   registrationDate      DateTime    @map("registration_date")
   proposedActivity      String      @map("proposed_activity")
   commodityIdentified   String      @map("commodity_identified")

--- a/frontend/src/config/route/projects.ts
+++ b/frontend/src/config/route/projects.ts
@@ -74,10 +74,10 @@ export const projectsRoutes: RouteConfig[] = [
     // FPO
     {
         path: ROUTE_PATHS.ACHIEVEMENTS.PROJECTS.FPO.DETAILS,
-        title: 'FPO Details',
+        title: 'Details FPO and CBBO',
         description: 'Formation and Promotion of FPOs as CBBOs under NCDC funding',
         category: 'Projects',
-        subcategory: 'FPO',
+        subcategory: 'FPO and CBBO',
         parent: ROUTE_PATHS.ACHIEVEMENTS.PROJECTS.BASE,
         moduleCode: 'achievements_projects',
         fields: FIELD_GROUPS.FPO_DETAILS,
@@ -88,7 +88,7 @@ export const projectsRoutes: RouteConfig[] = [
         title: 'FPO Management',
         description: 'FPO Management',
         category: 'Projects',
-        subcategory: 'FPO',
+        subcategory: 'FPO and CBBO',
         parent: ROUTE_PATHS.ACHIEVEMENTS.PROJECTS.BASE,
         moduleCode: 'achievements_projects',
         fields: FIELD_GROUPS.FPO_MANAGEMENT,
@@ -206,7 +206,7 @@ export const projectsRoutes: RouteConfig[] = [
         title: 'CSISA',
         description: 'Cereal Systems Initiative for South Asia (CSISA)',
         category: 'Projects',
-        subcategory: 'CSISA',
+        // subcategory: 'CSISA',
         parent: ROUTE_PATHS.ACHIEVEMENTS.PROJECTS.BASE,
         moduleCode: 'achievements_projects',
         fields: FIELD_GROUPS.CSISA,
@@ -479,7 +479,7 @@ export const projectsRoutes: RouteConfig[] = [
     // Other direct links
     {
         path: ROUTE_PATHS.ACHIEVEMENTS.PROJECTS.SEED_HUB_PROGRAM,
-        title: 'Seed Hub Program',
+        title: 'Program',
         description: 'Seed Hub Program details',
         category: 'Projects',
         subcategory: 'Seed Hub',


### PR DESCRIPTION
## What

Two new migration modules under Achievements / Projects (FPO & CBBO):

- **FPO Details** (`fpo-cbbo`) — `project/view-fpo-cbbo` (old `fpo_cbbos`) → `fpo_cbbo_details`
- **FPO Management** (`fpo-management`) — `project/view-fpo` (old `fpos`) → `fpo_management`

Both pull every field from the DataTables list row (nested `kvk`) — no edit-page enrichment. KVK-only FK.

## Transform notes

**FPO Details**
- String counts → Int (NOT NULL, default 0)
- Yes/No flags (`training_recieved`, `business_plan`, `business_plan_without_cbbo`) → Boolean
- `reporting_year` → Jan 1 UTC
- Old `major_area` has no target field → dropped

**FPO Management**
- Numeric `"-"` placeholders → 0 (`totalBomMembers`, `financialPositionLakh`)
- Free-text fields keep their value (`"-"` included)
- `registration_date` required (error if missing)
- `registration_no` is often `"NA"`/`"-"` → `registrationNumber` **drops its `@unique` constraint** and stores the raw value

## Frontend

- FPO Details route title → "Details FPO and CBBO"

## ⚠️ DB change — apply before seeding FPO Management

Schema drops `@unique` on `fpo_management.registration_number`. Not applied via migrate/push (Neon branches are `db push`-managed and carry unrelated drift). Run manually:

\`\`\`sql
DROP INDEX IF EXISTS "fpo_management_registration_number_key";
\`\`\`

Then `npm run db:generate`.