### PR TITLE
fix(natural-farming): make Normal Crops Grown a text field

### DIFF
--- a/backend/prisma/kvk/achievements/projects/natural_farming/farmers_practicing_schema.prisma
+++ b/backend/prisma/kvk/achievements/projects/natural_farming/farmers_practicing_schema.prisma
@@ -9,7 +9,7 @@ model FarmersPracticingNaturalFarming {
   address                                    String
   noOfIndigenousCows                         Int?      @map("no_of_indigenous_cows")
   landHolding                                Float?    @map("land_holding")
-  normalCropsGrown                           Int?      @map("normal_crops_grown")
+  normalCropsGrown                           String?   @map("normal_crops_grown")
   practicingYearsOfNaturalFarming            String?   @map("practicing_years_of_natural_farming")
   areaCoveredUnderNaturalFarming             Float     @default(0) @map("area_covered_under_natural_farming")
   cropGrownUnderNaturalFarming               String    @default("") @map("crop_grown_under_natural_farming")

--- a/backend/repositories/forms/farmersPracticingRepository.js
+++ b/backend/repositories/forms/farmersPracticingRepository.js
@@ -101,7 +101,7 @@ function mapFarmersFormToCreate(data) {
         address: data.address || '',
         noOfIndigenousCows: (data.noOfIndigenousCows || data.noOfAnimals) ? safeInt(data.noOfIndigenousCows || data.noOfAnimals, null) : null,
         landHolding: data.landHolding ? safeFloat(data.landHolding, null) : null,
-        normalCropsGrown: data.normalCropsGrown !== undefined && data.normalCropsGrown !== '' ? safeInt(data.normalCropsGrown, null) : null,
+        normalCropsGrown: data.normalCropsGrown != null && data.normalCropsGrown !== '' ? String(data.normalCropsGrown) : null,
         practicingYearsOfNaturalFarming: data.practicingYearOfNaturalFarming != null && data.practicingYearOfNaturalFarming !== ''
             ? String(data.practicingYearOfNaturalFarming)
             : null,
@@ -300,7 +300,7 @@ const farmersPracticingRepository = {
                         : existing.noOfIndigenousCows,
                     landHolding: data.landHolding !== undefined ? safeFloat(data.landHolding, null) : existing.landHolding,
                     normalCropsGrown: data.normalCropsGrown !== undefined
-                        ? (data.normalCropsGrown === '' ? null : safeInt(data.normalCropsGrown, null))
+                        ? (data.normalCropsGrown === '' || data.normalCropsGrown === null ? null : String(data.normalCropsGrown))
                         : existing.normalCropsGrown,
                     practicingYearsOfNaturalFarming: (() => {
                         const v = pickStrFromPayload(data, 'practicingYearsOfNaturalFarming', 'practicingYearOfNaturalFarming');

--- a/frontend/src/pages/dashboard/shared/forms/projects/NaturalFarmingForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/projects/NaturalFarmingForms.tsx
@@ -528,7 +528,7 @@ export const NaturalFarmingForms: React.FC<NaturalFarmingFormsProps> = ({
                         <FormInput
                             label="Normal Crops Grown"
                             required
-                            type="number"
+                            type="text"
                             value={formData.normalCropsGrown ?? ''}
                             onChange={(e) => setFormData({ ...formData, normalCropsGrown: e.target.value })}
                         />


### PR DESCRIPTION
## What
Change **Normal Crops Grown** (Farmers Practicing Natural Farming) from numeric to free text — crop names can be typed, stored, fetched and updated as strings.

## Changes
- `farmers_practicing_schema.prisma`: `normalCropsGrown Int?` → `String?`
- `farmersPracticingRepository.js`: store `String()` instead of `safeInt()` on create + update
- `NaturalFarmingForms.tsx`: input `type="number"` → `"text"`

## DB migration required
Column still `int`. Non-destructive int→text cast:
```sql
ALTER TABLE farmers_practicing_natural_farming
  ALTER COLUMN normal_crops_grown TYPE text
  USING normal_crops_grown::text;
```
Run via `npm run db:migrate` (Prisma autogenerates this cast from schema diff).

## Verified
- `validateFormRobustness` only validates pure-numeric strings (no mutation) — text input skipped.
- Report repos already coalesce to string — no change needed.