### PR TITLE
fix(forms): allow decimals on natural-farming measurement fields

### DIFF
--- a/backend/middleware/validateFormRobustness.js
+++ b/backend/middleware/validateFormRobustness.js
@@ -67,7 +67,17 @@ function shouldAllowDecimal(key) {
         // soil params
         k.includes('ph') ||
         k.includes('ec') ||
-        k.includes('oc')
+        k.includes('oc') ||
+        // Natural-farming observation comparisons — every with_/without_ (and the
+        // _practicing_ variants) field is a scientific reading that can be fractional
+        // (plant height, available N/P/K, soluble salt, microbes, …).
+        k.startsWith('with_') ||
+        k.startsWith('without_') ||
+        // soil microbe / microbial counts (e.g. ×10^n cfu) can be fractional
+        k.includes('microbe') ||
+        k.includes('microbial') ||
+        // soil-information before/after available N/P/K readings (beforeN, afterK, …)
+        /^(before|after)[npk]$/.test(k)
     );
 }
 


### PR DESCRIPTION
## Problem

Submitting Natural Farming forms (demonstration / farmer-practicing observations, soil information) failed with e.g.:

> Field "without_solubleSalt" must be a whole number

even though the DB columns are floats (the same values seed fine via the migration tool). The `validateFormRobustness` middleware's `shouldAllowDecimal` heuristic didn't recognise these field names, so decimals were rejected.

## Fix

Extend `shouldAllowDecimal` (`backend/middleware/validateFormRobustness.js`) to allow decimals for:
- any `with_` / `without_` field (covers all NF observation comparisons incl. the `_practicing_` variants — plant height, available N/P/K, soluble salt, microbes, …)
- `microbe` / `microbial` counts (soil microbes, ×10ⁿ cfu)
- soil-information before/after N/P/K readings (`beforeN`, `afterK`, …) via `/^(before|after)[npk]$/`

`0` and other whole numbers continue to pass everywhere. True integer fields (demographics like `generalM`, etc.) still reject decimals.

## Testing
Unit-checked the middleware directly:
- `0.5` on `without_solubleSalt`, `with_plantHeight`, `without_practicing_soilMicrobes`, `with_availableN`, `beforeN`, `afterK`, `beforeMicrobes` → **pass**
- `0` on `generalM` → pass
- `0.5` on `generalM` → still rejected (`must be a whole number`)