### PR TITLE
feat(migration): agri-drone/seed-hub/other-programme modules + FLD year filter fix

### DIFF
--- a/backend/migration/masterCatalog.js
+++ b/backend/migration/masterCatalog.js
@@ -48,6 +48,9 @@ const MASTER_CATALOG = {
     kvkEquipment: { model: 'kvkEquipment', idField: 'equipmentId', nameField: 'equipmentName' },
     kvkStaff: { model: 'kvkStaff', idField: 'kvkStaffId', nameField: 'staffName' },
     season: { model: 'season', idField: 'seasonId', nameField: 'seasonName' },
+    district: { model: 'districtMaster', idField: 'districtId', nameField: 'districtName' },
+    // The parent agri drone, used by the agri-drone-demonstration FK picker.
+    agriDrone: { model: 'kvkAgriDrone', idField: 'agriDroneId', nameField: 'pilotName' },
     oftSubject: { model: 'oftSubject', idField: 'oftSubjectId', nameField: 'subjectName' },
     oftThematicArea: {
         model: 'oftThematicArea',

--- a/backend/migration/modules/agriDrone.js
+++ b/backend/migration/modules/agriDrone.js
@@ -1,0 +1,107 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: Agri Drone (introduction). Source: atariams.org
+ * `project/agri-drone` (`kvk_agri_drone` table). Flat table, KVK only FK.
+ *
+ * The old list JSON only carries a subset of columns; the new model has many
+ * NOT-NULL columns that the list never exposes (cost_per_drone, target_area,
+ * demo amounts, operation_type, advantages, pilot_contact, project centre).
+ * Mirror the natural-farming modules: default missing required text → '' and
+ * required numbers → 0 so the row still seeds.
+ *
+ * Old → new:
+ *   kvk.kvk_name             → kvkId (match against selected KVK)
+ *   pic_name                 → pilotName
+ *   company                  → droneCompany
+ *   model                    → droneModel
+ *   agri_drone_sanctioned    → dronesSanctioned
+ *   agri_drone_purchased     → dronesPurchased
+ *   amount_sanctioned        → amountSanctioned
+ *   reporting_year ("2026")  → reportingYear (Jan 1 UTC, nullable)
+ */
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function intOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseInt(String(v).trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'agri-drone',
+    label: 'Agri Drone',
+    model: 'kvkAgriDrone',
+    idField: 'agriDroneId',
+    naturalKey: ['kvkId', 'reportingYear', 'pilotName'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+
+        // 2. reporting year ← "reporting_year" → Jan 1 (UTC), nullable.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        const pilotName = decodeEntities(cleanText(row.pic_name)) || '';
+        const droneCompany = decodeEntities(cleanText(row.company)) || '';
+        const droneModel = decodeEntities(cleanText(row.model)) || '';
+
+        // Columns absent from the old list — defaulted so the NOT-NULL row seeds.
+        warn('*', 'Old list lacks cost_per_drone/target_area/demo amounts/operation_type/advantages/pilot_contact/project_implementing_centre — defaulted to 0/empty');
+
+        const data = {
+            kvkId: ctx.kvkId,
+            projectImplementingCentre: '',
+            dronesSanctioned: intOrZero(row.agri_drone_sanctioned),
+            dronesPurchased: intOrZero(row.agri_drone_purchased),
+            amountSanctioned: floatOrZero(row.amount_sanctioned),
+            costPerDrone: 0,
+            droneCompany,
+            droneModel,
+            pilotName,
+            pilotContact: '',
+            targetAreaHa: 0,
+            demoAmountSanctioned: 0,
+            demoAmountUtilised: 0,
+            operationType: '',
+            advantagesObserved: '',
+            reportingYear,
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/agriDroneDemonstration.js
+++ b/backend/migration/modules/agriDroneDemonstration.js
@@ -1,0 +1,138 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: Agri Drone — Demonstration Details. Source: atariams.org
+ * `project/demonstration-details` (`kvk_agri_drone_demonstration` table).
+ *
+ * Each detail links to a PARENT Agri Drone (kvk_agri_drone) that must already be
+ * migrated — agriDroneId is resolved from OUR db by kvkId + pilotName
+ * (agri_drone.pic_name). Run the Agri Drone module first.
+ *
+ * Old → new:
+ *   agri_drone.kvk.kvk_name → kvkId (match against selected KVK)
+ *   agri_drone.pic_name     → agriDroneId (parent lookup by kvkId+pilotName)
+ *   district.district_name  → districtId (DistrictMaster, nullable)
+ *   date                    → dateOfDemonstration
+ *   place                   → placeOfDemonstration
+ *   crop_name               → cropName
+ *   no_of_demo              → noOfDemos
+ *   area                    → areaHa
+ *   total                   → noOfFarmers
+ *   reporting_year ("2024") → reportingYear (Jan 1 UTC, nullable)
+ *
+ * Gender breakdown + demonstrations_on are not on the old list — left null.
+ */
+
+function floatOrNull(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return null;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : null;
+}
+
+function intOrNull(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return null;
+    const n = parseInt(String(v).trim(), 10);
+    return Number.isFinite(n) ? n : null;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'agri-drone-demonstration',
+    label: 'Agri Drone — Demonstration Details',
+    model: 'kvkAgriDroneDemonstration',
+    idField: 'agriDroneDemonstrationId',
+    naturalKey: ['agriDroneId', 'reportingYear', 'dateOfDemonstration'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        agriDroneId: { master: 'agriDrone' },
+        districtId: { master: 'district' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match (from nested agri_drone.kvk.kvk_name).
+        const agriDroneObj = asObject(row.agri_drone) || {};
+        const kvkObj = asObject(agriDroneObj.kvk) || {};
+        const oldKvkName =
+            decodeEntities(
+                cleanText(
+                    kvkObj.kvk_name ||
+                    row['agri_drone.kvk.kvk_name'] ||
+                    '',
+                ),
+            ) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+
+        // 2. Resolve parent Agri Drone by kvkId + pilotName (must be migrated first).
+        const pilotName = decodeEntities(
+            cleanText(agriDroneObj.pic_name || row['agri_drone.pic_name'] || ''),
+        ) || '';
+        let agriDroneId = null;
+        if (pilotName) {
+            agriDroneId = await r.findId(
+                'kvkAgriDrone',
+                { kvkId: ctx.kvkId, pilotName },
+                'agriDroneId',
+            );
+        }
+        if (!agriDroneId) {
+            err('agriDroneId', `Parent Agri Drone (pilot "${pilotName || '?'}") not found — migrate Agri Drone first`);
+        }
+
+        // 3. District → DistrictMaster (nullable).
+        let districtId = null;
+        const districtObj = asObject(row.district) || {};
+        const districtName = decodeEntities(
+            cleanText(districtObj.district_name || row['district.district_name'] || ''),
+        ) || '';
+        if (districtName) {
+            const d = await r.resolve('districtMaster', 'districtName', 'districtId', districtName);
+            if (d.matched) districtId = d.id;
+            else warn('districtId', `District "${districtName}" not found in master — left null`);
+        }
+
+        // 4. reporting year ← "reporting_year" → Jan 1 (UTC), nullable.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        const dateIso = parseDate(row.date);
+
+        const data = {
+            kvkId: ctx.kvkId,
+            agriDroneId,
+            reportingYear,
+            districtId,
+            dateOfDemonstration: dateIso ? new Date(dateIso) : null,
+            placeOfDemonstration: decodeEntities(cleanText(row.place)) || null,
+            cropName: decodeEntities(cleanText(row.crop_name)) || null,
+            noOfDemos: intOrNull(row.no_of_demo),
+            areaHa: floatOrNull(row.area),
+            noOfFarmers: intOrNull(row.total),
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/otherProgramme.js
+++ b/backend/migration/modules/otherProgramme.js
@@ -1,0 +1,84 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: Any other programme organized by KVK (not covered elsewhere).
+ * Source: atariams.org `project/other-program` (`kvk_other_programme` table).
+ * Flat table, KVK only FK. No reporting_year column on the new model — the old
+ * reporting_year query param only filters the source list.
+ *
+ * The old list carries only a single `total` participant count; the new model
+ * stores a caste/gender breakdown (all NOT-NULL Int). The breakdown isn't on the
+ * list — default each to 0 so the row seeds.
+ *
+ * Old → new:
+ *   kvk.kvk_name → kvkId (match against selected KVK)
+ *   name         → programmeName
+ *   date         → programmeDate (REQUIRED)
+ *   venue        → venue
+ *   purpose      → purpose
+ */
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'other-programme',
+    label: 'Other KVK Programme',
+    model: 'kvkOtherProgramme',
+    idField: 'kvkOtherProgrammeId',
+    naturalKey: ['kvkId', 'programmeName', 'programmeDate'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+        const err = (f, m) => issues.push({ field: f, message: m, severity: 'error' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+
+        // 2. programmeDate (REQUIRED — no default).
+        const dateIso = parseDate(row.date);
+        if (!dateIso) err('programmeDate', `Missing/invalid date "${row.date}"`);
+
+        // Caste/gender breakdown not on the old list — defaulted (total "${row.total}" not stored).
+        warn('*', `Old list has only a single total ("${row.total ?? ''}") — caste/gender breakdown defaulted to 0`);
+
+        const data = {
+            kvkId: ctx.kvkId,
+            programmeName: decodeEntities(cleanText(row.name)) || '',
+            programmeDate: dateIso ? new Date(dateIso) : null,
+            venue: decodeEntities(cleanText(row.venue)) || '',
+            purpose: decodeEntities(cleanText(row.purpose)) || '',
+            farmersGeneralM: 0,
+            farmersGeneralF: 0,
+            farmersObcM: 0,
+            farmersObcF: 0,
+            farmersScM: 0,
+            farmersScF: 0,
+            farmersStM: 0,
+            farmersStF: 0,
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/modules/seedHubProgram.js
+++ b/backend/migration/modules/seedHubProgram.js
@@ -1,0 +1,107 @@
+const { normalize } = require('../masterResolver.js');
+const { parseDate, decodeEntities, cleanText } = require('../util.js');
+
+/**
+ * Module spec: Seed Hub Program. Source: atariams.org
+ * `project/seed-hub-program` (`kvk_seed_hub_program` table). Flat, KVK + Season FK.
+ *
+ * The old list JSON only carries crop/variety/area/yield + season; the new model
+ * has many NOT-NULL quantity/amount columns the list never exposes. Mirror the
+ * natural-farming modules: default missing required numbers → 0 so the row seeds.
+ *
+ * Old → new:
+ *   kvk.kvk_name               → kvkId (match against selected KVK)
+ *   season_detail.season_name  → seasonId (Season master, nullable)
+ *   crop_name                  → cropName
+ *   variety                    → varietyName
+ *   area                       → areaCoveredHa
+ *   yield                      → yieldQPerHa
+ *   reporting_year ("2025")    → reportingYear (Jan 1 UTC, nullable)
+ */
+
+function floatOrZero(v) {
+    if (v === null || v === undefined || String(v).trim() === '') return 0;
+    const n = parseFloat(String(v).trim());
+    return Number.isFinite(n) ? n : 0;
+}
+
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch { return null; }
+    }
+    return null;
+}
+
+module.exports = {
+    key: 'seed-hub-program',
+    label: 'Seed Hub Program',
+    model: 'kvkSeedHubProgram',
+    idField: 'seedHubId',
+    naturalKey: ['kvkId', 'reportingYear', 'seasonId', 'cropName'],
+
+    foreignKeys: {
+        kvkId: { master: 'kvk' },
+        seasonId: { master: 'season' },
+    },
+
+    async transform(row, ctx) {
+        const issues = [];
+        const r = ctx.resolver;
+        const warn = (f, m) => issues.push({ field: f, message: m, severity: 'warn' });
+
+        // 1. KVK match.
+        const kvkObj = asObject(row.kvk);
+        const oldKvkName = decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+        if (!oldKvkName) {
+            warn('kvkId', 'KVK name not in row — using selected target KVK');
+        } else if (normalize(oldKvkName) !== normalize(ctx.targetKvkName || '')) {
+            return {
+                data: null,
+                issues: [{ field: 'kvkId', message: `Row KVK "${oldKvkName}" ≠ selected "${ctx.targetKvkName}" — skipped`, severity: 'warn' }],
+            };
+        }
+
+        // 2. Season → Season master (nullable). Old data path is season_detail.season_name.
+        let seasonId = null;
+        const seasonObj = asObject(row.season_detail) || asObject(row.season) || {};
+        const seasonName = decodeEntities(
+            cleanText(seasonObj.season_name || row['season_detail.season_name'] || row['season.season_name'] || ''),
+        ) || '';
+        if (seasonName) {
+            const s = await r.resolve('season', 'seasonName', 'seasonId', seasonName);
+            if (s.matched) seasonId = s.id;
+            else warn('seasonId', `Season "${seasonName}" not found in master — left null`);
+        }
+
+        // 3. reporting year ← "reporting_year" → Jan 1 (UTC), nullable.
+        const reportingYear = (() => {
+            const iso = parseDate(String(row.reporting_year ?? ''));
+            return iso ? new Date(iso) : null;
+        })();
+
+        // Columns absent from the old list — defaulted so the NOT-NULL row seeds.
+        warn('*', 'Old list lacks quantity/sale/farmers/villages/amount columns — defaulted to 0');
+
+        const data = {
+            kvkId: ctx.kvkId,
+            seasonId,
+            cropName: decodeEntities(cleanText(row.crop_name)) || '',
+            varietyName: decodeEntities(cleanText(row.variety)) || '',
+            areaCoveredHa: floatOrZero(row.area),
+            yieldQPerHa: floatOrZero(row.yield),
+            quantityProducedQ: 0,
+            quantitySaleOutQ: 0,
+            farmersPurchased: 0,
+            quantitySaleToFarmersQ: 0,
+            villagesCovered: 0,
+            quantitySaleToOtherOrgQ: 0,
+            amountGeneratedLakh: 0,
+            totalAmountPresentLakh: 0,
+            reportingYear,
+        };
+
+        return { data, issues };
+    },
+};

--- a/backend/migration/registry.js
+++ b/backend/migration/registry.js
@@ -61,6 +61,10 @@ const specs = [
     require('./modules/nfBeneficiariesDetails.js'),
     require('./modules/nfSoilDataInfo.js'),
     require('./modules/nfFinancialInfo.js'),
+    require('./modules/agriDrone.js'),
+    require('./modules/agriDroneDemonstration.js'),
+    require('./modules/seedHubProgram.js'),
+    require('./modules/otherProgramme.js'),
 ];
 
 const byKey = new Map(specs.map(s => [s.key, s]));

--- a/frontend/src/pages/dashboard/shared/forms/OftFldForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/OftFldForms.tsx
@@ -258,10 +258,19 @@ export const OftFldForms: React.FC<OftFldFormsProps> = ({
         const match = text.match(/^(\d{4})/)
         return match ? Number(match[1]) : null
     }
+    // The FLD "belongs" to its START YEAR (what the FLD list grid shows),
+    // not its expectedCompletionDate (which is required and often a later
+    // year). Prefer the precomputed numeric startYear, then fall back to
+    // raw dates. startYear is already a year number, so don't run it
+    // through getYearValue (new Date(2025) would resolve to 1970).
+    const getFldYear = (f: any): number | null => {
+        if (f?.startYear != null) return Number(f.startYear)
+        return getYearValue(f?.startDate ?? f?.expectedCompletionDate ?? f?.reportingYear)
+    }
     const fldOptionsByKvkAndYear = useMemo(() => {
         return (fldList as any[]).filter((f: any) => {
             const fldKvkId = f.kvkId ?? f.kvk?.kvkId
-            const fldYear = getYearValue(f.expectedCompletionDate ?? f.startDate ?? f.reportingYear)
+            const fldYear = getFldYear(f)
             const selectedYear = getYearValue(selectedReportingYear)
             const kvkMatch = activeKvkId ? Number(fldKvkId) === Number(activeKvkId) : true
             const yearMatch = selectedYear ? Number(fldYear) === Number(selectedYear) : false
@@ -384,7 +393,7 @@ export const OftFldForms: React.FC<OftFldFormsProps> = ({
         return (fldList as any[])
             .filter((f: any) => {
                 const fldKvkId = f.kvkId ?? f.kvk?.kvkId
-                const fldYear = getYearValue(f.expectedCompletionDate ?? f.startDate ?? f.reportingYear)
+                const fldYear = getFldYear(f)
                 return Number(fldKvkId) === kvkId && Number(fldYear) === reportingYear
             })
             .map((f: any) => ({


### PR DESCRIPTION
## Migration tool — 4 new modules

| Module | key | Target table |
|---|---|---|
| Agri Drone | `agri-drone` | `kvk_agri_drone` |
| Agri Drone — Demonstration Details | `agri-drone-demonstration` | `kvk_agri_drone_demonstration` |
| Seed Hub Program | `seed-hub-program` | `kvk_seed_hub_program` |
| Other KVK Programme | `other-programme` | `kvk_other_programme` |

- `agri-drone-demonstration` is a **child** of `agri-drone` — resolves parent `agriDroneId` by `kvkId + pilotName`. **Run Agri Drone first.**
- Old list JSON exposes only a subset of columns; missing NOT-NULL columns default to `''`/`0`, each row carries a `*` warn naming them.
- KVK-name guard skips rows not matching the selected target KVK; `reporting_year` → Jan 1 UTC.
- `registry.js`: 4 specs registered (auto-surface in UI dropdown).
- `masterCatalog.js`: added `district` (DistrictMaster) + `agriDrone` (parent) FK pickers.

### Caveats (source-data limits)
- `other-programme`: old list has only a single `total` → caste/gender breakdown defaulted to 0; `date` required (errors if missing).
- Demonstration parent match keys on pilot name; shared pilot → picks first.

## FLD extension-training — year filter fix

The FLD dropdown filtered by `expectedCompletionDate` (required, often a *later* year), so FLDs whose **START YEAR** matched the selected activity year were hidden → "No FLD available for date \<year\>". Added `getFldYear()` preferring the numeric `startYear` (the grid's START YEAR), falling back to `startDate` → `expectedCompletionDate` → `reportingYear`. Applied to both filter spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)