### PR TITLE
feat(migration): CSISA & TSP/SCSP modules

### DIFF
--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -107,6 +107,9 @@ const MASTER_CATALOG = {
     cropCategory: { model: 'cropCategory', idField: 'cropCategoryId', nameField: 'name' },
     // ARYA enterprise master — what arya_current_year/arya_prev_year.enterpriseId references.
     enterprise: { model: 'enterprise', idField: 'enterpriseId', nameField: 'enterpriseName' },
+    // TSP/SCSP masters — what tsp_scsp.{tspScspTypeId,activityId} reference.
+    tspScspType: { model: 'tspScspTypeMaster', idField: 'tspScspTypeId', nameField: 'typeName' },
+    tspScspActivity: { model: 'tspScspActivities', idField: 'tspScspActivityId', nameField: 'activityName' },
 };
 
 function getMaster(key) {

--- a/backend/migration/modules/csisa.js
+++ b/backend/migration/modules/csisa.js
@@ -1,0 +1,155 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: CSISA — Achievements / Projects. Source: atariams.org
+ * `project/view-csisa` (`csisa` table). Writes a parent csisa row + one
+ * csisa_crop_detail child.
+ *
+ * The old `csisa` row is flat (denormalised): one record holds the trial-level
+ * info AND a single crop's agronomy/economics. The new schema splits these into
+ * a parent Csisa (trial) + CsisaCropDetail children, so each old row maps to one
+ * parent + one crop-detail child. No grouping/dedupe — every old row is its own
+ * trial (the engine inserts).
+ *
+ * Old → new (parent):
+ *   season ("Kharif 2024")  → seasonId   (year stripped, matched to season master)
+ *   village_covered         → villagesCovered
+ *   block_covered           → blocksCovered
+ *   district_covered        → districtsCovered
+ *   respondent_number       → respondents
+ *   trail_name [sic]        → trialName
+ *   area_covered            → areaCoveredHa
+ * Old → new (crop detail):
+ *   crop_name               → cropName
+ *   technology_options      → technologyOption
+ *   variety_name            → varietyName
+ *   duration                → durationDays
+ *   sowing_date/harvesting_date → sowingDate / harvestingDate (NOT NULL)
+ *   days_of_maturity        → daysOfMaturity
+ *   grain_yield             → grainYieldQPerHa
+ *   cost_of_cultivation     → costOfCultivation
+ *   gross_return/net_return → grossReturn / netReturn
+ *   bcr                     → bcr
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+/** "Kharif 2024" → "Kharif" — strip a trailing 4-digit year so it matches the master. */
+function stripSeasonYear(s) {
+    return String(s ?? '').replace(/\s*\d{4}.*$/, '').trim();
+}
+
+module.exports = {
+    key: 'csisa',
+    label: 'CSISA',
+    model: 'csisa',
+    idField: 'csisaId',
+    naturalKey: ['kvkId', 'reportingYear', 'seasonId', 'trialName'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        seasonId: { master: 'season' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const error = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match — same guard as the other project modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal string (e.g. "2024") → Jan 1 of that year.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Season ← old "Kharif 2024" → strip year → match master (nullable).
+        let seasonId = null;
+        const seasonRaw = decodeEntities(cleanText(row.season)) || '';
+        const seasonName = stripSeasonYear(seasonRaw);
+        if (seasonName) {
+            const hit = await r.resolve('season', 'seasonName', 'seasonId', seasonName);
+            if (hit.matched) seasonId = hit.id;
+            else warn('seasonId', `Season "${seasonRaw}" not in master — left null`);
+        }
+
+        // 4. Crop-detail dates (both REQUIRED on the child). yyyy-mm-dd.
+        const sowingIso = parseDate(row.sowing_date);
+        const harvestIso = parseDate(row.harvesting_date);
+        if (!sowingIso) error('sowingDate', `Missing/invalid sowing_date "${row.sowing_date}"`);
+        if (!harvestIso) error('harvestingDate', `Missing/invalid harvesting_date "${row.harvesting_date}"`);
+
+        const trialName = decodeEntities(cleanText(row.trail_name)) || '';
+        if (!trialName) warn('trialName', 'No trail_name on old row — set to empty string');
+
+        const data = {
+            kvkId,
+            seasonId,
+            reportingYear,
+            villagesCovered: intOrZero(row.village_covered),
+            blocksCovered: intOrZero(row.block_covered),
+            districtsCovered: intOrZero(row.district_covered),
+            respondents: intOrZero(row.respondent_number),
+            trialName,
+            areaCoveredHa: floatOrZero(row.area_covered),
+            // Child crop detail — carried alongside, split out in seedRecord.
+            cropDetail: {
+                cropName: decodeEntities(cleanText(row.crop_name)) || '',
+                technologyOption: decodeEntities(cleanText(row.technology_options)) || '',
+                varietyName: decodeEntities(cleanText(row.variety_name)) || '',
+                durationDays: intOrZero(row.duration),
+                sowingDate: sowingIso ? new Date(sowingIso) : null,
+                harvestingDate: harvestIso ? new Date(harvestIso) : null,
+                daysOfMaturity: intOrZero(row.days_of_maturity),
+                grainYieldQPerHa: floatOrZero(row.grain_yield),
+                costOfCultivation: floatOrZero(row.cost_of_cultivation),
+                grossReturn: floatOrZero(row.gross_return),
+                netReturn: floatOrZero(row.net_return),
+                bcr: floatOrZero(row.bcr),
+            },
+        };
+
+        return { data, issues };
+    },
+
+    async seedRecord(prisma, data) {
+        const { cropDetail, ...csisa } = data;
+        const created = await prisma.csisa.create({ data: csisa });
+        await prisma.csisaCropDetail.create({
+            data: { csisaId: created.csisaId, ...cropDetail },
+        });
+        return 'created';
+    },
+};

--- a/backend/migration/modules/tspScsp.js
+++ b/backend/migration/modules/tspScsp.js
@@ -1,0 +1,160 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: TSP / SCSP Sub-Plan Activity — Achievements / Projects. Source:
+ * atariams.org `project/sub-plan-activity` (`tsp_scsp` table). Writes tsp_scsp.
+ *
+ * Single flat table on both sides. The old row carries the activity as a nested
+ * subplan_activity {id,name}; we resolve by NAME against TspScspActivities (a
+ * miss maps to the "Other activities" master row and parks the text in
+ * activity_other). The TSP/SCSP kind lives both as the `type` enum AND a
+ * TspScspTypeMaster FK, both derived from old `type` ("TSP"/"SCSP").
+ *
+ * The old district_id comes from the OLD db's district table whose ids DO NOT
+ * line up with ours (old 28 = our "Madhepura", but the KVK is Rohtas) and the
+ * old row carries no district name, so districtId is left null (+warn) rather
+ * than mis-pointed.
+ *
+ * Old → new:
+ *   type                          → type (enum) + tspScspTypeId (master)
+ *   subplan_activity.name         → activityId (+ activityOther on miss)
+ *   subplan_other_activity        → activityOther (when present)
+ *   number_of_achievments         → numberOfTrainingsOrDemos
+ *   number_of_beneficieries       → numberOfBeneficiaries
+ *   fund_received                 → fundsReceived
+ *   family_income_unit/_income    → achievementFamilyIncomeUnit / achievementFamilyIncome
+ *   consumption_level_unit/_level  → achievementConsumptionLevelUnit / achievementConsumptionLevel
+ *   availability_of_agricultural_unit/_  → achievementImplementsAvailabilityUnit / achievementImplementsAvailability
+ *   sub_district                  → subDistrict
+ *   no_of_village                 → numberOfVillagesCovered
+ *   name_of_village               → villageNamesCovered
+ *   male/female/total             → stMale / stFemale / stTotal
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+/** Nullable float — old units come as "%20"/"%80"; strip the % and parse. */
+function floatOrNull(v) {
+    if (v === null || v === undefined) return null;
+    const s = String(v).replace(/%/g, '').trim();
+    if (s === '') return null;
+    const n = parseFloat(s);
+    return Number.isFinite(n) ? n : null;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'tsp-scsp',
+    label: 'TSP / SCSP Sub-Plan Activity',
+    model: 'tspScsp',
+    idField: 'tspScspId',
+    naturalKey: ['kvkId', 'reportingYear', 'type', 'activityId'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        tspScspTypeId: { master: 'tspScspType' },
+        activityId: { master: 'tspScspActivity' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const error = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match — same guard as the other project modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old fiscal int/string → Jan 1 of that year.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Type — enum (REQUIRED) + master FK, both from old `type`.
+        const typeRaw = String(row.type ?? '').trim().toUpperCase();
+        let type = null;
+        if (typeRaw === 'TSP' || typeRaw === 'SCSP') type = typeRaw;
+        else error('type', `Unknown type "${row.type}" — expected TSP/SCSP`);
+        let tspScspTypeId = null;
+        if (type) {
+            const hit = await r.resolve('tspScspTypeMaster', 'typeName', 'tspScspTypeId', type);
+            if (hit.matched) tspScspTypeId = hit.id;
+            else warn('tspScspTypeId', `Type "${type}" not in type master — left null`);
+        }
+
+        // 4. Activity ← subplan_activity.name; miss → "Other activities" + activityOther.
+        const actObj = asObject(row.subplan_activity);
+        const actName = decodeEntities(cleanText(actObj?.name || row['subplan_activity.name'])) || '';
+        const otherObj = asObject(row.subplan_other_activity);
+        const otherName = decodeEntities(cleanText(otherObj?.name || row.subplan_other_activity)) || '';
+        let activityId = null;
+        let activityOther = otherName || null;
+        if (actName) {
+            const hit = await r.resolve('tspScspActivities', 'activityName', 'tspScspActivityId', actName);
+            if (hit.matched) {
+                activityId = hit.id;
+            } else {
+                const fallback = await r.resolve('tspScspActivities', 'activityName', 'tspScspActivityId', 'Other activities');
+                activityId = fallback.matched ? fallback.id : null;
+                activityOther = activityOther || actName;
+                warn('activityId', `Activity "${actName}" not in master — mapped to "Other activities" with activity_other`);
+            }
+        } else {
+            warn('activityId', 'No activity on old row — left null');
+        }
+
+        const data = {
+            kvkId,
+            reportingYear,
+            type,
+            tspScspTypeId,
+            activityId,
+            activityOther,
+            numberOfTrainingsOrDemos: intOrZero(row.number_of_achievments),
+            numberOfBeneficiaries: intOrZero(row.number_of_beneficieries),
+            fundsReceived: floatOrNull(row.fund_received),
+            achievementFamilyIncomeUnit: floatOrNull(row.family_income_unit),
+            achievementConsumptionLevelUnit: floatOrNull(row.consumption_level_unit),
+            achievementImplementsAvailabilityUnit: floatOrNull(row.availability_of_agricultural_unit),
+            achievementFamilyIncome: floatOrNull(row.family_income),
+            achievementConsumptionLevel: floatOrNull(row.consumption_level),
+            achievementImplementsAvailability: floatOrNull(row.availability_of_agricultural),
+            // Old district_id is from the old db and doesn't align with ours → null.
+            districtId: null,
+            subDistrict: decodeEntities(cleanText(row.sub_district)),
+            numberOfVillagesCovered: row.no_of_village != null ? intOrZero(row.no_of_village) : null,
+            villageNamesCovered: decodeEntities(cleanText(row.name_of_village)),
+            stMale: row.male != null ? intOrZero(row.male) : null,
+            stFemale: row.female != null ? intOrZero(row.female) : null,
+            stTotal: row.total != null ? intOrZero(row.total) : null,
+        };
+        if (row.district_id != null) {
+            warn('districtId', `Old district_id ${row.district_id} not mappable to our districts — left null`);
+        }
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -40,6 +40,8 @@ const specs = [
     require('./modules/nariExtensionActivity.js'),
     require('./modules/aryaCurrentYear.js'),
     require('./modules/aryaPrevYear.js'),
+    require('./modules/csisa.js'),
+    require('./modules/tspScsp.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));


### PR DESCRIPTION
## What

Adds two migration modules to the data-migration tool.

| key | source (old site) | target table(s) |
|---|---|---|
| `csisa` | `project/view-csisa` | `csisa` + `csisa_crop_detail` |
| `tsp-scsp` | `project/sub-plan-activity` | `tsp_scsp` |

## CSISA

Old `csisa` row is flat (denormalised): one record holds the trial-level info **and** a single crop's agronomy/economics. New schema splits these → each old row maps to one parent `Csisa` + one `CsisaCropDetail` child (via `seedRecord`).
- `season` ("Kharif 2024") → year stripped → matched to season master (nullable; miss → null + warn).
- `reporting_year` → Jan 1 UTC. `trail_name` [sic] → `trialName`.

## TSP/SCSP

Single flat table both sides.
- `type` ("TSP"/"SCSP") → `type` enum **and** `TspScspTypeMaster` FK.
- Activity resolves by name against `TspScspActivities`; a miss maps to the **"Other activities"** master row and parks the text in `activity_other`.
- Percentage unit fields (`"%20"`) are stripped and parsed to numbers.
- **Old `district_id` is from the old DB and does not align with ours** (old 28 = our "Madhepura", but the KVK is Rohtas) and the row carries no district name → `districtId` left null with a warn.
- Adds `tspScspType` + `tspScspActivity` to `masterCatalog` for the FK pickers.

## Verification

Dry-run `transform` against live old-site samples for KVK Rohtas: **CSISA 1/1**, **TSP/SCSP 9/9** mapped, both seedable, zero errors. CSISA season→Kharif(2), crop child split correctly; TSP type SCSP→2, activity FLD→3, units parsed. Only warns are the intended district-not-mapped notices. No DB writes.