### PR TITLE
feat(migration): NICRA Others migration modules

### DIFF
--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -113,6 +113,12 @@ const MASTER_CATALOG = {
     // NICRA details masters — what nicra_details.{nicraCategoryId,nicraSubCategoryId} reference.
     nicraCategory: { model: 'nicraCategory', idField: 'nicraCategoryId', nameField: 'categoryName' },
     nicraSubCategory: { model: 'nicraSubCategory', idField: 'nicraSubCategoryId', nameField: 'subCategoryName' },
+    // NICRA seed-bank/fodder-bank master — what nicra_intervention.seedBankFodderBankId references.
+    nicraSeedBankFodderBank: { model: 'nicraSeedBankFodderBankMaster', idField: 'nicraSeedBankFodderBankId', nameField: 'name' },
+    // NICRA dignitary-type master — what nicra_dignitaries_visited.dignitaryTypeId references.
+    nicraDignitaryType: { model: 'nicraDignitaryTypeMaster', idField: 'nicraDignitaryTypeId', nameField: 'name' },
+    // NICRA PI-type master — what nicra_pi_copi.piTypeId references.
+    nicraPiType: { model: 'nicraPiTypeMaster', idField: 'nicraPiTypeId', nameField: 'name' },
 };
 
 function getMaster(key) {

--- a/backend/migration/modules/nicraConvergenceProgramme.js
+++ b/backend/migration/modules/nicraConvergenceProgramme.js
@@ -1,0 +1,100 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, extractImgSrc } = require('../util.js');
+
+/**
+ * Module spec: NICRA Others — Convergence Programme. Source: atariams.org
+ * `project/nicra/convergence-program` (`nicra_convergence_programme` table).
+ * Writes nicra_convergence_programme. Flat table, KVK is the only FK.
+ *
+ * Old → new:
+ *   start_date/end_date (dd-mm-yyyy) → startDate / endDate (both NOT NULL)
+ *   program                          → developmentSchemeProgramme
+ *   work_nature                      → natureOfWork
+ *   amount                           → amountRs
+ *   images (JSON ["file.jpeg"])      → photographs (NOT NULL; first filename, '' when absent)
+ * Old reporting_year has no new column → dropped.
+ */
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+/**
+ * Old `images` is either an <img …> blob or a JSON array of bare filenames
+ * (HTML-entity-encoded), e.g. ["convergence-program-01769673075.jpeg"].
+ * Return the first usable reference, or '' (column is NOT NULL).
+ */
+function firstPhoto(value) {
+    const direct = extractImgSrc(value);
+    if (direct) return direct;
+    const decoded = decodeEntities(value);
+    if (!decoded) return '';
+    const arr = asObject(decoded);
+    if (Array.isArray(arr) && arr.length) return String(arr[0]).trim();
+    return '';
+}
+
+module.exports = {
+    key: 'nicra-convergence-programme',
+    label: 'NICRA Convergence Programme',
+    model: 'nicraConvergenceProgramme',
+    idField: 'nicraConvergenceProgrammeId',
+    naturalKey: ['kvkId', 'startDate', 'developmentSchemeProgramme'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Dates (both REQUIRED). Old format is dd-mm-yyyy.
+        const startIso = parseDate(row.start_date);
+        const endIso = parseDate(row.end_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start_date "${row.start_date}"`);
+        if (!endDate) err('endDate', `Missing/invalid end_date "${row.end_date}"`);
+
+        const developmentSchemeProgramme = decodeEntities(cleanText(row.program)) || '';
+        if (!developmentSchemeProgramme) warn('developmentSchemeProgramme', 'No program on old row — set to empty string');
+
+        const data = {
+            kvkId,
+            startDate,
+            endDate,
+            developmentSchemeProgramme,
+            natureOfWork: decodeEntities(cleanText(row.work_nature)) || '',
+            amountRs: floatOrZero(row.amount),
+            photographs: firstPhoto(row.images),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nicraCustomHiring.js
+++ b/backend/migration/modules/nicraCustomHiring.js
@@ -1,0 +1,111 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, extractImgSrc } = require('../util.js');
+
+/**
+ * Module spec: NICRA Others — Custom Hiring (Farm Implements). Source:
+ * atariams.org `project/nicra/custom-hiring` (`nicra_farm_implement` table).
+ * Writes nicra_farm_implement. Flat table, KVK is the only FK.
+ *
+ * Old → new:
+ *   reporting_year ("2025")        → reportingYear (Jan 1 UTC, nullable)
+ *   start_date/end_date (ISO)      → startDate / endDate (both NOT NULL)
+ *   name                           → nameOfFarmImplement
+ *   area                           → areaCovered
+ *   used_in_hours                  → farmImplementUsedHours
+ *   revenue                        → revenueGeneratedRs
+ *   repairing_expenditure          → expenditureIncurredRepairingRs
+ *   general_m … st_f               → demographics
+ *   images                         → photographs (NOT NULL; '' when absent)
+ * Old *_t totals + total_m/f + sub_total are derived → dropped.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nicra-custom-hiring',
+    label: 'NICRA Custom Hiring',
+    model: 'nicraFarmImplement',
+    idField: 'nicraFarmImplementId',
+    naturalKey: ['kvkId', 'reportingYear', 'nameOfFarmImplement', 'startDate'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. reporting year ← old "reporting_year" → Jan 1 (UTC), nullable.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Dates (both REQUIRED). Old format is ISO datetime.
+        const startIso = parseDate(row.start_date);
+        const endIso = parseDate(row.end_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start_date "${row.start_date}"`);
+        if (!endDate) err('endDate', `Missing/invalid end_date "${row.end_date}"`);
+
+        const nameOfFarmImplement = decodeEntities(cleanText(row.name)) || '';
+        if (!nameOfFarmImplement) warn('nameOfFarmImplement', 'No name on old row — set to empty string');
+
+        const data = {
+            kvkId,
+            reportingYear,
+            startDate,
+            endDate,
+            nameOfFarmImplement,
+            areaCovered: floatOrZero(row.area),
+            farmImplementUsedHours: floatOrZero(row.used_in_hours),
+            revenueGeneratedRs: floatOrZero(row.revenue),
+            expenditureIncurredRepairingRs: floatOrZero(row.repairing_expenditure),
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+            photographs: extractImgSrc(row.images) || '',
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nicraDignitariesVisited.js
+++ b/backend/migration/modules/nicraDignitariesVisited.js
@@ -1,0 +1,85 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, extractImgSrc } = require('../util.js');
+
+/**
+ * Module spec: NICRA Others — Dignitaries Visited. Source: atariams.org
+ * `project/nicra/dignitaries-visited` (`nicra_dignitaries_visited` table).
+ * Writes nicra_dignitaries_visited. Flat table, KVK + (nullable) dignitary-type FK.
+ *
+ * Old → new:
+ *   date (yyyy-mm-dd)         → dateOfVisit (NOT NULL)
+ *   type ("VIP"/"Expert")     → dignitaryTypeId (findOrCreate on the master; nullable)
+ *   name                      → name
+ *   remark                    → remark (NOT NULL; '' when absent)
+ *   images                    → photographs (nullable)
+ */
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nicra-dignitaries-visited',
+    label: 'NICRA Dignitaries Visited',
+    model: 'nicraDignitariesVisited',
+    idField: 'nicraDignitariesVisitedId',
+    naturalKey: ['kvkId', 'dateOfVisit', 'name'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        dignitaryTypeId: { master: 'nicraDignitaryType' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Date of visit (REQUIRED).
+        const dateIso = parseDate(row.date);
+        const dateOfVisit = dateIso ? new Date(dateIso) : null;
+        if (!dateOfVisit) err('dateOfVisit', `Missing/invalid date "${row.date}"`);
+
+        // 3. type → dignitary-type master (nullable). findOrCreate keeps any value
+        // the seed master doesn't already cover.
+        let dignitaryTypeId = null;
+        const typeRaw = decodeEntities(cleanText(row.type));
+        if (typeRaw) {
+            const hit = await r.findOrCreate('nicraDignitaryTypeMaster', 'name', 'nicraDignitaryTypeId', typeRaw);
+            dignitaryTypeId = hit.id;
+            if (hit.created) warn('dignitaryTypeId', `Created new dignitary-type master "${typeRaw}"`);
+        } else {
+            warn('dignitaryTypeId', 'No type on old row — left null');
+        }
+
+        const data = {
+            kvkId,
+            dateOfVisit,
+            dignitaryTypeId,
+            name: decodeEntities(cleanText(row.name)) || '',
+            remark: decodeEntities(cleanText(row.remark)) || '',
+            photographs: extractImgSrc(row.images),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nicraIntervention.js
+++ b/backend/migration/modules/nicraIntervention.js
@@ -1,0 +1,96 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: NICRA Others — Intervention. Source: atariams.org
+ * `project/nicra/intervention` (`nicra_intervention` table). Writes
+ * nicra_intervention. Flat table, KVK + (nullable) seed-bank/fodder-bank FK.
+ *
+ * Old → new:
+ *   start_date/end_date (dd-mm-yyyy) → startDate / endDate (both NOT NULL)
+ *   type ("Seed bank"/"Fodder bank") → seedBankFodderBankId (findOrCreate on the
+ *                                      2-row master; nullable)
+ *   crop    → crop        variety → variety
+ *   quantity → quantityQ
+ * Old reporting_year, images have no new column → dropped.
+ */
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nicra-intervention',
+    label: 'NICRA Intervention',
+    model: 'nicraIntervention',
+    idField: 'nicraInterventionId',
+    naturalKey: ['kvkId', 'startDate', 'crop', 'variety'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        seedBankFodderBankId: { master: 'nicraSeedBankFodderBank' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Dates (both REQUIRED). Old format is dd-mm-yyyy.
+        const startIso = parseDate(row.start_date);
+        const endIso = parseDate(row.end_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start_date "${row.start_date}"`);
+        if (!endDate) err('endDate', `Missing/invalid end_date "${row.end_date}"`);
+
+        // 3. type → seed-bank/fodder-bank master (nullable). findOrCreate keeps any
+        // value the 2-row seed master doesn't already cover.
+        let seedBankFodderBankId = null;
+        const typeRaw = decodeEntities(cleanText(row.type));
+        if (typeRaw) {
+            const hit = await r.findOrCreate('nicraSeedBankFodderBankMaster', 'name', 'nicraSeedBankFodderBankId', typeRaw);
+            seedBankFodderBankId = hit.id;
+            if (hit.created) warn('seedBankFodderBankId', `Created new seed/fodder-bank master "${typeRaw}"`);
+        } else {
+            warn('seedBankFodderBankId', 'No type on old row — left null');
+        }
+
+        const data = {
+            kvkId,
+            startDate,
+            endDate,
+            seedBankFodderBankId,
+            crop: decodeEntities(cleanText(row.crop)) || '',
+            variety: decodeEntities(cleanText(row.variety)) || '',
+            quantityQ: floatOrZero(row.quantity),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nicraPiCopi.js
+++ b/backend/migration/modules/nicraPiCopi.js
@@ -1,0 +1,86 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: NICRA Others — PI & Co-PI. Source: atariams.org
+ * `project/nicra/investigator` (`nicra_pi_copi` table). Writes nicra_pi_copi.
+ * Flat table, KVK + (nullable) PI-type FK.
+ *
+ * Old → new:
+ *   start_date/end_date (dd-mm-yyyy) → startDate / endDate (both NOT NULL)
+ *   type ("PI"/"CO PI")              → piTypeId (findOrCreate on the master; nullable)
+ *   name                             → name
+ * Old reporting_year, images have no new column → dropped.
+ */
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nicra-pi-copi',
+    label: 'NICRA PI & Co-PI',
+    model: 'nicraPiCopi',
+    idField: 'nicraPiCopiId',
+    naturalKey: ['kvkId', 'startDate', 'name'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        piTypeId: { master: 'nicraPiType' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Dates (both REQUIRED). Old format is dd-mm-yyyy.
+        const startIso = parseDate(row.start_date);
+        const endIso = parseDate(row.end_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start_date "${row.start_date}"`);
+        if (!endDate) err('endDate', `Missing/invalid end_date "${row.end_date}"`);
+
+        // 3. type → PI-type master (nullable). findOrCreate keeps any value the
+        // seed master doesn't already cover.
+        let piTypeId = null;
+        const typeRaw = decodeEntities(cleanText(row.type));
+        if (typeRaw) {
+            const hit = await r.findOrCreate('nicraPiTypeMaster', 'name', 'nicraPiTypeId', typeRaw);
+            piTypeId = hit.id;
+            if (hit.created) warn('piTypeId', `Created new PI-type master "${typeRaw}"`);
+        } else {
+            warn('piTypeId', 'No type on old row — left null');
+        }
+
+        const data = {
+            kvkId,
+            startDate,
+            endDate,
+            piTypeId,
+            name: decodeEntities(cleanText(row.name)) || '',
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nicraRevenueGenerated.js
+++ b/backend/migration/modules/nicraRevenueGenerated.js
@@ -1,0 +1,73 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: NICRA Others — Revenue Generated. Source: atariams.org
+ * `project/nicra/revenue-generated` (`nicra_revenue_generated` table). Writes
+ * nicra_revenue_generated. Flat table, KVK is the only FK.
+ *
+ * Old → new:
+ *   year ("2025") → reportingYear (Jan 1 UTC, nullable)
+ *   revenue → revenue
+ * Old `total` is a derived column (no new field) → dropped.
+ */
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nicra-revenue-generated',
+    label: 'NICRA Revenue Generated',
+    model: 'nicraRevenueGenerated',
+    idField: 'nicraRevenueGeneratedId',
+    naturalKey: ['kvkId', 'reportingYear', 'revenue'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. reporting year ← old "year" → Jan 1 (UTC), nullable.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.year ?? row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+        if (!reportingYear) warn('reportingYear', `No usable year on old row ("${row.year}") — left null`);
+
+        const data = {
+            kvkId,
+            reportingYear,
+            revenue: floatOrZero(row.revenue),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nicraSoilHealthCard.js
+++ b/backend/migration/modules/nicraSoilHealthCard.js
@@ -1,0 +1,90 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, extractImgSrc } = require('../util.js');
+
+/**
+ * Module spec: NICRA Others — Soil Health Card. Source: atariams.org
+ * `project/nicra/soil-health-card` (`nicra_soil_health_card` table). Writes
+ * nicra_soil_health_card. Flat table, KVK is the only FK.
+ *
+ * Old → new:
+ *   start_date/end_date (dd-mm-yyyy) → startDate / endDate (both NOT NULL)
+ *   soil_samples                     → noOfSoilSamplesCollected
+ *   soil_samples_analyzed            → noOfSamplesAnalysed
+ *   shc_issued ("25")                → shcIssued
+ *   general_m … st_f                 → demographics
+ *   images                           → photographs (nullable)
+ * Old reporting_year, *_t totals, total_m/f, sub_total are derived → dropped.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nicra-soil-health-card',
+    label: 'NICRA Soil Health Card',
+    model: 'nicraSoilHealthCard',
+    idField: 'nicraSoilHealthCardId',
+    naturalKey: ['kvkId', 'startDate', 'noOfSoilSamplesCollected'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Dates (both REQUIRED). Old format is dd-mm-yyyy.
+        const startIso = parseDate(row.start_date);
+        const endIso = parseDate(row.end_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start_date "${row.start_date}"`);
+        if (!endDate) err('endDate', `Missing/invalid end_date "${row.end_date}"`);
+
+        const data = {
+            kvkId,
+            startDate,
+            endDate,
+            noOfSoilSamplesCollected: intOrZero(row.soil_samples),
+            noOfSamplesAnalysed: intOrZero(row.soil_samples_analyzed),
+            shcIssued: intOrZero(row.shc_issued),
+            generalM: intOrZero(row.general_m),
+            generalF: intOrZero(row.general_f),
+            obcM: intOrZero(row.obc_m),
+            obcF: intOrZero(row.obc_f),
+            scM: intOrZero(row.sc_m),
+            scF: intOrZero(row.sc_f),
+            stM: intOrZero(row.st_m),
+            stF: intOrZero(row.st_f),
+            photographs: extractImgSrc(row.images),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nicraVcrmc.js
+++ b/backend/migration/modules/nicraVcrmc.js
@@ -1,0 +1,100 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, extractImgSrc } = require('../util.js');
+
+/**
+ * Module spec: NICRA Others — Village wise VCRMC. Source: atariams.org
+ * `project/nicra/village-climate-risk` (`nicra_vcrmc` table). Writes
+ * nicra_vcrmc. Flat table, KVK is the only FK.
+ *
+ * Old → new:
+ *   reporting_year ("2025")          → reportingYear (Jan 1 UTC, nullable)
+ *   village_name                     → villageName
+ *   constitution_date (yyyy-mm-dd)   → constitutionDate (NOT NULL)
+ *   meeting_organized ("03")         → meetingsOrganized
+ *   meeting_date (yyyy-mm-dd)        → meetingDate (NOT NULL)
+ *   secretary_name                   → nameOfSecretary
+ *   president_name                   → nameOfPresident
+ *   decision_taken                   → majorDecisionTaken
+ *   male / female                    → maleMembers / femaleMembers
+ *   images                           → photographs (NOT NULL; '' when absent)
+ * Old `total` is a derived column → dropped.
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nicra-vcrmc',
+    label: 'NICRA VCRMC',
+    model: 'nicraVcrmc',
+    idField: 'nicraVcrmcId',
+    naturalKey: ['kvkId', 'reportingYear', 'villageName', 'meetingDate'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. reporting year ← old "reporting_year" → Jan 1 (UTC), nullable.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. Dates (both REQUIRED).
+        const constIso = parseDate(row.constitution_date);
+        const meetingIso = parseDate(row.meeting_date);
+        const constitutionDate = constIso ? new Date(constIso) : null;
+        const meetingDate = meetingIso ? new Date(meetingIso) : null;
+        if (!constitutionDate) err('constitutionDate', `Missing/invalid constitution_date "${row.constitution_date}"`);
+        if (!meetingDate) err('meetingDate', `Missing/invalid meeting_date "${row.meeting_date}"`);
+
+        const villageName = decodeEntities(cleanText(row.village_name)) || '';
+        if (!villageName) warn('villageName', 'No village_name on old row — set to empty string');
+
+        const data = {
+            kvkId,
+            reportingYear,
+            villageName,
+            constitutionDate,
+            meetingsOrganized: intOrZero(row.meeting_organized),
+            meetingDate,
+            nameOfSecretary: decodeEntities(cleanText(row.secretary_name)) || '',
+            nameOfPresident: decodeEntities(cleanText(row.president_name)) || '',
+            majorDecisionTaken: decodeEntities(cleanText(row.decision_taken)) || '',
+            maleMembers: intOrZero(row.male),
+            femaleMembers: intOrZero(row.female),
+            photographs: extractImgSrc(row.images) || '',
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -46,6 +46,14 @@ const specs = [
     require('./modules/nicraDetails.js'),
     require('./modules/nicraTraining.js'),
     require('./modules/nicraExtensionActivity.js'),
+    require('./modules/nicraIntervention.js'),
+    require('./modules/nicraRevenueGenerated.js'),
+    require('./modules/nicraCustomHiring.js'),
+    require('./modules/nicraVcrmc.js'),
+    require('./modules/nicraSoilHealthCard.js'),
+    require('./modules/nicraConvergenceProgramme.js'),
+    require('./modules/nicraDignitariesVisited.js'),
+    require('./modules/nicraPiCopi.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));


### PR DESCRIPTION
## Summary

Adds **8 NICRA Others** migration-tool modules that pull data from the old `atariams.org` site into the new app DB. Target Prisma models already exist (live forms under *Achievements › Projects › NICRA › Others*); this wires up the migration specs.

| Module key | Old endpoint | Target model |
|---|---|---|
| `nicra-intervention` | `/project/nicra/intervention` | `NicraIntervention` |
| `nicra-revenue-generated` | `/project/nicra/revenue-generated` | `NicraRevenueGenerated` |
| `nicra-custom-hiring` | `/project/nicra/custom-hiring` | `NicraFarmImplement` |
| `nicra-vcrmc` | `/project/nicra/village-climate-risk` | `NicraVcrmc` |
| `nicra-soil-health-card` | `/project/nicra/soil-health-card` | `NicraSoilHealthCard` |
| `nicra-convergence-programme` | `/project/nicra/convergence-program` | `NicraConvergenceProgramme` |
| `nicra-dignitaries-visited` | `/project/nicra/dignitaries-visited` | `NicraDignitariesVisited` |
| `nicra-pi-copi` | `/project/nicra/investigator` | `NicraPiCopi` |

## Details
- Each spec follows existing project-module conventions: KVK-name guard (skip on mismatch), `parseDate`, `decodeEntities`/`cleanText`, demographics ints, `reportingYear` → Jan-1 UTC.
- Controlled-list FKs resolved via `findOrCreate` against seeded masters (all old values — Seed/Fodder bank, VIP, PI/CO PI — already in seed, so no new master rows created):
  - `nicraSeedBankFodderBank`, `nicraDignitaryType`, `nicraPiType` added to `masterCatalog.js` for the FK pickers.
- Derived old columns (`total`, `sub_total`, `*_t`, `total_m/f`) dropped.
- Convergence `images` is a JSON filename array → `firstPhoto()` decodes + keeps first filename (column is NOT NULL).

## Testing
- Registry loads; all 8 Prisma accessors + 3 masters resolve.
- Dry-ran each `transform` against live sample rows from every endpoint: **0 errors, 0 warnings**, output matches schema field names/types.

## Caveat
- Custom-hiring's old `start_date`/`end_date` are full Laravel UTC timestamps (`...T18:30:00Z` = IST midnight). `parseDate` keeps the UTC date-part → 1-day-earlier calendar date. Consistent with tool-wide date handling (no module does TZ adjustment); eyeball in the preview before seeding. Other modules use plain `dd-mm-yyyy` strings (no skew).