### PR TITLE
feat(migration): ARYA Current Year & Previous Year modules

### DIFF
--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -105,6 +105,8 @@ const MASTER_CATALOG = {
     nariActivity: { model: 'nariActivity', idField: 'nariActivityId', nameField: 'activityName' },
     nutritionGardenType: { model: 'nutritionGardenType', idField: 'nutritionGardenTypeId', nameField: 'name' },
     cropCategory: { model: 'cropCategory', idField: 'cropCategoryId', nameField: 'name' },
+    // ARYA enterprise master — what arya_current_year/arya_prev_year.enterpriseId references.
+    enterprise: { model: 'enterprise', idField: 'enterpriseId', nameField: 'enterpriseName' },
 };
 
 function getMaster(key) {

--- a/backend/migration/modules/aryaCurrentYear.js
+++ b/backend/migration/modules/aryaCurrentYear.js
@@ -1,0 +1,151 @@
+const { parseDate, decodeEntities, cleanText, extractImgSrc } = require('../util.js');
+const { normalize } = require('../masterResolver.js');
+
+/**
+ * Module spec: ARYA Current Year — Achievements / Projects. Source:
+ * atariams.org `project/arya` (`arya` table). Writes arya_current_year.
+ *
+ * Every field lives on the DataTables list row (nested kvk + enterprise objects
+ * and the full flat column set) — no per-row edit-page fetch. KVK + Enterprise
+ * are the two FKs. Enterprise resolves by name against enterprise_master;
+ * a miss parks the name in enterprise_other under the "Others" master row.
+ *
+ * Old → new field map:
+ *   established_male/female  → unitsMale / unitsFemale
+ *   viable_units/closed_units → viableUnits / closedUnits
+ *   training_conducted        → trainingsConducted
+ *   start_date/end_date       → startDate / endDate
+ *   youth_trained_male/female → youthMale / youthFemale
+ *   group_formed/active       → groupsFormed / groupsActive
+ *   group_left                → personsLeftGroup
+ *   no_of_members             → membersPerGroup
+ *   avg_size                  → avgSizeOfUnit
+ *   total_production          → totalProductionPerYear
+ *   cost_of_production        → perUnitCostOfProduction
+ *   sale_produce              → saleValueOfProduce
+ *   employment_generated      → employmentGeneratedMandays
+ *   images                    → imagePath
+ * Old established_total, economic_gains, bc_ration have no new column → dropped.
+ */
+
+function intOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseInt(String(v).trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'arya-current-year',
+    label: 'ARYA Current Year',
+    model: 'aryaCurrentYear',
+    idField: 'aryaCurrentYearId',
+    naturalKey: ['kvkId', 'reportingYear', 'enterpriseId'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        enterpriseId: { master: 'enterprise' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+
+        // 1. KVK match — same guard as the other project modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal string (e.g. "2024") → Jan 1 of that year.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Enterprise — match by name; unmatched parks the text in enterpriseOther
+        //    under the "Others" master row.
+        const entObj = asObject(row.enterprise);
+        const oldEntName = decodeEntities(cleanText(entObj?.name || row['enterprise.name'])) || '';
+        let enterpriseId = null;
+        let enterpriseOther = null;
+        const hit = await ctx.resolver.resolve('enterprise', 'enterpriseName', 'enterpriseId', oldEntName);
+        if (hit.matched) {
+            enterpriseId = hit.id;
+        } else {
+            const others = await ctx.resolver.resolve('enterprise', 'enterpriseName', 'enterpriseId', 'Others');
+            if (!others.matched) {
+                return {
+                    data: null,
+                    issues: [{ field: 'enterpriseId', message: `Enterprise "${oldEntName}" unmatched and no "Others" master row exists — skipped`, severity: 'error' }],
+                };
+            }
+            enterpriseId = others.id;
+            enterpriseOther = oldEntName || null;
+            warn('enterpriseId', `Enterprise "${oldEntName}" not in master — mapped to "Others" with enterprise_other`);
+        }
+
+        // 4. Required start/end dates — old rows can carry null; fall back to the
+        //    reporting-year date (or now) so the NOT NULL column is satisfied.
+        const fallbackDate = reportingYear || new Date();
+        const startDate = (() => {
+            const iso = parseDate(row.start_date);
+            if (!iso) { warn('startDate', 'No start_date on old row — defaulted'); return fallbackDate; }
+            return new Date(iso);
+        })();
+        const endDate = (() => {
+            const iso = parseDate(row.end_date);
+            if (!iso) { warn('endDate', 'No end_date on old row — defaulted'); return fallbackDate; }
+            return new Date(iso);
+        })();
+
+        const data = {
+            kvkId,
+            reportingYear,
+            enterpriseId,
+            enterpriseOther,
+            unitsMale: intOrZero(row.established_male),
+            unitsFemale: intOrZero(row.established_female),
+            viableUnits: intOrZero(row.viable_units),
+            closedUnits: intOrZero(row.closed_units),
+            trainingsConducted: intOrZero(row.training_conducted),
+            startDate,
+            endDate,
+            youthMale: intOrZero(row.youth_trained_male),
+            youthFemale: intOrZero(row.youth_trained_female),
+            groupsFormed: intOrZero(row.group_formed),
+            groupsActive: intOrZero(row.group_active),
+            personsLeftGroup: intOrZero(row.group_left),
+            membersPerGroup: intOrZero(row.no_of_members),
+            avgSizeOfUnit: floatOrZero(row.avg_size),
+            totalProductionPerYear: floatOrZero(row.total_production),
+            perUnitCostOfProduction: floatOrZero(row.cost_of_production),
+            saleValueOfProduce: floatOrZero(row.sale_produce),
+            employmentGeneratedMandays: floatOrZero(row.employment_generated),
+            imagePath: extractImgSrc(row.images),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/aryaPrevYear.js
+++ b/backend/migration/modules/aryaPrevYear.js
@@ -1,0 +1,148 @@
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+const { normalize } = require('../masterResolver.js');
+
+/**
+ * Module spec: ARYA Previous Year (evaluation) — Achievements / Projects.
+ * Source: atariams.org `project/arya-evaluation` (`arya_evaluation` table).
+ * Writes arya_prev_year.
+ *
+ * Every field lives on the DataTables list row (nested kvk + enterprise objects
+ * and the full flat column set) — no per-row edit-page fetch. KVK + Enterprise
+ * are the two FKs (same enterprise-by-name resolution as arya-current-year).
+ *
+ * Old → new field map:
+ *   established_male/female → unitsMale / unitsFemale
+ *   total_closed            → nonFunctionalUnitsClosed
+ *   closing_date            → dateOfClosing       (nullable)
+ *   total_restarted         → nonFunctionalUnitsRestarted
+ *   restarted_date          → dateOfRestart       (nullable)
+ *   no_of_unit              → numberOfUnits
+ *   unit_capacity           → unitCapacity
+ *   fixed_cost/variable_cost → fixedCost / variableCost
+ *   total_production        → totalProductionPerUnitYear
+ *   gross_cost              → grossCostPerUnitYear
+ *   gross_return            → grossReturnPerUnitYear
+ *   net_benefit             → netBenefitPerUnitYear
+ *   family                  → employmentFamilyMandays
+ *   other_than_family       → employmentOtherMandays
+ *   person_visited          → personsVisitedUnit
+ * Old financial_year, established_total, viable_units, training_*, group_*,
+ * no_of_members, cost_of_production, economic_gains, avg_size, sale_produce,
+ * bc_ration, total_employment_generated, images have no new column → dropped.
+ */
+
+function intOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseInt(String(v).trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'arya-prev-year',
+    label: 'ARYA Previous Year',
+    model: 'aryaPrevYear',
+    idField: 'aryaPrevYearId',
+    naturalKey: ['kvkId', 'reportingYear', 'enterpriseId'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        enterpriseId: { master: 'enterprise' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (field, msg) => issues.push({ field, message: msg, severity: 'warn' });
+
+        // 1. KVK match — same guard as the other project modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal string (e.g. "2025") → Jan 1 of that year.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Enterprise — match by name; unmatched parks the text in enterpriseOther
+        //    under the "Others" master row.
+        const entObj = asObject(row.enterprise);
+        const oldEntName = decodeEntities(cleanText(entObj?.name || row['enterprise.name'])) || '';
+        let enterpriseId = null;
+        let enterpriseOther = null;
+        const hit = await ctx.resolver.resolve('enterprise', 'enterpriseName', 'enterpriseId', oldEntName);
+        if (hit.matched) {
+            enterpriseId = hit.id;
+        } else {
+            const others = await ctx.resolver.resolve('enterprise', 'enterpriseName', 'enterpriseId', 'Others');
+            if (!others.matched) {
+                return {
+                    data: null,
+                    issues: [{ field: 'enterpriseId', message: `Enterprise "${oldEntName}" unmatched and no "Others" master row exists — skipped`, severity: 'error' }],
+                };
+            }
+            enterpriseId = others.id;
+            enterpriseOther = oldEntName || null;
+            warn('enterpriseId', `Enterprise "${oldEntName}" not in master — mapped to "Others" with enterprise_other`);
+        }
+
+        // 4. Closing / restart dates are nullable on the new model — keep null.
+        const dateOfClosing = (() => {
+            const iso = parseDate(row.closing_date);
+            return iso ? new Date(iso) : null;
+        })();
+        const dateOfRestart = (() => {
+            const iso = parseDate(row.restarted_date);
+            return iso ? new Date(iso) : null;
+        })();
+
+        const data = {
+            kvkId,
+            reportingYear,
+            enterpriseId,
+            enterpriseOther,
+            unitsMale: intOrZero(row.established_male),
+            unitsFemale: intOrZero(row.established_female),
+            nonFunctionalUnitsClosed: intOrZero(row.total_closed),
+            dateOfClosing,
+            nonFunctionalUnitsRestarted: intOrZero(row.total_restarted),
+            dateOfRestart,
+            numberOfUnits: intOrZero(row.no_of_unit),
+            unitCapacity: floatOrZero(row.unit_capacity),
+            fixedCost: floatOrZero(row.fixed_cost),
+            variableCost: floatOrZero(row.variable_cost),
+            totalProductionPerUnitYear: floatOrZero(row.total_production),
+            grossCostPerUnitYear: floatOrZero(row.gross_cost),
+            grossReturnPerUnitYear: floatOrZero(row.gross_return),
+            netBenefitPerUnitYear: floatOrZero(row.net_benefit),
+            employmentFamilyMandays: floatOrZero(row.family),
+            employmentOtherMandays: floatOrZero(row.other_than_family),
+            personsVisitedUnit: intOrZero(row.person_visited),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -38,6 +38,8 @@ const specs = [
     require('./modules/nariValueAddition.js'),
     require('./modules/nariTrainingProgramme.js'),
     require('./modules/nariExtensionActivity.js'),
+    require('./modules/aryaCurrentYear.js'),
+    require('./modules/aryaPrevYear.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));


### PR DESCRIPTION
## What

Adds two ARYA migration modules to the data-migration tool.

| key | source (old site) | target table |
|---|---|---|
| `arya-current-year` | `project/arya` | `arya_current_year` |
| `arya-prev-year` | `project/arya-evaluation` | `arya_prev_year` |

## Notes

- Both are single-table; every field lives on the DataTables list row (no per-row edit-page enrich).
- **FKs:** KVK + Enterprise. Enterprise resolves by name against `enterprise_master`; an unmatched name maps to the `Others` master row and parks the original text in `enterprise_other` (with a warn). Adds `enterprise` to `masterCatalog` for the FK picker.
- `reporting_year` taken from the row's own field → Jan 1 UTC.
- Current-year `start_date`/`end_date` are NOT NULL → fall back to the reporting-year date when absent (+warn). Prev-year `closing_date`/`restart_date` are nullable → kept null.
- Dropped old columns with no new equivalent (`established_total`, `bc_ration`, `economic_gains`, etc.).

## Verification

Dry-run `transform` against live old-site samples for KVK Ranchi: **current 4/4**, **prev 3/3** mapped, seedable, zero warnings. Enterprise matched by name (`Goat Farming`, `Lac Farming`). No DB writes.

## Base branch

Based on `feat/nari-drmr-migration-modules` (not `dev`) so the diff is ARYA-only — the registry requires the nari/drmr module files, which aren't in `dev` yet. **Retarget to `dev` once the nari/drmr PR merges.**