### PR TITLE
feat(migration): DRMR & NARI migration modules

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,3 +2,7 @@ node_modules
 .env
 
 /generated/prisma
+
+# local env backups (may contain secrets)
+*.env.bak
+.env.bak

--- a/backend/migration/README.md
+++ b/backend/migration/README.md
@@ -129,4 +129,5 @@ budget), training, extension activity (+other), technology week, celebration
 day, production supply, soil-water analysis, publication, awards (KVK /
 scientist / farmer), HRD program, CRA (details / extension activity), FPO
 (CBBO / management), DRMR (details / activity), **NARI (nutrition garden /
-bio-fortified crops)**.
+bio-fortified crops / value addition / training programme / extension
+activity)**.

--- a/backend/migration/README.md
+++ b/backend/migration/README.md
@@ -1,0 +1,132 @@
+# Data Migration Tool
+
+Migrates per-KVK data from the **old** site (`atariams.org`, Laravel/MySQL) into
+**this** app's Postgres DB. Module-driven: each old entity has one spec under
+`modules/`; adding a spec to the registry wires it into the UI and every engine
+endpoint automatically.
+
+Lives in `backend/migration/`. Admin-only UI at
+`frontend/src/pages/migration/MigrationTool.tsx`.
+
+## Flow
+
+```
+paste curl (old site) ──► /fetch ──► raw rows
+                                       │
+        pick target KVK + module       ▼
+                          /transform ──► mapped records + validation report
+                                       │   (no DB writes; edit/fix in the grid)
+                                       ▼
+                              /seed ──► insert into our DB
+```
+
+1. **Fetch** — copy a DataTables list request as cURL from the old site (browser
+   devtools → Network → right-click → Copy as cURL). The browser can't replay it
+   (cross-origin + old session cookie), so the server does via `/fetch`.
+2. **Transform** — pick the target KVK and module. The engine runs the module's
+   `transform(row, ctx)` over every row, resolving masters by name and emitting a
+   per-row + aggregate validation report. **No DB writes.**
+3. **Review/edit** — fix cells inline in the grid; warnings/errors shown per row.
+4. **Seed** — `/seed` inserts the mapped records. **Insert-only, never dedupes**
+   (the old site has genuine near-duplicate rows distinguished only by
+   uncovered fields; matching would collapse them).
+
+## Files
+
+| File | Role |
+|------|------|
+| `routes.js` | Express routes (mounted under `/api/migration`, auth-gated) |
+| `engine.js` | Orchestrates fetch → transform → seed |
+| `registry.js` | Module spec registry — **add new modules here** |
+| `masterResolver.js` | `MasterResolver`: name→id master lookup with normalization |
+| `masterCatalog.js` | Whitelist of FK masters exposed to the UI picker |
+| `curlParser.js` | Parses a pasted cURL into `{url, method, headers, body}` |
+| `util.js` | Shared transform helpers (`parseDate`, `decodeEntities`, `cleanText`, …) |
+| `modules/*.js` | One spec per old entity |
+| `fixtures/*.json` | Sample old-site responses for reference |
+
+## Endpoints (all under `/api/migration`, require admin auth)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET  | `/kvks` | List target KVKs (id + name) |
+| GET  | `/modules` | List registered modules for the dropdown |
+| GET  | `/master-options/:master` | Whitelisted master options for FK pickers |
+| POST | `/fetch` | Replay a pasted cURL against the old site; returns raw JSON |
+| POST | `/transform` | Map raw rows → our schema + validation report (no writes) |
+| POST | `/seed` | Insert mapped records |
+
+## Module spec shape
+
+```js
+module.exports = {
+    key: 'drmr-details',          // unique slug; UI dropdown value
+    label: 'DRMR Details',        // UI label
+    model: 'drmrDetails',         // prisma model (default seed target)
+    idField: 'drmrDetailsId',     // PK field name
+    naturalKey: ['kvkId', ...],   // metadata only — engine never dedupes
+    foreignKeys: {                // render FK cells as labels in the grid
+        kvkId: { master: 'kvk' },
+        seasonId: { master: 'season', otherField: 'seasonOther' },
+    },
+    async transform(row, ctx) {
+        // map one old row -> { data, issues }
+        // data: object for prisma create (or null to skip the row)
+        // issues: [{ field, message, severity: 'warn'|'error' }]
+        return { data, issues };
+    },
+    // OPTIONAL — only when the spec spans >1 table (parent + children).
+    // Without it the engine does prisma[model].create({ data }).
+    async seedRecord(prisma, data, { kvkId }) {
+        // create parent + children; return 'created' | 'updated'
+    },
+};
+```
+
+### The `ctx` object (built in `engine.js` `transform()`)
+
+| Field | Meaning |
+|-------|---------|
+| `kvkId` | Target KVK PK in our DB |
+| `targetKvkName` | Its name — used to guard rows against the selected KVK |
+| `resolver` | A `MasterResolver` instance (shared across the run, cached) |
+
+Modules may stash per-run caches on `ctx` (e.g. CRA's `_craCropBySeason`).
+
+## Conventions / gotchas
+
+- **KVK guard**: every module compares `row.kvk.kvk_name` (normalized) to
+  `ctx.targetKvkName`; mismatched rows return `{ data: null }` and are skipped.
+  Missing name → warn + fall back to `ctx.kvkId`.
+- **Always resolve masters via `MasterResolver`**, never Prisma ILIKE directly.
+  `normalize()` collapses whitespace (incl. non-breaking spaces), case, and
+  `._-/` that ILIKE misses. `resolve()` = name→id (miss → park in `*Other`);
+  `findOrCreate()` = name→id or create (for `@unique` masters with no `*Other`).
+- **Reporting year**: old fiscal int (e.g. `2024`) → `Jan 1 of that year (UTC)`
+  via `parseDate`.
+- **`*_t` / total / sub_total columns** from the old site are dropped — the new
+  UI recomputes them.
+- **Parent + children** (e.g. `drmr-activity`, `fld`, `vehicle`): `transform`
+  returns the parent fields plus a nested array/object; `seedRecord` creates the
+  parent then the children. The grid renders nested values as read-only JSON.
+
+## Adding a module
+
+1. Find the old DataTables endpoint; copy its request as cURL; inspect the JSON
+   row shape (`/fetch` or curl directly).
+2. Find the target prisma model(s) under `prisma/kvk/**` or `prisma/superadmin/**`.
+3. Write `modules/<entity>.js` (copy the closest existing spec — `craDetails.js`
+   for a flat table, `drmrActivity.js`/`fld.js` for parent+children).
+4. Register it in `registry.js`.
+5. Test transform read-only against a sample row before seeding — never seed
+   against the shared live DB during testing.
+
+## Registered modules
+
+See `registry.js`. Currently includes: bank account, employee, infrastructure,
+OFT, vehicle (+details), equipment (+details), FLD, CFLD (technical / extension /
+budget), training, extension activity (+other), technology week, celebration
+day, production supply, soil-water analysis, publication, awards (KVK /
+scientist / farmer), HRD program, CRA (details / extension activity), FPO
+(CBBO / management), DRMR (details / activity), **NARI (nutrition garden /
+bio-fortified crops)**.

--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -101,6 +101,10 @@ const MASTER_CATALOG = {
     // CRA system masters — what cra_details.{croppingSystemId,farmingSystemId} reference.
     craCropingSystem: { model: 'craCropingSystem', idField: 'craCropingSystemId', nameField: 'cropName' },
     craFarmingSystem: { model: 'craFarmingSystem', idField: 'craFarmingSystemId', nameField: 'farmingSystemName' },
+    // NARI masters — nutrition garden references activity + garden type.
+    nariActivity: { model: 'nariActivity', idField: 'nariActivityId', nameField: 'activityName' },
+    nutritionGardenType: { model: 'nutritionGardenType', idField: 'nutritionGardenTypeId', nameField: 'name' },
+    cropCategory: { model: 'cropCategory', idField: 'cropCategoryId', nameField: 'name' },
 };
 
 function getMaster(key) {

--- a/backend/migration/modules/drmrActivity.js
+++ b/backend/migration/modules/drmrActivity.js
@@ -1,0 +1,148 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: DRMR Activity — Achievements / Projects. Source: atariams.org
+ * `project/view-drmr-activity` (`drmr_activities` table). Writes a parent
+ * drmr_activity row + one drmr_activity_component per non-zero activity type.
+ *
+ * The old row is one flat record holding every activity type's count/qty + unit;
+ * the new model normalises those into a child table keyed by DrmrActivityType.
+ * The old list carries no farmer demographics (general_m … st_f) and no
+ * per-component specification, so those default to 0 / null. Each old
+ * <thing>_count|qty + <thing>_count|qty_unit pair maps to one enum component:
+ *
+ *   training_count        → TRAINING
+ *   fld_count             → FRONTLINE_DEMONSTRATION
+ *   awareness_count       → AWARENESS_CAMP
+ *   seeds_qty             → INPUT_SEEDS
+ *   small_equip_qty       → INPUT_SMALL_EQUIPMENT
+ *   large_equip_qty       → INPUT_LARGE_EQUIPMENT
+ *   fertilizer_qty        → INPUT_FERTILIZER
+ *   pp_chemicals_qty      → INPUT_PPC
+ *   lecture_count         → LITERATURE_DISTRIBUTION
+ *   kisan_mela_count      → KISAN_MELA
+ *   any_other_count       → OTHER
+ *
+ * total_budget → totalBudgetUtilized. A component is emitted only when its
+ * quantity > 0 (0 means the activity didn't happen) — seedRecord creates the
+ * parent then the components.
+ */
+
+const COMPONENT_MAP = [
+    ['TRAINING', 'training_count', 'training_count_unit'],
+    ['FRONTLINE_DEMONSTRATION', 'fld_count', 'fld_count_unit'],
+    ['AWARENESS_CAMP', 'awareness_count', 'awareness_count_unit'],
+    ['INPUT_SEEDS', 'seeds_qty', 'seeds_qty_unit'],
+    ['INPUT_SMALL_EQUIPMENT', 'small_equip_qty', 'small_equip_qty_unit'],
+    ['INPUT_LARGE_EQUIPMENT', 'large_equip_qty', 'large_equip_qty_unit'],
+    ['INPUT_FERTILIZER', 'fertilizer_qty', 'fertilizer_qty_unit'],
+    ['INPUT_PPC', 'pp_chemicals_qty', 'pp_chemicals_qty_unit'],
+    ['LITERATURE_DISTRIBUTION', 'lecture_count', 'lecture_count_unit'],
+    ['KISAN_MELA', 'kisan_mela_count', 'kisan_mela_count_unit'],
+    ['OTHER', 'any_other_count', 'any_other_count_unit'],
+];
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+const ZERO_DEMOGRAPHICS = {
+    generalM: 0, generalF: 0, obcM: 0, obcF: 0,
+    scM: 0, scF: 0, stM: 0, stF: 0,
+};
+
+module.exports = {
+    key: 'drmr-activity',
+    label: 'DRMR Activity',
+    model: 'drmrActivity',
+    idField: 'drmrActivityId',
+    naturalKey: ['kvkId', 'reportingYear', 'startDate', 'endDate'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+        const error = (field, msg) => issues.push({ field, message: msg, severity: 'error' });
+
+        // 1. KVK match — same guard as the other modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int (e.g. 2024) → Jan 1 of that year (UTC).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Dates (both REQUIRED, NOT NULL). yyyy-mm-dd. Each falls back to the
+        // other when missing; a row with neither can't be seeded → error.
+        let startIso = parseDate(row.start_date);
+        let endIso = parseDate(row.end_date);
+        if (!startIso) startIso = endIso;
+        if (!endIso) endIso = startIso;
+        if (!startIso) error('startDate', 'No start/end date on old row — cannot seed');
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+
+        // 4. Components — one per activity type with a non-zero quantity.
+        const components = [];
+        for (const [activityType, qtyField, unitField] of COMPONENT_MAP) {
+            const quantity = floatOrZero(row[qtyField]);
+            if (quantity <= 0) continue;
+            components.push({
+                activityType,
+                quantity,
+                unit: decodeEntities(cleanText(row[unitField])),
+                specification: null,
+                ...ZERO_DEMOGRAPHICS,
+            });
+        }
+        if (!components.length) warn('components', 'No non-zero activity counts on old row');
+
+        const data = {
+            kvkId,
+            reportingYear,
+            startDate,
+            endDate,
+            totalBudgetUtilized: floatOrZero(row.total_budget),
+            components,
+        };
+
+        return { data, issues };
+    },
+
+    async seedRecord(prisma, data) {
+        const { components, ...activity } = data;
+        const created = await prisma.drmrActivity.create({ data: activity });
+        if (components && components.length) {
+            await prisma.drmrActivityComponent.createMany({
+                data: components.map(c => ({ drmrActivityId: created.drmrActivityId, ...c })),
+            });
+        }
+        return 'created';
+    },
+};

--- a/backend/migration/modules/drmrDetails.js
+++ b/backend/migration/modules/drmrDetails.js
@@ -1,0 +1,99 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: DRMR Details — Achievements / Projects. Source: atariams.org
+ * `project/view-drmr` (`drmrs` table). Writes drmr_details.
+ *
+ * Every field lives on the DataTables list row (nested kvk + flat
+ * variety/yield/cost/return columns) — no per-row edit-page fetch. KVK is the
+ * only FK; no masters to resolve. The old `anmr` (additional net monetary
+ * return) column has no new-model column → dropped.
+ *
+ * Old → new field map:
+ *   situations    → situation
+ *   varieties_ip  → varietyImprovedPractice    varieties_fp → varietyFarmerPractice
+ *   yield_ip/fp   → yieldImproved/FarmerKgPerHa  yiofp_fp   → yieldIncreasePercent
+ *   coc_ip/fp     → costImproved/FarmerPerHa
+ *   gmr_ip/fp     → grossReturnImproved/FarmerPerHa
+ *   net_return_ip/fp → netReturnImproved/FarmerPerHa
+ *   ratio_gmr_ip/fp  → bcRatioImproved/Farmer
+ */
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'drmr-details',
+    label: 'DRMR Details',
+    model: 'drmrDetails',
+    idField: 'drmrDetailsId',
+    naturalKey: ['kvkId', 'reportingYear', 'situation', 'varietyImprovedPractice'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+
+        // 1. KVK match — same guard as the other modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int (e.g. 2024) → Jan 1 of that year (UTC).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Required strings — keep raw text, default '' when absent.
+        const situation = decodeEntities(cleanText(row.situations)) || '';
+        const varietyImprovedPractice = decodeEntities(cleanText(row.varieties_ip)) || '';
+        const varietyFarmerPractice = decodeEntities(cleanText(row.varieties_fp)) || '';
+        if (!varietyImprovedPractice) warn('varietyImprovedPractice', 'No varieties_ip on old row');
+
+        const data = {
+            kvkId,
+            reportingYear,
+            situation,
+            varietyImprovedPractice,
+            varietyFarmerPractice,
+            yieldImprovedKgPerHa: floatOrZero(row.yield_ip),
+            yieldFarmerKgPerHa: floatOrZero(row.yield_fp),
+            yieldIncreasePercent: floatOrZero(row.yiofp_fp),
+            costImprovedPerHa: floatOrZero(row.coc_ip),
+            costFarmerPerHa: floatOrZero(row.coc_fp),
+            grossReturnImprovedPerHa: floatOrZero(row.gmr_ip),
+            grossReturnFarmerPerHa: floatOrZero(row.gmr_fp),
+            netReturnImprovedPerHa: floatOrZero(row.net_return_ip),
+            netReturnFarmerPerHa: floatOrZero(row.net_return_fp),
+            bcRatioImproved: floatOrZero(row.ratio_gmr_ip),
+            bcRatioFarmer: floatOrZero(row.ratio_gmr_fp),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nariBioFortifiedCrop.js
+++ b/backend/migration/modules/nariBioFortifiedCrop.js
@@ -39,6 +39,21 @@ function asObject(value) {
     return null;
 }
 
+/**
+ * Old site stores crop_category in the singular ("Cereal", "Vegetable"); the
+ * new CropCategory master is plural ("Cereals", "Vegetables"). Map the
+ * normalized old value → the canonical master name so it resolves without a
+ * manual grid pick. Curated, fixed list — both singular and plural keyed.
+ */
+const CROP_CATEGORY_ALIASES = {
+    cereal: 'Cereals', cereals: 'Cereals',
+    vegetable: 'Vegetables', vegetables: 'Vegetables',
+    pulse: 'Pulses', pulses: 'Pulses',
+    oilseed: 'Oilseeds', oilseeds: 'Oilseeds',
+    fruit: 'Fruits', fruits: 'Fruits',
+    other: 'Other', others: 'Other',
+};
+
 module.exports = {
     key: 'nari-bio-fortified-crop',
     label: 'NARI Bio-fortified Crops (Nutri-Smart village)',
@@ -108,7 +123,9 @@ module.exports = {
         let cropCategoryId = null;
         const cropCategory = decodeEntities(cleanText(row.crop_category)) || '';
         if (cropCategory) {
-            const c = await r.resolve('cropCategory', 'name', 'cropCategoryId', cropCategory);
+            // Canonicalise old singular → master plural before resolving.
+            const canonical = CROP_CATEGORY_ALIASES[normalize(cropCategory)] || cropCategory;
+            const c = await r.resolve('cropCategory', 'name', 'cropCategoryId', canonical);
             if (c.matched) cropCategoryId = c.id;
             else error('cropCategoryId', `Crop category "${cropCategory}" not in master — pick one in the grid`);
         } else {

--- a/backend/migration/modules/nariBioFortifiedCrop.js
+++ b/backend/migration/modules/nariBioFortifiedCrop.js
@@ -1,0 +1,148 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: NARI — Details of Bio-fortified crops used in Nutri-Smart
+ * village. Source: atariams.org `project/nari/bio-fortified/view`
+ * (`nari_bio_fortifieds` table). Writes nari_bio_fortified_crop.
+ *
+ * Every field lives on the DataTables list row (nested kvk/season_info + flat
+ * activity/crop/demographics) — no per-row edit-page fetch. The per-crop
+ * production/consumption "results" are a SEPARATE old endpoint
+ * (`nari/bio-fortified-detail`) and are NOT migrated here.
+ *
+ * Three REQUIRED FKs:
+ *   season_info.season_name → Season.seasonName       (resolve; error if unmatched)
+ *   activity                → NariActivity.activityName (find-or-create, @unique)
+ *   crop_category           → CropCategory.name         (find-or-create, @unique)
+ * status falls back to the model default (ONGOING). Old `*_t` / total columns
+ * are dropped (the UI recomputes them).
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nari-bio-fortified-crop',
+    label: 'NARI Bio-fortified Crops (Nutri-Smart village)',
+    model: 'nariBioFortifiedCrop',
+    idField: 'nariBioFortifiedCropId',
+    naturalKey: ['kvkId', 'reportingYear', 'seasonId', 'nameOfNutriSmartVillage', 'nameOfCrop'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        seasonId: { master: 'season' },
+        activityId: { master: 'nariActivity', otherField: 'activityOther' },
+        cropCategoryId: { master: 'cropCategory' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+        const error = (field, msg) => issues.push({ field, message: msg, severity: 'error' });
+
+        // 1. KVK match — same guard as the other modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int (e.g. 2024) → Jan 1 of that year (UTC).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Season ← season_info.season_name → Season master. REQUIRED FK,
+        // resolved by name (ids don't line up across sites); error if unmatched.
+        let seasonId = null;
+        const seasonName = decodeEntities(cleanText(asObject(row.season_info)?.season_name || row['season_info.season_name'] || ''));
+        if (seasonName) {
+            const s = await r.resolve('season', 'seasonName', 'seasonId', seasonName);
+            if (s.matched) seasonId = s.id;
+            else error('seasonId', `Season "${seasonName}" not in master — required`);
+        } else {
+            error('seasonId', 'No season on old row — required');
+        }
+
+        // 4. Activity ← activity string → NariActivity master (find-or-create).
+        let activityId = null;
+        const activityName = decodeEntities(cleanText(asObject(row.activity)?.activity_name || row.activity)) || '';
+        if (activityName) {
+            const a = await r.findOrCreate('nariActivity', 'activityName', 'nariActivityId', activityName);
+            activityId = a.id;
+            if (a.created) warn('activityId', `Activity "${activityName}" not in master — created`);
+        } else {
+            error('activityId', 'No activity on old row — required');
+        }
+
+        // 5. Crop category ← crop_category → CropCategory master. REQUIRED FK,
+        // resolved by name only (curated fixed list; old singular "Cereal" vs
+        // master "Cereals" must NOT auto-create a dup). On a miss, error + let
+        // the human re-pick via the grid FK picker before seeding.
+        let cropCategoryId = null;
+        const cropCategory = decodeEntities(cleanText(row.crop_category)) || '';
+        if (cropCategory) {
+            const c = await r.resolve('cropCategory', 'name', 'cropCategoryId', cropCategory);
+            if (c.matched) cropCategoryId = c.id;
+            else error('cropCategoryId', `Crop category "${cropCategory}" not in master — pick one in the grid`);
+        } else {
+            error('cropCategoryId', 'No crop_category on old row — required');
+        }
+
+        // 6. Required strings.
+        const nameOfNutriSmartVillage = decodeEntities(cleanText(row.village_name)) || '';
+        if (!nameOfNutriSmartVillage) warn('nameOfNutriSmartVillage', 'No village_name on old row');
+        const nameOfCrop = decodeEntities(cleanText(row.crop_name)) || '';
+        if (!nameOfCrop) warn('nameOfCrop', 'No crop_name on old row');
+        const variety = decodeEntities(cleanText(row.variety)) || '';
+
+        const data = {
+            kvkId,
+            reportingYear,
+            seasonId,
+            activityId,
+            cropCategoryId,
+            nameOfNutriSmartVillage,
+            nameOfCrop,
+            variety,
+            areaHa: floatOrZero(row.area),
+            // Demographics — *_t / total dropped (UI recomputes).
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nariExtensionActivity.js
+++ b/backend/migration/modules/nariExtensionActivity.js
@@ -1,0 +1,104 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: NARI — Extension Activities under NARI Project.
+ * Source: atariams.org `project/nari/extension-activities/view`
+ * (`nari_extension_activities` table). Writes nari_extension_activity.
+ *
+ * Every field lives on the DataTables list row (nested kvk + flat
+ * activity/name/count/demographics) — no per-row edit-page fetch.
+ *
+ * activity → NariActivity.activityName (find-or-create, @unique). status falls
+ * back to the model default (ONGOING). Old `*_t` / total columns are dropped.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nari-extension-activity',
+    label: 'NARI Extension Activity',
+    model: 'nariExtensionActivity',
+    idField: 'nariExtensionActivityId',
+    naturalKey: ['kvkId', 'reportingYear', 'nameOfNutriSmartVillage', 'nameOfActivity'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        activityId: { master: 'nariActivity', otherField: 'activityOther' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+        const error = (field, msg) => issues.push({ field, message: msg, severity: 'error' });
+
+        // 1. KVK match — same guard as the other modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int → Jan 1 of that year (UTC).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Activity ← activity string → NariActivity master (find-or-create).
+        let activityId = null;
+        const activityName = decodeEntities(cleanText(asObject(row.activity)?.activity_name || row.activity)) || '';
+        if (activityName) {
+            const a = await r.findOrCreate('nariActivity', 'activityName', 'nariActivityId', activityName);
+            activityId = a.id;
+            if (a.created) warn('activityId', `Activity "${activityName}" not in master — created`);
+        } else {
+            error('activityId', 'No activity on old row — required');
+        }
+
+        // 4. Required strings.
+        const nameOfNutriSmartVillage = decodeEntities(cleanText(row.village_name)) || '';
+        if (!nameOfNutriSmartVillage) warn('nameOfNutriSmartVillage', 'No village_name on old row');
+        const nameOfActivity = decodeEntities(cleanText(row.activity_name)) || '';
+        if (!nameOfActivity) warn('nameOfActivity', 'No activity_name on old row');
+
+        const data = {
+            kvkId,
+            reportingYear,
+            activityId,
+            nameOfNutriSmartVillage,
+            nameOfActivity,
+            noOfActivities: intOrZero(row.no_of_activities),
+            // Demographics — *_t / total dropped (UI recomputes).
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nariNutritionGarden.js
+++ b/backend/migration/modules/nariNutritionGarden.js
@@ -1,0 +1,130 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: NARI — Details of established Nutrition Garden in Nutri-Smart
+ * village. Source: atariams.org `project/nari/nutri-smart/view`
+ * (`nari_nutri_smarts` table). Writes nari_nutritional_garden.
+ *
+ * Every field lives on the DataTables list row (nested kvk + flat
+ * activity/village/type/demographics) — no per-row edit-page fetch. The
+ * per-garden production/consumption "results" are a SEPARATE old endpoint
+ * (`nari/prod-consum`) and are NOT migrated here.
+ *
+ * Two REQUIRED FKs, both @unique-name masters with an `is_other` flag:
+ *   activity            → NariActivity.activityName        (find-or-create)
+ *   type_nutri_gardern  → NutritionGardenType.name         (find-or-create)
+ * The raw name is find-or-created on the master and its id used; the matching
+ * *_other columns stay null (only the new form's explicit "Other" pick uses
+ * them). status falls back to the model default (ONGOING). The old `*_t` totals
+ * are dropped (the UI recomputes them).
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nari-nutrition-garden',
+    label: 'NARI Nutrition Garden (Nutri-Smart village)',
+    model: 'nariNutritionalGarden',
+    idField: 'nariNutritionalGardenId',
+    naturalKey: ['kvkId', 'reportingYear', 'nameOfNutriSmartVillage', 'typeOfNutritionalGardenId'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        activityId: { master: 'nariActivity', otherField: 'activityOther' },
+        typeOfNutritionalGardenId: { master: 'nutritionGardenType', otherField: 'typeOfNutritionalGardenOther' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+        const error = (field, msg) => issues.push({ field, message: msg, severity: 'error' });
+
+        // 1. KVK match — same guard as the other modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int (e.g. 2024) → Jan 1 of that year (UTC).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Activity ← activity string → NariActivity master. REQUIRED FK, no
+        // *_other used (raw name find-or-created on the @unique master).
+        let activityId = null;
+        const activityName = decodeEntities(cleanText(asObject(row.activity)?.activity_name || row.activity)) || '';
+        if (activityName) {
+            const a = await r.findOrCreate('nariActivity', 'activityName', 'nariActivityId', activityName);
+            activityId = a.id;
+            if (a.created) warn('activityId', `Activity "${activityName}" not in master — created`);
+        } else {
+            error('activityId', 'No activity on old row — required');
+        }
+
+        // 4. Type of nutritional garden ← type_nutri_gardern → NutritionGardenType
+        // master. REQUIRED FK, find-or-create on the @unique name.
+        let typeOfNutritionalGardenId = null;
+        const typeName = decodeEntities(cleanText(row.type_nutri_gardern)) || '';
+        if (typeName) {
+            const t = await r.findOrCreate('nutritionGardenType', 'name', 'nutritionGardenTypeId', typeName);
+            typeOfNutritionalGardenId = t.id;
+            if (t.created) warn('typeOfNutritionalGardenId', `Garden type "${typeName}" not in master — created`);
+        } else {
+            error('typeOfNutritionalGardenId', 'No type_nutri_gardern on old row — required');
+        }
+
+        // 5. Village name (REQUIRED string).
+        const nameOfNutriSmartVillage = decodeEntities(cleanText(row.village_name)) || '';
+        if (!nameOfNutriSmartVillage) warn('nameOfNutriSmartVillage', 'No village_name on old row');
+
+        const data = {
+            kvkId,
+            reportingYear,
+            activityId,
+            typeOfNutritionalGardenId,
+            nameOfNutriSmartVillage,
+            number: intOrZero(row.number),
+            areaSqm: floatOrZero(row.area),
+            // Demographics — *_t totals dropped (UI recomputes).
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nariTrainingProgramme.js
+++ b/backend/migration/modules/nariTrainingProgramme.js
@@ -1,0 +1,129 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: NARI — Training Programmes in Nutri-Smart Village.
+ * Source: atariams.org `project/nari/training-programm/view`
+ * (`nari_training_programmes` table). Writes nari_training_programme.
+ *
+ * Every field lives on the DataTables list row (nested kvk + flat
+ * activity/area/title/days/courses/venue/demographics) — no per-row edit fetch.
+ *
+ * activity → NariActivity.activityName (find-or-create, @unique). campusType is
+ * a REQUIRED CampusType enum (ON_CAMPUS|OFF_CAMPUS); the old `campus_type` is
+ * frequently null, so it defaults to ON_CAMPUS with a warning. `venue` is a
+ * REQUIRED String, defaults to '' when null. Old `*_t` / total columns dropped.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+/** Old campus_type ("On Campus"/"Off Campus"/1/2/null) → CampusType enum. */
+function toCampusType(value) {
+    const s = normalize(value);
+    if (!s) return null;
+    if (s.includes('off') || s === '2') return 'OFF_CAMPUS';
+    if (s.includes('on') || s === '1') return 'ON_CAMPUS';
+    return null;
+}
+
+module.exports = {
+    key: 'nari-training-programme',
+    label: 'NARI Training Programme (Nutri-Smart village)',
+    model: 'nariTrainingProgramme',
+    idField: 'nariTrainingProgrammeId',
+    naturalKey: ['kvkId', 'reportingYear', 'nameOfNutriSmartVillage', 'titleOfTraining'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        activityId: { master: 'nariActivity', otherField: 'activityOther' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+        const error = (field, msg) => issues.push({ field, message: msg, severity: 'error' });
+
+        // 1. KVK match — same guard as the other modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int → Jan 1 of that year (UTC).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Activity ← activity string → NariActivity master (find-or-create).
+        let activityId = null;
+        const activityName = decodeEntities(cleanText(asObject(row.activity)?.activity_name || row.activity)) || '';
+        if (activityName) {
+            const a = await r.findOrCreate('nariActivity', 'activityName', 'nariActivityId', activityName);
+            activityId = a.id;
+            if (a.created) warn('activityId', `Activity "${activityName}" not in master — created`);
+        } else {
+            error('activityId', 'No activity on old row — required');
+        }
+
+        // 4. Campus type (REQUIRED enum). Old value often null → default ON_CAMPUS.
+        let campusType = toCampusType(row.campus_type);
+        if (!campusType) {
+            campusType = 'ON_CAMPUS';
+            warn('campusType', 'No campus_type on old row — defaulted to ON_CAMPUS');
+        }
+
+        // 5. Required strings.
+        const nameOfNutriSmartVillage = decodeEntities(cleanText(row.village_name)) || '';
+        if (!nameOfNutriSmartVillage) warn('nameOfNutriSmartVillage', 'No village_name on old row');
+        const areaOfTraining = decodeEntities(cleanText(row.area)) || '';
+        const titleOfTraining = decodeEntities(cleanText(row.training_tiltle)) || '';
+        if (!titleOfTraining) warn('titleOfTraining', 'No training_tiltle on old row');
+        let venue = decodeEntities(cleanText(row.venue)) || '';
+        if (!venue) warn('venue', 'No venue on old row — left blank');
+
+        const data = {
+            kvkId,
+            reportingYear,
+            activityId,
+            campusType,
+            nameOfNutriSmartVillage,
+            areaOfTraining,
+            titleOfTraining,
+            noOfDays: intOrZero(row.no_of_days),
+            noOfCourses: intOrZero(row.no_of_courses),
+            venue,
+            // Demographics — *_t / total dropped (UI recomputes).
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nariValueAddition.js
+++ b/backend/migration/modules/nariValueAddition.js
@@ -1,0 +1,107 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: NARI — Details of Value addition in Nutri-Smart village.
+ * Source: atariams.org `project/nari/value-addition/view`
+ * (`nari_value_additions` table). Writes nari_value_addition.
+ *
+ * Every field lives on the DataTables list row (nested kvk + flat
+ * activity/crop/product/demographics) — no per-row edit-page fetch. The
+ * per-product "results" are a SEPARATE old endpoint and are NOT migrated here.
+ *
+ * activity → NariActivity.activityName (find-or-create, @unique). status falls
+ * back to the model default (ONGOING). Old `*_t` / total columns are dropped.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nari-value-addition',
+    label: 'NARI Value Addition (Nutri-Smart village)',
+    model: 'nariValueAddition',
+    idField: 'nariValueAdditionId',
+    naturalKey: ['kvkId', 'reportingYear', 'nameOfNutriSmartVillage', 'nameOfValueAddedProduct'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        activityId: { master: 'nariActivity', otherField: 'activityOther' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+        const error = (field, msg) => issues.push({ field, message: msg, severity: 'error' });
+
+        // 1. KVK match — same guard as the other modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int → Jan 1 of that year (UTC).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Activity ← activity string → NariActivity master (find-or-create).
+        let activityId = null;
+        const activityName = decodeEntities(cleanText(asObject(row.activity)?.activity_name || row.activity)) || '';
+        if (activityName) {
+            const a = await r.findOrCreate('nariActivity', 'activityName', 'nariActivityId', activityName);
+            activityId = a.id;
+            if (a.created) warn('activityId', `Activity "${activityName}" not in master — created`);
+        } else {
+            error('activityId', 'No activity on old row — required');
+        }
+
+        // 4. Required strings.
+        const nameOfNutriSmartVillage = decodeEntities(cleanText(row.village_name)) || '';
+        if (!nameOfNutriSmartVillage) warn('nameOfNutriSmartVillage', 'No village_name on old row');
+        const nameOfCrop = decodeEntities(cleanText(row.crop_name)) || '';
+        if (!nameOfCrop) warn('nameOfCrop', 'No crop_name on old row');
+        const nameOfValueAddedProduct = decodeEntities(cleanText(row.value_added_name)) || '';
+        if (!nameOfValueAddedProduct) warn('nameOfValueAddedProduct', 'No value_added_name on old row');
+
+        const data = {
+            kvkId,
+            reportingYear,
+            activityId,
+            nameOfNutriSmartVillage,
+            nameOfCrop,
+            nameOfValueAddedProduct,
+            // Demographics — *_t / total dropped (UI recomputes).
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -35,6 +35,9 @@ const specs = [
     require('./modules/drmrActivity.js'),
     require('./modules/nariNutritionGarden.js'),
     require('./modules/nariBioFortifiedCrop.js'),
+    require('./modules/nariValueAddition.js'),
+    require('./modules/nariTrainingProgramme.js'),
+    require('./modules/nariExtensionActivity.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -31,6 +31,10 @@ const specs = [
     require('./modules/craExtensionActivity.js'),
     require('./modules/fpoCbbo.js'),
     require('./modules/fpoManagement.js'),
+    require('./modules/drmrDetails.js'),
+    require('./modules/drmrActivity.js'),
+    require('./modules/nariNutritionGarden.js'),
+    require('./modules/nariBioFortifiedCrop.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));

--- a/frontend/src/components/common/ConfirmModal.tsx
+++ b/frontend/src/components/common/ConfirmModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Modal } from '@/components/ui/Modal'
 import { AlertTriangle, Info, XCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { LoadingButton } from './LoadingButton'
 
 interface ConfirmModalProps {
@@ -75,13 +76,15 @@ export const ConfirmModal: React.FC<ConfirmModalProps> = ({
 
                 {/* Actions */}
                 <div className="flex items-center justify-end gap-3 pt-4 border-t border-[#E0E0E0]">
-                    <button
+                    <Button
+                        variant="outline"
+                        size="md"
                         onClick={onClose}
                         disabled={isLoading}
-                        className="px-4 py-2 text-[#757575] hover:text-[#212121] font-medium rounded-xl hover:bg-[#F5F5F5] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="border-[#E0E0E0] text-[#757575] hover:text-[#212121] hover:bg-[#F5F5F5]"
                     >
                         {cancelText}
-                    </button>
+                    </Button>
                     <LoadingButton
                         onClick={handleConfirm}
                         isLoading={isLoading}

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -13,11 +13,10 @@ export const Card: React.FC<CardProps> = ({
 }) => {
     return (
         <div
-            className={`bg-[#FAF9F6] rounded-xl transition-all duration-200 ${
-                onClick
-                    ? 'cursor-pointer hover:border-[#BDBDBD] hover:shadow-md'
-                    : ''
-            } ${className}`}
+            className={`bg-[#FAF9F6] rounded-xl transition-all duration-200 ${onClick
+                ? 'cursor-pointer hover:border-[#BDBDBD] hover:shadow-md'
+                : ''
+                } ${className}`}
             onClick={onClick}
         >
             {children}
@@ -35,7 +34,7 @@ export const CardHeader: React.FC<CardHeaderProps> = ({
     className = '',
 }) => {
     return (
-        <div className={`px-6 py-4 border-b border-[#E0E0E0] ${className}`}>
+        <div className={`px-4 py-4 border-b border-[#E0E0E0] ${className}`}>
             {children}
         </div>
     )

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -35,7 +35,7 @@ export const Modal: React.FC<ModalProps> = ({
 
             {/* Modal - stop propagation so clicks inside don't close */}
             <div
-                className={`relative z-10 bg-white rounded-xl border border-[#E0E0E0] shadow-xl w-full ${sizeClasses[size]} max-h-[90vh] overflow-y-auto`}
+                className={`relative z-10 bg-white rounded-4xl border border-[#E0E0E0] shadow-xl w-full ${sizeClasses[size]} max-h-[90vh] overflow-y-auto`}
                 onClick={e => e.stopPropagation()}
             >
                 {/* Header */}
@@ -55,7 +55,7 @@ export const Modal: React.FC<ModalProps> = ({
                 )}
 
                 {/* Content */}
-                <div className="px-6 py-4">{children}</div>
+                <div className="px-4 py-4">{children}</div>
             </div>
         </div>
     )

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -4,58 +4,58 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-  {
-    variants: {
-      variant: {
-        primary:
-          "bg-[#487749] text-white hover:bg-[#3d6540] active:bg-[#487749] focus-visible:ring-[#487749]/30 shadow-sm hover:shadow-md",
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-        outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
-        destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-10 gap-1 rounded-xl px-4 text-sm in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
-        md: "h-12 gap-1.5 rounded-xl px-5 text-base in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-4 has-data-[icon=inline-start]:pl-4",
-        lg: "h-14 gap-1.5 rounded-xl px-6 text-lg in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-5 has-data-[icon=inline-start]:pl-5",
-        icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
+    "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+    {
+        variants: {
+            variant: {
+                primary:
+                    "bg-[#487749] text-white hover:bg-[#3d6540] active:bg-[#487749] focus-visible:ring-[#487749]/30 shadow-sm hover:shadow-md",
+                default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+                outline:
+                    "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+                secondary:
+                    "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+                ghost:
+                    "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+                destructive:
+                    "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+                link: "text-primary underline-offset-4 hover:underline",
+            },
+            size: {
+                default:
+                    "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+                xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+                sm: "h-10 gap-1 rounded-xl px-4 text-sm in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+                md: "h-12 gap-1.5 rounded-xl px-5 text-base in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-4 has-data-[icon=inline-start]:pl-4",
+                lg: "h-14 gap-1.5 rounded-xl px-6 text-lg in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-5 has-data-[icon=inline-start]:pl-5",
+                icon: "size-8",
+                "icon-xs":
+                    "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+                "icon-sm":
+                    "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+                "icon-lg": "size-9",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+            size: "default",
+        },
+    }
 )
 
 function Button({
-  className,
-  variant = "default",
-  size = "default",
-  ...props
+    className,
+    variant = "default",
+    size = "default",
+    ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
-  return (
-    <ButtonPrimitive
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
-    />
-  )
+    return (
+        <ButtonPrimitive
+            data-slot="button"
+            className={cn(buttonVariants({ variant, size, className }))}
+            {...props}
+        />
+    )
 }
 
 export { Button, buttonVariants }

--- a/frontend/src/pages/dashboard/shared/forms/performance-indicators/InfrastructurePerformanceForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/performance-indicators/InfrastructurePerformanceForms.tsx
@@ -283,7 +283,7 @@ export const InfrastructurePerformanceForms: React.FC<InfrastructurePerformanceF
                                 required
                                 type="number"
                                 step="0.01"
-                                value={formData.quantity || ''}
+                                value={formData.quantity ?? ''}
                                 onChange={handleNumberChange('quantity')}
                                 placeholder="Enter quantity"
                             />
@@ -297,7 +297,7 @@ export const InfrastructurePerformanceForms: React.FC<InfrastructurePerformanceF
                                 required
                                 type="number"
                                 step="0.01"
-                                value={formData.costOfInputs || ''}
+                                value={formData.costOfInputs ?? ''}
                                 onChange={handleNumberChange('costOfInputs')}
                                 placeholder="Enter cost"
                             />
@@ -307,7 +307,7 @@ export const InfrastructurePerformanceForms: React.FC<InfrastructurePerformanceF
                                 required
                                 type="number"
                                 step="0.01"
-                                value={formData.grossIncome || ''}
+                                value={formData.grossIncome ?? ''}
                                 onChange={handleNumberChange('grossIncome')}
                                 placeholder="Enter gross income"
                             />
@@ -392,7 +392,7 @@ export const InfrastructurePerformanceForms: React.FC<InfrastructurePerformanceF
                                 required
                                 type="number"
                                 step="0.01"
-                                value={formData.quantity || ''}
+                                value={formData.quantity ?? ''}
                                 onChange={handleNumberChange('quantity')}
                                 placeholder="Enter quantity"
                             />
@@ -406,7 +406,7 @@ export const InfrastructurePerformanceForms: React.FC<InfrastructurePerformanceF
                                 required
                                 type="number"
                                 step="0.01"
-                                value={formData.costOfInputs || ''}
+                                value={formData.costOfInputs ?? ''}
                                 onChange={handleNumberChange('costOfInputs')}
                                 placeholder="Enter cost"
                             />
@@ -416,7 +416,7 @@ export const InfrastructurePerformanceForms: React.FC<InfrastructurePerformanceF
                                 required
                                 type="number"
                                 step="0.01"
-                                value={formData.grossIncome || ''}
+                                value={formData.grossIncome ?? ''}
                                 onChange={handleNumberChange('grossIncome')}
                                 placeholder="Enter gross income"
                             />
@@ -475,7 +475,7 @@ export const InfrastructurePerformanceForms: React.FC<InfrastructurePerformanceF
                                 required
                                 type="number"
                                 step="0.01"
-                                value={formData.costOfInputs || ''}
+                                value={formData.costOfInputs ?? ''}
                                 onChange={handleNumberChange('costOfInputs')}
                                 placeholder="Enter cost"
                             />
@@ -485,7 +485,7 @@ export const InfrastructurePerformanceForms: React.FC<InfrastructurePerformanceF
                                 required
                                 type="number"
                                 step="0.01"
-                                value={formData.grossIncome || ''}
+                                value={formData.grossIncome ?? ''}
                                 onChange={handleNumberChange('grossIncome')}
                                 placeholder="Enter gross income"
                             />
@@ -546,7 +546,7 @@ export const InfrastructurePerformanceForms: React.FC<InfrastructurePerformanceF
                                 required
                                 type="number"
                                 step="0.01"
-                                value={formData.quantity || ''}
+                                value={formData.quantity ?? ''}
                                 onChange={handleNumberChange('quantity')}
                                 placeholder="Enter quantity"
                             />
@@ -560,7 +560,7 @@ export const InfrastructurePerformanceForms: React.FC<InfrastructurePerformanceF
                                 required
                                 type="number"
                                 step="0.01"
-                                value={formData.costOfInputs || ''}
+                                value={formData.costOfInputs ?? ''}
                                 onChange={handleNumberChange('costOfInputs')}
                                 placeholder="Enter cost"
                             />
@@ -570,7 +570,7 @@ export const InfrastructurePerformanceForms: React.FC<InfrastructurePerformanceF
                                 required
                                 type="number"
                                 step="0.01"
-                                value={formData.grossIncome || ''}
+                                value={formData.grossIncome ?? ''}
                                 onChange={handleNumberChange('grossIncome')}
                                 placeholder="Enter gross income"
                             />

--- a/frontend/src/pages/dashboard/shared/forms/projects/DrmrForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/projects/DrmrForms.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { ENTITY_TYPES } from '@/constants/entityConstants'
 import { FormInput } from '../shared/FormComponents'
 import { CasteGenderTotals } from '@/components/common/CasteGenderTotals'
+import { parseDecimalInput } from '@/utils/formNumericGuards'
 
 interface DrmrFormsProps {
     entityType: string
@@ -122,80 +123,89 @@ export const DrmrForms: React.FC<DrmrFormsProps> = ({
                             label="Yield Improved Practice(Kg/ha)"
                             required
                             type="number"
+                            step="any"
                             value={formData.yieldImproved ?? ''}
-                            onChange={(e) => setFormData({ ...formData, yieldImproved: e.target.value })}
+                            onChange={(e) => setFormData({ ...formData, yieldImproved: parseDecimalInput(e.target.value) })}
                         />
                         <FormInput
                             label="Yield Farmer Practise(Kg/ha)"
                             required
                             type="number"
+                            step="any"
                             value={formData.yieldFarmerPractise ?? ''}
-                            onChange={(e) => setFormData({ ...formData, yieldFarmerPractise: e.target.value })}
+                            onChange={(e) => setFormData({ ...formData, yieldFarmerPractise: parseDecimalInput(e.target.value) })}
                         />
                         <FormInput
                             label="Yield Increase(%)"
                             required
                             type="number"
+                            step="any"
                             value={formData.yieldIncreasePercent ?? ''}
-                            onChange={(e) => setFormData({ ...formData, yieldIncreasePercent: e.target.value })}
+                            onChange={(e) => setFormData({ ...formData, yieldIncreasePercent: parseDecimalInput(e.target.value) })}
                         />
                         <FormInput
                             label="Cost of Cultivation Improved Practice(Rs./ha)"
                             required
                             type="number"
+                            step="any"
                             value={formData.costImproved ?? ''}
-                            onChange={(e) => setFormData({ ...formData, costImproved: e.target.value })}
+                            onChange={(e) => setFormData({ ...formData, costImproved: parseDecimalInput(e.target.value) })}
                         />
                         <FormInput
                             label="Cost of Cultivation Farmer Practice(Rs./ha)"
                             required
                             type="number"
+                            step="any"
                             value={formData.costFarmerPractise ?? ''}
-                            onChange={(e) => setFormData({ ...formData, costFarmerPractise: e.target.value })}
+                            onChange={(e) => setFormData({ ...formData, costFarmerPractise: parseDecimalInput(e.target.value) })}
                         />
                         <FormInput
                             label="Gross Return Improved Practice(Rs./ha)"
                             required
                             type="number"
+                            step="any"
                             value={formData.grossReturnImproved ?? ''}
-                            onChange={(e) => setFormData({ ...formData, grossReturnImproved: e.target.value })}
+                            onChange={(e) => setFormData({ ...formData, grossReturnImproved: parseDecimalInput(e.target.value) })}
                         />
                         <FormInput
                             label="Gross Return Farmer Practice(Rs./ha)"
                             required
                             type="number"
+                            step="any"
                             value={formData.grossReturnFarmerPractise ?? ''}
-                            onChange={(e) => setFormData({ ...formData, grossReturnFarmerPractise: e.target.value })}
+                            onChange={(e) => setFormData({ ...formData, grossReturnFarmerPractise: parseDecimalInput(e.target.value) })}
                         />
                         <FormInput
                             label="Net Return Improved Practice(Rs./ha)"
                             required
                             type="number"
+                            step="any"
                             value={formData.netReturnImproved ?? ''}
-                            onChange={(e) => setFormData({ ...formData, netReturnImproved: e.target.value })}
+                            onChange={(e) => setFormData({ ...formData, netReturnImproved: parseDecimalInput(e.target.value) })}
                         />
                         <FormInput
                             label="Net Return Farmer Practice(Rs./ha)"
                             required
                             type="number"
+                            step="any"
                             value={formData.netReturnFarmerPractise ?? ''}
-                            onChange={(e) => setFormData({ ...formData, netReturnFarmerPractise: e.target.value })}
+                            onChange={(e) => setFormData({ ...formData, netReturnFarmerPractise: parseDecimalInput(e.target.value) })}
                         />
                         <FormInput
                             label="B:C ratio Improved Practice"
                             required
                             type="number"
-                            step="0.01"
+                            step="any"
                             value={formData.bcRatioImproved ?? ''}
-                            onChange={(e) => setFormData({ ...formData, bcRatioImproved: e.target.value })}
+                            onChange={(e) => setFormData({ ...formData, bcRatioImproved: parseDecimalInput(e.target.value) })}
                         />
                         <FormInput
                             label="B:C ratio Farmer Practice"
                             required
                             type="number"
-                            step="0.01"
+                            step="any"
                             value={formData.bcRatioFarmerPractise ?? ''}
-                            onChange={(e) => setFormData({ ...formData, bcRatioFarmerPractise: e.target.value })}
+                            onChange={(e) => setFormData({ ...formData, bcRatioFarmerPractise: parseDecimalInput(e.target.value) })}
                         />
                     </div>
                 </div>

--- a/frontend/src/utils/formNumericGuards.ts
+++ b/frontend/src/utils/formNumericGuards.ts
@@ -10,6 +10,23 @@ export function parseEstablishmentYearInput(raw: string): number | '' {
     return Number.isNaN(n) ? '' : n
 }
 
+/**
+ * Decimal number inputs (whole or decimal). Strips anything that isn't a
+ * digit, a single leading minus, or a single dot — so the field can never
+ * hold a non-numeric string. Preserves a trailing "." while typing (e.g. "1.")
+ * so decimals can be entered smoothly; backend coerces to a number.
+ */
+export function parseDecimalInput(raw: string): string {
+    let s = raw.replace(/[^\d.-]/g, '')
+    const neg = s.startsWith('-')
+    s = s.replace(/-/g, '')
+    const firstDot = s.indexOf('.')
+    if (firstDot !== -1) {
+        s = s.slice(0, firstDot + 1) + s.slice(firstDot + 1).replace(/\./g, '')
+    }
+    return (neg ? '-' : '') + s
+}
+
 /** Member / headcount style counts (max 6 digits). */
 export function parseBoundedCountInput(raw: string, maxDigits = 6): number | '' {
     const digits = raw.replace(/\D/g, '').slice(0, maxDigits)


### PR DESCRIPTION
## What

Adds data-migration tool modules (old atariams.org → new DB):

| key | old endpoint | target model |
|-----|--------------|--------------|
| `drmr-details` | `project/view-drmr` | `drmr_details` |
| `drmr-activity` | `project/view-drmr-activity` | `drmr_activity` + `drmr_activity_component` (one per non-zero activity type) |
| `nari-nutrition-garden` | `project/nari/nutri-smart/view` | `nari_nutritional_garden` |
| `nari-bio-fortified-crop` | `project/nari/bio-fortified/view` | `nari_bio_fortified_crop` |
| `nari-value-addition` | `project/nari/value-addition/view` | `nari_value_addition` |
| `nari-training-programme` | `project/nari/training-programm/view` | `nari_training_programme` |
| `nari-extension-activity` | `project/nari/extension-activities/view` | `nari_extension_activity` |

Supporting changes:
- Register all in `registry.js`
- Add `nariActivity`, `nutritionGardenType`, `cropCategory` to the FK master catalog
- New `backend/migration/README.md` documenting the tool
- Ignore `backend/*.env.bak`

## Notes

- **Insert-only** seeding (engine never dedupes) — consistent with existing modules.
- DRMR activity flattens 11 old count/qty columns into typed child components; emitted only when qty > 0; demographics default 0 (old list lacks them).
- NARI per-crop/garden/product **results** are separate old endpoints — not migrated here.
- **crop_category** (bio-fortified): old site stores it singular ("Cereal"); the master is plural ("Cereals"). An alias map canonicalises singular→plural so it resolves automatically. Still resolve-only (no auto-create) — genuinely unknown values error and the user re-picks via the grid FK picker. Season handled the same way.
- NARI training: old `campus_type` often null → CampusType enum defaults `ON_CAMPUS` (warn); null `venue` → '' (warn).
- All `transform`s verified read-only against live old-site sample rows.

## Also included
Unrelated working-tree changes bundled per request: DRMR / infrastructure form numeric-guard updates and shared UI tweaks (`Card`, `Modal`, `button`, `ConfirmModal`, `formNumericGuards`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
