### PR TITLE
feat(migration): Natural Farming migration modules

### DIFF
--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -119,6 +119,10 @@ const MASTER_CATALOG = {
     nicraDignitaryType: { model: 'nicraDignitaryTypeMaster', idField: 'nicraDignitaryTypeId', nameField: 'name' },
     // NICRA PI-type master — what nicra_pi_copi.piTypeId references.
     nicraPiType: { model: 'nicraPiTypeMaster', idField: 'nicraPiTypeId', nameField: 'name' },
+    // Natural-farming activity master — what physical_info / financial_information.activityId reference.
+    naturalFarmingActivity: { model: 'naturalFarmingActivityMaster', idField: 'naturalFarmingActivityId', nameField: 'activityName' },
+    // Natural-farming soil-parameter master — what soil_data_information.soilParameterId references.
+    naturalFarmingSoilParameter: { model: 'naturalFarmingSoilParameterMaster', idField: 'naturalFarmingSoilParameterId', nameField: 'parameterName' },
 };
 
 function getMaster(key) {

--- a/backend/migration/modules/nfBeneficiariesDetails.js
+++ b/backend/migration/modules/nfBeneficiariesDetails.js
@@ -1,0 +1,86 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: Natural Farming — Beneficiaries Details. Source: atariams.org
+ * `project/natural-farming/beneficiaries-details` (`beneficiaries_details` table).
+ * Writes beneficiaries_details. Flat table, KVK is the only FK.
+ *
+ * Old → new:
+ *   reporting_year ("2026")       → year (Int) + reportingYearDate (Jan 1 UTC, nullable)
+ *   no_of_block                   → blocksCovered
+ *   no_of_village                 → villagesCovered
+ *   no_of_training                → totalTrainedFarmers
+ *   no_of_influenced_farmer       → farmersInfluenced
+ *   no_of_farmer_all_Season       → farmersEngagedAllSeason
+ *   no_of_farmer_one_Season       → farmersEngagedOneSeason
+ *   feedback                      → remarks (NOT NULL; '' when absent)
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nf-beneficiaries-details',
+    label: 'Natural Farming — Beneficiaries Details',
+    model: 'beneficiariesDetails',
+    idField: 'beneficiariesDetailsId',
+    naturalKey: ['kvkId', 'year', 'blocksCovered'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. year (REQUIRED Int) + reportingYearDate (nullable) from reporting_year.
+        const year = parseInt(String(row.reporting_year ?? '').trim(), 10);
+        if (!Number.isInteger(year)) err('year', `Missing/invalid reporting_year "${row.reporting_year}"`);
+        const reportingYearDate = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        const data = {
+            kvkId,
+            year: Number.isInteger(year) ? year : 0,
+            reportingYearDate,
+            blocksCovered: intOrZero(row.no_of_block),
+            villagesCovered: intOrZero(row.no_of_village),
+            totalTrainedFarmers: intOrZero(row.no_of_training),
+            farmersInfluenced: intOrZero(row.no_of_influenced_farmer),
+            farmersEngagedAllSeason: intOrZero(row.no_of_farmer_all_Season),
+            farmersEngagedOneSeason: intOrZero(row.no_of_farmer_one_Season),
+            remarks: decodeEntities(cleanText(row.feedback)) || '',
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nfDemonstrationInfo.js
+++ b/backend/migration/modules/nfDemonstrationInfo.js
@@ -1,0 +1,134 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, extractImgSrc, parseNfObservation } = require('../util.js');
+
+/**
+ * Module spec: Natural Farming — Demonstration Details. Source: atariams.org
+ * `project/natural-farming/demonstration-details` (`demonstration_info` table).
+ * Writes demonstration_info. KVK + (nullable) season + staff-category FKs.
+ *
+ * Old → new:
+ *   start_date/end_date (ISO)        → startDate / endDate (both NOT NULL)
+ *   farmer_name/contact_number       → farmerName / contactNumber
+ *   gender ("male") / category ("general") → gender / category (enums)
+ *   village → villageName             address → address
+ *   cropping_patter → croppingPattern farming_situation → farmingSituation
+ *   latitude / longitude             activity_name → activityName (plain string)
+ *   crop / variety                   season_id → seasonId (resolveById; nullable)
+ *   technology_demo → technologyDemonstrated   area → areaInHa
+ *   farmer_practice → farmerPracticeDetails    feedback → farmerFeedback
+ *   observation_recorded (JSON)      → <param>With / <param>Without floats
+ *   images → images                  reporting_year → reportingYear (nullable)
+ * No old fields for no_of_indigenous_cows / land_holding / staff_category here → null.
+ */
+
+const GENDER = { male: 'MALE', female: 'FEMALE', m: 'MALE', f: 'FEMALE' };
+const CATEGORY = { general: 'GENERAL', gen: 'GENERAL', obc: 'OBC', sc: 'SC', st: 'ST' };
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nf-demonstration-info',
+    label: 'Natural Farming — Demonstration Details',
+    model: 'demonstrationInfo',
+    idField: 'demonstrationInfoId',
+    naturalKey: ['kvkId', 'startDate', 'farmerName', 'crop'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        seasonId: { master: 'season' },
+        staffCategoryId: { master: 'staffCategory' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Dates (both REQUIRED). Old format is ISO datetime.
+        const startIso = parseDate(row.start_date);
+        const endIso = parseDate(row.end_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start_date "${row.start_date}"`);
+        if (!endDate) err('endDate', `Missing/invalid end_date "${row.end_date}"`);
+
+        // 3. reporting year (nullable).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 4. Enums (REQUIRED) — default + warn on unknown.
+        const gender = GENDER[String(row.gender ?? '').trim().toLowerCase()] || 'MALE';
+        if (!GENDER[String(row.gender ?? '').trim().toLowerCase()]) warn('gender', `Unknown gender "${row.gender}" — defaulted to MALE`);
+        const category = CATEGORY[String(row.category ?? '').trim().toLowerCase()] || 'GENERAL';
+        if (!CATEGORY[String(row.category ?? '').trim().toLowerCase()]) warn('category', `Unknown category "${row.category}" — defaulted to GENERAL`);
+
+        // 5. season → resolveById (old ids align with ours; nullable).
+        let seasonId = null;
+        if (row.season_id != null && String(row.season_id).trim() !== '') {
+            const hit = await r.resolveById('season', 'seasonName', 'seasonId', row.season_id);
+            if (hit.matched) seasonId = hit.id;
+            else warn('seasonId', `Old season_id ${row.season_id} not in our master — left null`);
+        }
+
+        const data = {
+            kvkId,
+            reportingYear,
+            startDate,
+            endDate,
+            farmerName: decodeEntities(cleanText(row.farmer_name)) || '',
+            villageName: decodeEntities(cleanText(row.village)) || '',
+            address: decodeEntities(cleanText(row.address)) || '',
+            contactNumber: decodeEntities(cleanText(row.contact_number)) || '',
+            noOfIndigenousCows: null,
+            landHolding: null,
+            gender,
+            category,
+            croppingPattern: decodeEntities(cleanText(row.cropping_patter)) || '',
+            farmingSituation: decodeEntities(cleanText(row.farming_situation)) || '',
+            latitude: floatOrZero(row.latitude),
+            longitude: floatOrZero(row.longitude),
+            activityName: decodeEntities(cleanText(row.activity_name)) || '',
+            crop: decodeEntities(cleanText(row.crop)) || '',
+            variety: decodeEntities(cleanText(row.variety)) || '',
+            seasonId,
+            technologyDemonstrated: decodeEntities(cleanText(row.technology_demo)) || '',
+            areaInHa: floatOrZero(row.area),
+            farmerPracticeDetails: decodeEntities(cleanText(row.farmer_practice)) || '',
+            ...parseNfObservation(row.observation_recorded),
+            farmerFeedback: decodeEntities(cleanText(row.feedback)) || '',
+            images: extractImgSrc(row.images),
+            staffCategoryId: null,
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nfFarmersPracticing.js
+++ b/backend/migration/modules/nfFarmersPracticing.js
@@ -1,0 +1,107 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, extractImgSrc, parseNfObservation } = require('../util.js');
+
+/**
+ * Module spec: Natural Farming — Farmer Details (farmers practicing NF). Source:
+ * atariams.org `project/natural-farming/farmer-details`
+ * (`farmers_practicing_natural_farming` table). KVK is the only FK; PK is a uuid
+ * (auto — never set).
+ *
+ * Old → new:
+ *   reporting_year ("2026")          → reportingYear (Jan 1 UTC, nullable)
+ *   farmer_name → farmerName          contact_number → contactNumber
+ *   village → villageName             address → address
+ *   no_of_indigenous → noOfIndigenousCows   land_holding → landHolding
+ *   normal_crops_grown → normalCropsGrown
+ *   practicing_year → practicingYearsOfNaturalFarming (String)
+ *   area_covered → areaCoveredUnderNaturalFarming
+ *   nfr_crop_grown → cropGrownUnderNaturalFarming
+ *   technology → naturalFarmingTechnologyPracticingAdopted
+ *   observation_recorded (JSON)      → <param>With / <param>Without floats
+ *   feedback → farmerFeedback         images → images
+ */
+
+function intOrNull(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return null;
+    const n = parseInt(String(v).trim(), 10);
+    return Number.isFinite(n) ? n : null;
+}
+
+function floatOrNull(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return null;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : null;
+}
+
+function floatOrZero(v) {
+    const n = floatOrNull(v);
+    return n == null ? 0 : n;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nf-farmers-practicing',
+    label: 'Natural Farming — Farmer Details',
+    model: 'farmersPracticingNaturalFarming',
+    idField: 'farmersPracticingId',
+    naturalKey: ['kvkId', 'farmerName', 'villageName'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. reporting year (nullable).
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        const practicingYears = cleanText(row.practicing_year);
+
+        const data = {
+            kvkId,
+            reportingYear,
+            farmerName: decodeEntities(cleanText(row.farmer_name)) || '',
+            contactNumber: decodeEntities(cleanText(row.contact_number)) || '',
+            villageName: decodeEntities(cleanText(row.village)) || '',
+            address: decodeEntities(cleanText(row.address)) || '',
+            noOfIndigenousCows: intOrNull(row.no_of_indigenous),
+            landHolding: floatOrNull(row.land_holding),
+            normalCropsGrown: decodeEntities(cleanText(row.normal_crops_grown)),
+            practicingYearsOfNaturalFarming: practicingYears == null ? null : String(practicingYears),
+            areaCoveredUnderNaturalFarming: floatOrZero(row.area_covered),
+            cropGrownUnderNaturalFarming: decodeEntities(cleanText(row.nfr_crop_grown)) || '',
+            naturalFarmingTechnologyPracticingAdopted: decodeEntities(cleanText(row.technology)) || '',
+            ...parseNfObservation(row.observation_recorded),
+            farmerFeedback: decodeEntities(cleanText(row.feedback)) || '',
+            images: extractImgSrc(row.images),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nfFinancialInfo.js
+++ b/backend/migration/modules/nfFinancialInfo.js
@@ -1,0 +1,102 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: Natural Farming — Budget & Expenditure. Source: atariams.org
+ * `project/natural-farming/budget-expenditure` (`financial_information` table).
+ * Writes financial_information. KVK + (nullable) activity FK.
+ *
+ * Old → new:
+ *   reporting_year ("2026")  → year (Int) + reportingYearDate (Jan 1 UTC, nullable)
+ *   activity.name            → activityId (resolve on activity master; nullable)
+ *   no_of_activity           → numberOfActivities
+ *   sanction                 → budgetSanction
+ *   expenditure              → budgetExpenditure
+ *   total_expenditure        → totalBudgetExpenditure
+ */
+
+function intOrZero(v) {
+    const n = parseInt(String(v ?? '').trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nf-financial-info',
+    label: 'Natural Farming — Budget & Expenditure',
+    model: 'financialInformation',
+    idField: 'financialInformationId',
+    naturalKey: ['kvkId', 'year', 'activityId'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        activityId: { master: 'naturalFarmingActivity' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. year (REQUIRED Int) + reportingYearDate (nullable).
+        const year = parseInt(String(row.reporting_year ?? '').trim(), 10);
+        if (!Number.isInteger(year)) err('year', `Missing/invalid reporting_year "${row.reporting_year}"`);
+        const reportingYearDate = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. activity → activity master (nullable). Resolve by nested name.
+        let activityId = null;
+        const activityObj = asObject(row.activity);
+        const activityName = decodeEntities(cleanText(activityObj?.name || row['activity.name']));
+        if (activityName) {
+            const hit = await r.resolve('naturalFarmingActivityMaster', 'activityName', 'naturalFarmingActivityId', activityName);
+            if (hit.matched) activityId = hit.id;
+            else warn('activityId', `Activity "${activityName}" not in our master — left null`);
+        } else {
+            warn('activityId', 'No activity on old row — left null');
+        }
+
+        const data = {
+            kvkId,
+            year: Number.isInteger(year) ? year : 0,
+            reportingYearDate,
+            activityId,
+            numberOfActivities: intOrZero(row.no_of_activity),
+            budgetSanction: floatOrZero(row.sanction),
+            budgetExpenditure: floatOrZero(row.expenditure),
+            totalBudgetExpenditure: floatOrZero(row.total_expenditure),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nfGeographicalInfo.js
+++ b/backend/migration/modules/nfGeographicalInfo.js
@@ -1,0 +1,88 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: Natural Farming — Geographical Information. Source: atariams.org
+ * `project/natural-farming/geopgraphical-information` (`geographical_info` table).
+ * Writes geographical_info. Flat table, KVK is the only FK.
+ *
+ * Old → new:
+ *   start_date/end_date (yyyy-mm-dd) → startDate / endDate (both NOT NULL)
+ *   agro_climatic_zone               → agroClimaticZone
+ *   farming_situation                → farmingSituation
+ *   latitude / longitude             → latitude / longitude
+ *   reporting_year ("2025")          → reportingYear (Jan 1 UTC, nullable)
+ */
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nf-geographical-info',
+    label: 'Natural Farming — Geographical Info',
+    model: 'geographicalInfo',
+    idField: 'geographicalInfoId',
+    naturalKey: ['kvkId', 'startDate', 'agroClimaticZone'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. Dates (both REQUIRED).
+        const startIso = parseDate(row.start_date);
+        const endIso = parseDate(row.end_date);
+        const startDate = startIso ? new Date(startIso) : null;
+        const endDate = endIso ? new Date(endIso) : null;
+        if (!startDate) err('startDate', `Missing/invalid start_date "${row.start_date}"`);
+        if (!endDate) err('endDate', `Missing/invalid end_date "${row.end_date}"`);
+
+        // 3. reporting year ← old "reporting_year" → Jan 1 (UTC), nullable.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        const data = {
+            kvkId,
+            startDate,
+            endDate,
+            agroClimaticZone: decodeEntities(cleanText(row.agro_climatic_zone)) || '',
+            farmingSituation: decodeEntities(cleanText(row.farming_situation)) || '',
+            latitude: floatOrZero(row.latitude),
+            longitude: floatOrZero(row.longitude),
+            reportingYear,
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nfPhysicalInfo.js
+++ b/backend/migration/modules/nfPhysicalInfo.js
@@ -1,0 +1,105 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText, extractImgSrc } = require('../util.js');
+
+/**
+ * Module spec: Natural Farming — Physical Information. Source: atariams.org
+ * `project/natural-farming/physical-information` (`physical_info` table).
+ * Writes physical_info. KVK + (nullable) activity FK. No reporting_year column.
+ *
+ * Old → new:
+ *   activity.name                 → activityId (resolve by name; nullable)
+ *   program_title                 → trainingTitle
+ *   date (yyyy-mm-dd)             → trainingDate (nullable)
+ *   venue                         → venue
+ *   general_m … st_f             → demographics (all nullable)
+ *   remarks                       → remarks
+ *   significance                  → significanceOfInnovativeProgramme
+ *   images                        → images
+ * Old *_t totals + total_m/f + sub_total are derived → dropped.
+ * innovativeProgrammeName has no old field → left null.
+ */
+
+function intOrNull(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return null;
+    const n = parseInt(String(v).trim(), 10);
+    return Number.isFinite(n) ? n : null;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nf-physical-info',
+    label: 'Natural Farming — Physical Info',
+    model: 'physicalInfo',
+    idField: 'physicalInfoId',
+    naturalKey: ['kvkId', 'trainingTitle', 'trainingDate'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        activityId: { master: 'naturalFarmingActivity' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. activity → activity master (nullable). Resolve by nested name.
+        let activityId = null;
+        const activityObj = asObject(row.activity);
+        const activityName = decodeEntities(cleanText(activityObj?.name || row['activity.name']));
+        if (activityName) {
+            const hit = await r.resolve('naturalFarmingActivityMaster', 'activityName', 'naturalFarmingActivityId', activityName);
+            if (hit.matched) activityId = hit.id;
+            else warn('activityId', `Activity "${activityName}" not in our master — left null`);
+        } else {
+            warn('activityId', 'No activity on old row — left null');
+        }
+
+        // 3. training date (nullable).
+        const dateIso = parseDate(row.date);
+        const trainingDate = dateIso ? new Date(dateIso) : null;
+
+        const data = {
+            kvkId,
+            activityId,
+            trainingTitle: decodeEntities(cleanText(row.program_title)),
+            trainingDate,
+            venue: decodeEntities(cleanText(row.venue)),
+            generalM: intOrNull(row.general_m),
+            generalF: intOrNull(row.general_f),
+            obcM: intOrNull(row.obc_m),
+            obcF: intOrNull(row.obc_f),
+            scM: intOrNull(row.sc_m),
+            scF: intOrNull(row.sc_f),
+            stM: intOrNull(row.st_m),
+            stF: intOrNull(row.st_f),
+            remarks: decodeEntities(cleanText(row.remarks)),
+            innovativeProgrammeName: null,
+            significanceOfInnovativeProgramme: decodeEntities(cleanText(row.significance)),
+            images: extractImgSrc(row.images),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/nfSoilDataInfo.js
+++ b/backend/migration/modules/nfSoilDataInfo.js
@@ -1,0 +1,123 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: Natural Farming — Soil Information. Source: atariams.org
+ * `project/natural-farming/soil-information` (`soil_data_information` table).
+ * Writes soil_data_information. KVK + (nullable) season + soil-parameter FKs.
+ *
+ * Old → new:
+ *   reporting_year ("2026")          → year (Int) + reportingYearDate (Jan 1 UTC, nullable)
+ *   season.season_name               → seasonId (resolve by name; nullable)
+ *   type                             → soilParameterId (resolve by name; on miss → null + soilParameterOther)
+ *   crop_name                        → crop
+ *   before_ph/ec/oc                  → phBefore/ecBefore/ocBefore
+ *   before_n_kg_ha/p_kg_ha/k_kg_ha   → nBefore/pBefore/kBefore
+ *   before_soil_microbes             → soilMicrobesBefore
+ *   after_*                          → *After (same mapping)
+ */
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'nf-soil-data-info',
+    label: 'Natural Farming — Soil Information',
+    model: 'soilDataInformation',
+    idField: 'soilDataInformationId',
+    naturalKey: ['kvkId', 'year', 'crop'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        seasonId: { master: 'season' },
+        soilParameterId: { master: 'naturalFarmingSoilParameter' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+        const kvkId = ctx.kvkId;
+
+        // 2. year (REQUIRED Int) + reportingYearDate (nullable).
+        const year = parseInt(String(row.reporting_year ?? '').trim(), 10);
+        if (!Number.isInteger(year)) err('year', `Missing/invalid reporting_year "${row.reporting_year}"`);
+        const reportingYearDate = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // 3. season → resolve by nested name (nullable).
+        let seasonId = null;
+        const seasonObj = asObject(row.season);
+        const seasonName = decodeEntities(cleanText(seasonObj?.season_name || row['season.season_name']));
+        if (seasonName) {
+            const hit = await r.resolve('season', 'seasonName', 'seasonId', seasonName);
+            if (hit.matched) seasonId = hit.id;
+            else warn('seasonId', `Season "${seasonName}" not in our master — left null`);
+        } else {
+            warn('seasonId', 'No season on old row — left null');
+        }
+
+        // 4. soil parameter → resolve `type` by name; on miss park raw in soilParameterOther.
+        let soilParameterId = null;
+        let soilParameterOther = null;
+        const typeRaw = decodeEntities(cleanText(row.type));
+        if (typeRaw) {
+            const hit = await r.resolve('naturalFarmingSoilParameterMaster', 'parameterName', 'naturalFarmingSoilParameterId', typeRaw);
+            if (hit.matched) soilParameterId = hit.id;
+            else { soilParameterOther = typeRaw; warn('soilParameterId', `Soil parameter "${typeRaw}" not in master — parked in soilParameterOther`); }
+        }
+
+        const data = {
+            kvkId,
+            year: Number.isInteger(year) ? year : 0,
+            reportingYearDate,
+            crop: decodeEntities(cleanText(row.crop_name)) || '',
+            seasonId,
+            soilParameterId,
+            soilParameterOther,
+            phBefore: floatOrZero(row.before_ph),
+            ecBefore: floatOrZero(row.before_ec),
+            ocBefore: floatOrZero(row.before_oc),
+            nBefore: floatOrZero(row.before_n_kg_ha),
+            pBefore: floatOrZero(row.before_p_kg_ha),
+            kBefore: floatOrZero(row.before_k_kg_ha),
+            soilMicrobesBefore: floatOrZero(row.before_soil_microbes),
+            phAfter: floatOrZero(row.after_ph),
+            ecAfter: floatOrZero(row.after_ec),
+            ocAfter: floatOrZero(row.after_oc),
+            nAfter: floatOrZero(row.after_n_kg_ha),
+            pAfter: floatOrZero(row.after_p_kg_ha),
+            kAfter: floatOrZero(row.after_k_kg_ha),
+            soilMicrobesAfter: floatOrZero(row.after_soil_microbes),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -54,6 +54,13 @@ const specs = [
     require('./modules/nicraConvergenceProgramme.js'),
     require('./modules/nicraDignitariesVisited.js'),
     require('./modules/nicraPiCopi.js'),
+    require('./modules/nfGeographicalInfo.js'),
+    require('./modules/nfPhysicalInfo.js'),
+    require('./modules/nfDemonstrationInfo.js'),
+    require('./modules/nfFarmersPracticing.js'),
+    require('./modules/nfBeneficiariesDetails.js'),
+    require('./modules/nfSoilDataInfo.js'),
+    require('./modules/nfFinancialInfo.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));

--- a/backend/migration/util.js
+++ b/backend/migration/util.js
@@ -76,6 +76,55 @@ function stripHtml(value) {
     return String(value).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
+/**
+ * Natural-farming "observation_recorded" is an entity-encoded JSON array of
+ * {parameter, with_nf, without_nf}. Both the demonstration and farmer-practicing
+ * tables store the same 15-parameter shape; the new models split each into
+ * `<base>With` / `<base>Without` Float columns. Maps each old parameter label to
+ * its column base; values "N/A"/blank → null.
+ * @returns {Object} e.g. { plantHeightWith: 87.4, plantHeightWithout: 89.9, … }
+ */
+const NF_OBSERVATION_FIELD_MAP = {
+    'Plant height (cm)': 'plantHeight',
+    'Other relevant parameter': 'otherRelevantParameter',
+    'Yield (q/ha)': 'yield',
+    'Cost of cultivation (Rs/ha)': 'cost',
+    'Gross Return (Rs/ha)': 'grossReturn',
+    'Net Return (Rs/ha)': 'netReturn',
+    'B:C Ratio': 'bcRatio',
+    'Soil PH': 'soilPh',
+    'Soil OC (%)': 'soilOc',
+    'Soil EC (dS/m)': 'soilEc',
+    'Available N (Kg/ha)': 'availableN',
+    'Available P (Kg/ha)': 'availableP',
+    'Available K (Kg/ha)': 'availableK',
+    'Soil Microbes (cfu)': 'soilMicrobes',
+    'Any other, specify': 'anyOther',
+};
+
+function nfFloatOrNull(v) {
+    if (v == null) return null;
+    const s = String(v).trim();
+    if (!s || s.toLowerCase() === 'n/a') return null;
+    const n = parseFloat(s);
+    return Number.isFinite(n) ? n : null;
+}
+
+function parseNfObservation(raw) {
+    const out = {};
+    if (raw == null) return out;
+    let arr;
+    try { arr = JSON.parse(decodeEntities(String(raw))); } catch { return out; }
+    if (!Array.isArray(arr)) return out;
+    for (const item of arr) {
+        const base = NF_OBSERVATION_FIELD_MAP[String(item?.parameter ?? '').trim()];
+        if (!base) continue;
+        out[`${base}With`] = nfFloatOrNull(item.with_nf);
+        out[`${base}Without`] = nfFloatOrNull(item.without_nf);
+    }
+    return out;
+}
+
 module.exports = {
     parseDate,
     parseYearMonth,
@@ -84,4 +133,5 @@ module.exports = {
     cleanText,
     toBool,
     stripHtml,
+    parseNfObservation,
 };


### PR DESCRIPTION
## Summary

Adds **7 Natural Farming** migration-tool modules pulling data from the old `atariams.org` site into the new app DB. Target Prisma models already exist (live forms under *Achievements › Projects › Natural Farming*); this wires up the migration specs.

| Module key | Old endpoint | Target model |
|---|---|---|
| `nf-geographical-info` | `/natural-farming/geopgraphical-information` | `GeographicalInfo` |
| `nf-physical-info` | `/natural-farming/physical-information` | `PhysicalInfo` |
| `nf-demonstration-info` | `/natural-farming/demonstration-details` | `DemonstrationInfo` |
| `nf-farmers-practicing` | `/natural-farming/farmer-details` | `FarmersPracticingNaturalFarming` |
| `nf-beneficiaries-details` | `/natural-farming/beneficiaries-details` | `BeneficiariesDetails` |
| `nf-soil-data-info` | `/natural-farming/soil-information` | `SoilDataInformation` |
| `nf-financial-info` | `/natural-farming/budget-expenditure` | `FinancialInformation` |

## Details
- Standard project-module conventions: KVK-name guard, `parseDate`, `decodeEntities`/`cleanText`, demographics ints, reporting-year handling.
- **Shared helper** `parseNfObservation()` (in `util.js`): old `observation_recorded` is an entity-encoded JSON array of 15 `{parameter, with_nf, without_nf}` rows; splits each into the new `<base>With` / `<base>Without` float columns (`N/A`/blank → null). Used by both demonstration + farmer-practicing.
- FK resolution by name against seeded masters (`naturalFarmingActivity`, `naturalFarmingSoilParameter`, `season`); both added to `masterCatalog.js` for the pickers.
- Soil `type` resolves to `soilParameterId`; on miss it parks the raw text in `soilParameterOther` (nullable escape).
- Demonstration enums: `gender` (male/female → MALE/FEMALE) and `category` (general/obc/sc/st → GENERAL/OBC/SC/ST); unknown → default + warn.
- Year-only models (beneficiaries, soil, financial) set both `year` (Int) and `reportingYearDate` (Jan-1 UTC) from the old `reporting_year`.

## Testing
- Registry loads; all 7 Prisma accessors + 2 NF masters resolve.
- Dry-ran each `transform` against live sample rows from every endpoint: **0 errors, 0 warnings**; observation parameters split correctly, enums mapped, `N/A` → null.

## Caveat
- Demonstration `start_date`/`end_date` are full Laravel UTC timestamps (`...T18:30:00Z` = IST midnight). `parseDate` keeps the UTC date-part → 1-day-earlier calendar date. Consistent with tool-wide date handling; eyeball in the preview before seeding.