### PR TITLE
feat(migration): NICRA modules (basic-info, details, training, extension)

### DIFF
--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -110,6 +110,9 @@ const MASTER_CATALOG = {
     // TSP/SCSP masters — what tsp_scsp.{tspScspTypeId,activityId} reference.
     tspScspType: { model: 'tspScspTypeMaster', idField: 'tspScspTypeId', nameField: 'typeName' },
     tspScspActivity: { model: 'tspScspActivities', idField: 'tspScspActivityId', nameField: 'activityName' },
+    // NICRA details masters — what nicra_details.{nicraCategoryId,nicraSubCategoryId} reference.
+    nicraCategory: { model: 'nicraCategory', idField: 'nicraCategoryId', nameField: 'categoryName' },
+    nicraSubCategory: { model: 'nicraSubCategory', idField: 'nicraSubCategoryId', nameField: 'subCategoryName' },
 };
 
 function getMaster(key) {

--- a/backend/migration/modules/nicraBasicInfo.js
+++ b/backend/migration/modules/nicraBasicInfo.js
@@ -1,0 +1,111 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: NICRA Basic Information — Achievements / Projects. Source:
+ * atariams.org `project/nicra/basic-information` (`nicra_basic_info` table).
+ * Writes nicra_basic_info. Single flat table, KVK is the only FK.
+ *
+ * The new model has no reporting_year column; it keys off reportingDate, which
+ * the form builds from a month+year picker. The old row carries `reporting_year`
+ * ("2025") + `month` ("12") → reportingDate = first of that month (UTC).
+ *
+ * Old → new field map:
+ *   normal/received        → rfNormal / rfReceived
+ *   max/min                → tempMax / tempMin
+ *   ten_days/fifteen_days/twenty_days → drySpell10Days / 15Days / 20Days
+ *   intensive_rain         → intensiveRainAbove60mm
+ *   water_depth            → waterDepthCm
+ *   start_date/end_date    → startDate / endDate (both NOT NULL)
+ * Old `duration` is derived (end-start) and recomputed in our UI → dropped.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nicra-basic-info',
+    label: 'NICRA Basic Information',
+    model: 'nicraBasicInfo',
+    idField: 'nicraBasicInfoId',
+    naturalKey: ['kvkId', 'reportingDate', 'startDate'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match — same guard as the other project modules.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Dates (both REQUIRED). yyyy-mm-dd.
+        const startIso = parseDate(row.start_date);
+        const endIso = parseDate(row.end_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start_date "${row.start_date}"`);
+        if (!endDate) err('endDate', `Missing/invalid end_date "${row.end_date}"`);
+
+        // 3. reportingDate ← reporting_year + month → first of that month (UTC).
+        // Fall back to startDate when the month/year pair is unusable.
+        const reportingDate = (() => {
+            const year = parseInt(String(row.reporting_year ?? '').trim(), 10);
+            const month = parseInt(String(row.month ?? '').trim(), 10);
+            if (Number.isInteger(year) && month >= 1 && month <= 12) {
+                return new Date(Date.UTC(year, month - 1, 1));
+            }
+            if (startDate) { warn('reportingDate', 'No usable month/year — fell back to start_date'); return startDate; }
+            return null;
+        })();
+        if (!reportingDate) err('reportingDate', 'Cannot derive reportingDate (no month/year or start_date)');
+
+        const data = {
+            kvkId,
+            reportingDate,
+            rfNormal: floatOrZero(row.normal),
+            rfReceived: floatOrZero(row.received),
+            tempMax: floatOrZero(row.max),
+            tempMin: floatOrZero(row.min),
+            drySpell10Days: intOrZero(row.ten_days),
+            drySpell15Days: intOrZero(row.fifteen_days),
+            drySpell20Days: intOrZero(row.twenty_days),
+            intensiveRainAbove60mm: intOrZero(row.intensive_rain),
+            waterDepthCm: floatOrZero(row.water_depth),
+            startDate,
+            endDate,
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nicraDetails.js
+++ b/backend/migration/modules/nicraDetails.js
@@ -1,0 +1,144 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, extractImgSrc } = require('../util.js');
+
+/**
+ * Module spec: NICRA Details — Achievements / Projects. Source: atariams.org
+ * `project/nicra/details` (`nicra_details` table). Writes nicra_details.
+ * Single flat table. KVK + (nullable) category/sub-category/season FKs.
+ *
+ * The old category_id / subcategory_id / season_name(=id) line up 1:1 with our
+ * masters (verified), so they resolve by id (resolveById verifies existence).
+ *
+ * Old → new:
+ *   category_id      → nicraCategoryId       subcategory_id → nicraSubCategoryId
+ *   season_name (id) → seasonId              month (1-12)   → month (Month enum)
+ *   fst_type         → fstType               crop_name      → cropName
+ *   technology_demo  → technologyDemonstrated
+ *   area_unit        → areaOrUnit            body_weight    → bodyWeight
+ *   yield → yield    gross_cost/gross_return/net_return/bcr → grossCost/grossReturn/netReturn/bcrRatio
+ *   general_m … st_f → demographics          images → photographs
+ * Old *_t totals + the many category-specific columns (survival_rate_*,
+ * storage_capacity, potential, …) have no new column → dropped. month is a
+ * REQUIRED enum but the old row is usually null → defaults to JANUARY (+warn).
+ */
+
+const MONTHS = ['JANUARY', 'FEBRUARY', 'MARCH', 'APRIL', 'MAY', 'JUNE',
+    'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER'];
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nicra-details',
+    label: 'NICRA Details',
+    model: 'nicraDetails',
+    idField: 'nicraDetailsId',
+    naturalKey: ['kvkId', 'reportingYear', 'cropName', 'fstType'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        nicraCategoryId: { master: 'nicraCategory' },
+        nicraSubCategoryId: { master: 'nicraSubCategory' },
+        seasonId: { master: 'season' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Reporting year ← old "2025" → Jan 1 (UTC), nullable.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Category / sub-category / season — old ids align with ours.
+        let nicraCategoryId = null;
+        if (row.category_id != null) {
+            const hit = await r.resolveById('nicraCategory', 'categoryName', 'nicraCategoryId', row.category_id);
+            if (hit.matched) nicraCategoryId = hit.id;
+            else warn('nicraCategoryId', `Old category_id ${row.category_id} not in our master — left null`);
+        }
+        let nicraSubCategoryId = null;
+        if (row.subcategory_id != null) {
+            const hit = await r.resolveById('nicraSubCategory', 'subCategoryName', 'nicraSubCategoryId', row.subcategory_id);
+            if (hit.matched) nicraSubCategoryId = hit.id;
+            else warn('nicraSubCategoryId', `Old subcategory_id ${row.subcategory_id} not in our master — left null`);
+        }
+        let seasonId = null;
+        if (row.season_name != null && String(row.season_name).trim() !== '') {
+            const hit = await r.resolveById('season', 'seasonName', 'seasonId', row.season_name);
+            if (hit.matched) seasonId = hit.id;
+            else warn('seasonId', `Old season "${row.season_name}" not a known season id — left null`);
+        }
+
+        // 4. Month (REQUIRED enum) — old is usually null → default JANUARY.
+        const monthNum = parseInt(String(row.month ?? '').trim(), 10);
+        let month = 'JANUARY';
+        if (monthNum >= 1 && monthNum <= 12) month = MONTHS[monthNum - 1];
+        else warn('month', `No usable month on old row ("${row.month}") — defaulted to JANUARY`);
+
+        const data = {
+            kvkId,
+            reportingYear,
+            nicraCategoryId,
+            categoryOther: null,
+            nicraSubCategoryId,
+            seasonId,
+            month,
+            fstType: decodeEntities(cleanText(row.fst_type)) || '',
+            cropName: decodeEntities(cleanText(row.crop_name)) || '',
+            technologyDemonstrated: decodeEntities(cleanText(row.technology_demo)) || '',
+            areaOrUnit: floatOrZero(row.area_unit),
+            bodyWeight: floatOrZero(row.body_weight),
+            yield: floatOrZero(row.yield),
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+            grossCost: floatOrZero(row.gross_cost),
+            grossReturn: floatOrZero(row.gross_return),
+            netReturn: floatOrZero(row.net_return),
+            bcrRatio: floatOrZero(row.bcr),
+            photographs: extractImgSrc(row.images),
+            uploadFile: null,
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nicraExtensionActivity.js
+++ b/backend/migration/modules/nicraExtensionActivity.js
@@ -1,0 +1,95 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: NICRA Extension Activity — Achievements / Projects. Source:
+ * atariams.org `project/nicra/extension-activity` (`nicra_extension_activity`
+ * table). Writes nicra_extension_activity. Single flat table, KVK is the only
+ * FK; the new model has no reporting_year.
+ *
+ * Old → new:
+ *   activity_name → activityName
+ *   start_date/end_date → startDate / endDate (old format is DD-MM-YYYY)
+ *   no_of_program → venue  (the old column actually holds the location text,
+ *                           e.g. "Village-Garhi, Block-Poreiyahat, Dist.-Godda")
+ *   general_m … st_f → demographics
+ * Old *_t totals + total_m/f are derived → dropped.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nicra-extension-activity',
+    label: 'NICRA Extension Activity',
+    model: 'nicraExtensionActivity',
+    idField: 'nicraExtensionActivityId',
+    naturalKey: ['kvkId', 'activityName', 'startDate'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Dates (both REQUIRED). Old format is DD-MM-YYYY.
+        const startIso = parseDate(row.start_date);
+        const endIso = parseDate(row.end_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start_date "${row.start_date}"`);
+        if (!endDate) err('endDate', `Missing/invalid end_date "${row.end_date}"`);
+
+        const activityName = decodeEntities(cleanText(row.activity_name)) || '';
+        if (!activityName) warn('activityName', 'No activity_name on old row — set to empty string');
+
+        // venue (REQUIRED) ← old no_of_program location text.
+        const venue = decodeEntities(cleanText(row.no_of_program)) || '';
+        if (!venue) warn('venue', 'No venue/no_of_program on old row — set to empty string');
+
+        const data = {
+            kvkId,
+            activityName,
+            startDate,
+            endDate,
+            venue,
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nicraTraining.js
+++ b/backend/migration/modules/nicraTraining.js
@@ -1,0 +1,96 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: NICRA Training — Achievements / Projects. Source: atariams.org
+ * `project/nicra/training` (`nicra_training` table). Writes nicra_training.
+ * Single flat table, KVK is the only FK; the new model has no reporting_year.
+ *
+ * Old → new:
+ *   title        → titleOfTraining
+ *   campus_type  → campusType (CampusType enum: "Off-campus" → OFF_CAMPUS, else ON_CAMPUS)
+ *   start_date/end_date → startDate / endDate
+ *   remark       → remark
+ *   general_m … st_f → demographics
+ * Old *_t totals + total_m/f are derived → dropped.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nicra-training',
+    label: 'NICRA Training',
+    model: 'nicraTraining',
+    idField: 'nicraTrainingId',
+    naturalKey: ['kvkId', 'titleOfTraining', 'startDate'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Dates (both REQUIRED).
+        const startIso = parseDate(row.start_date);
+        const endIso = parseDate(row.end_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start_date "${row.start_date}"`);
+        if (!endDate) err('endDate', `Missing/invalid end_date "${row.end_date}"`);
+
+        // 3. Campus type → CampusType enum (REQUIRED).
+        const campusRaw = normalize(row.campus_type || '');
+        const campusType = campusRaw.includes('off') ? 'OFF_CAMPUS' : 'ON_CAMPUS';
+        if (!campusRaw) warn('campusType', 'No campus_type on old row — defaulted to ON_CAMPUS');
+
+        const titleOfTraining = decodeEntities(cleanText(row.title)) || '';
+        if (!titleOfTraining) warn('titleOfTraining', 'No title on old row — set to empty string');
+
+        const data = {
+            kvkId,
+            titleOfTraining,
+            campusType,
+            startDate,
+            endDate,
+            remark: decodeEntities(cleanText(row.remark)) || '',
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -42,6 +42,10 @@ const specs = [
     require('./modules/aryaPrevYear.js'),
     require('./modules/csisa.js'),
     require('./modules/tspScsp.js'),
+    require('./modules/nicraBasicInfo.js'),
+    require('./modules/nicraDetails.js'),
+    require('./modules/nicraTraining.js'),
+    require('./modules/nicraExtensionActivity.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));


### PR DESCRIPTION
## What

Adds four NICRA migration modules to the data-migration tool.

| key | source (old site) | target table |
|---|---|---|
| `nicra-basic-info` | `nicra/basic-information` | `nicra_basic_info` |
| `nicra-details` | `nicra/details` | `nicra_details` |
| `nicra-training` | `nicra/training` | `nicra_training` |
| `nicra-extension-activity` | `nicra/extension-activity` | `nicra_extension_activity` |

## Notes

- **basic-info:** model has no `reporting_year`; `reportingDate` is built from old `reporting_year` + `month` → first of that month (UTC), falling back to `start_date`. `normal/received/max/min`→`rfNormal/rfReceived/tempMax/tempMin`, dry spells, intensive rain, water depth, start/end mapped directly.
- **details:** old `category_id` / `subcategory_id` / `season_name`(=id) line up 1:1 with our masters → resolved by id. `month` is a REQUIRED enum but old rows are usually null → defaults to `JANUARY` (+warn). Category-specific extra columns (survival_rate_*, storage_capacity, …) have no new column → dropped. Adds `nicraCategory` + `nicraSubCategory` to masterCatalog.
- **training:** `campus_type` → `CampusType` enum (`Off-campus`→`OFF_CAMPUS`).
- **extension:** old `no_of_program` actually holds the location text → `venue`. Dates are DD-MM-YYYY.
- All single-table; KVK-only FK except details' nullable category/subcategory/season.

## Verification

Dry-run transform against live old-site samples for KVK Godda (#49): **basic-info 10/10, details 10/10, training 9/9, extension 3/3** — all seedable, 0 errors. Only warns are the expected month-default notices on details. No DB writes.