### PR TITLE
fix(forms): skip number check for normalCropsGrown text field

### DIFF
--- a/backend/middleware/validateFormRobustness.js
+++ b/backend/middleware/validateFormRobustness.js
@@ -92,10 +92,16 @@ function isValidNumberString(v) {
     return /^-?\d+(\.\d+)?$/.test(v.trim());
 }
 
+// Free-text fields that may hold a numeric-looking value but must be stored as
+// text — skip numeric validation/coercion so "2" or "2.5" save as-is.
+const NON_NUMERIC_TEXT_KEYS = new Set(['normalcropsgrown']);
+
 function validateNumbers(body) {
     for (const [key, value] of Object.entries(body || {})) {
         // Skip id fields
         if (key.toLowerCase().endsWith('id')) continue;
+        // Skip declared free-text fields (stored as String in the DB).
+        if (NON_NUMERIC_TEXT_KEYS.has(key.toLowerCase())) continue;
         if (value === null || value === undefined || value === '') continue;
 
         if (!isValidNumberString(value)) continue;


### PR DESCRIPTION
## Problem
**Normal Crops Grown** (Farmers Practicing Natural Farming) is a free-text field (`normal_crops_grown` is `String`). But `validateFormRobustness` still ran numeric validation on it, rejecting decimal text (e.g. `2.5` → "must be a whole number"). Stale builds also surfaced a Prisma `Expected a string … got number` error.

## Fix
Skip numeric validation/coercion for declared free-text keys (`normalCropsGrown`) in `validateFormRobustness`. Repo already stores it via `String(...)`, so numeric-looking input saves as a string with no error.

## Verified
- middleware test: `normalCropsGrown="2.5"` passes (skipped); unrelated numeric fields still validated; value left unmutated.