### PR TITLE
fix(equipment): parent-record FK + inherited funding, full-column fil…

### DIFF
--- a/backend/migration/modules/equipmentDetails.js
+++ b/backend/migration/modules/equipmentDetails.js
@@ -10,9 +10,9 @@ module.exports = {
     naturalKey: ['equipmentId', 'reportingYear'],
 
     foreignKeys: {
-        equipmentId: { master: 'equipmentMaster' },
+        equipmentId: { master: 'kvkEquipment' },
         equipmentStatusId: { master: 'equipmentStatus' },
-        assetFundingSourceId: { master: 'assetFundingSource' },
+        // assetFundingSourceId is inherited from the parent equipment, not picked.
     },
 
     async transform(row, ctx) {
@@ -41,6 +41,12 @@ module.exports = {
         const kvkId = ctx.kvkId;
 
         // ── Resolve parent KvkEquipment (must be migrated first) ──────────
+        // kvk_equipment_detail.equipment_id is a FK to KvkEquipment (the per-KVK
+        // parent record), NOT to EquipmentMaster. So resolve the parent record's
+        // autoincrement id for THIS kvk by the old equipment name, mirroring how
+        // vehicle-details resolves its parent vehicle. The Equipment module stores
+        // the old raw name as companyBrandModel (and a curated name as
+        // equipmentName), so try both. Run the Equipment module first.
         const equipmentName = decodeEntities(
             cleanText(
                 row.equipment?.equipment_name ||
@@ -48,30 +54,25 @@ module.exports = {
                 '',
             ),
         );
-        // The OLD site has only two equipment masters: type + equipment. Those old
-        // equipment names were loaded into our (temporary) equipment_model_master,
-        // each pointing at a curated EquipmentMaster. So resolve the raw detail name
-        // → equipment_model row → its equipmentMasterId, and use THAT as equipmentId.
-        // Fallback: the name may already equal an EquipmentMaster name directly.
         let equipmentId = null;
         if (equipmentName) {
-            const model = await r.resolve('equipmentModelMaster', 'name', 'equipmentModelId', equipmentName);
-            if (model.matched) {
-                const modelRow = await prisma.equipmentModelMaster.findUnique({
-                    where: { equipmentModelId: model.id },
-                    select: { equipmentMasterId: true },
-                });
-                equipmentId = modelRow?.equipmentMasterId ?? null;
+            equipmentId = await r.findId(
+                'kvkEquipment',
+                { kvkId, companyBrandModel: equipmentName },
+                'equipmentId',
+            );
+            if (!equipmentId) {
+                equipmentId = await r.findId(
+                    'kvkEquipment',
+                    { kvkId, equipmentName },
+                    'equipmentId',
+                );
             }
             if (!equipmentId) {
-                const em = await r.resolve('equipmentMaster', 'name', 'equipmentMasterId', equipmentName);
-                if (em.matched) equipmentId = em.id;
-            }
-            if (!equipmentId) {
-                err('equipmentId', `Equipment "${equipmentName}" not found in equipment_model/equipment master`);
+                err('equipmentId', `Parent equipment "${equipmentName}" not found for this KVK — migrate Equipment first`);
             }
         } else {
-            err('equipmentId', 'Missing equipment.equipment_name — cannot resolve equipment');
+            err('equipmentId', 'Missing equipment.equipment_name — cannot resolve parent equipment');
         }
 
         // ── Reporting year ────────────────────────────────────────────────
@@ -105,17 +106,18 @@ module.exports = {
             err('equipmentStatusId', 'equipmentStatusId required — no present_status on row');
         }
 
-        // ── Source of fund → AssetFundingSourceMaster (find-or-create) ──────
-        // Old site stores "no source" as 0 — map that (and empty) to the "-" master.
+        // ── Source of fund → inherited from the PARENT equipment ───────────
+        // The detail's funding source is not captured separately; it always
+        // mirrors the parent KvkEquipment's assetFundingSourceId. Pull it from the
+        // parent record we resolved above (the old row's own source_of_fund is
+        // ignored on purpose).
         let assetFundingSourceId = null;
-        let rawFunding = decodeEntities(cleanText(row.source_of_fund || ''));
-        if (!rawFunding || rawFunding === '0') rawFunding = '-';
-        if (rawFunding) {
-            const fs = await r.findOrCreate('assetFundingSourceMaster', 'name', 'assetFundingSourceId', rawFunding);
-            if (fs.id) {
-                assetFundingSourceId = fs.id;
-                if (fs.created) warn('assetFundingSourceId', `Created funding source "${rawFunding}"`);
-            }
+        if (equipmentId) {
+            const parent = await prisma.kvkEquipment.findUnique({
+                where: { equipmentId },
+                select: { assetFundingSourceId: true },
+            });
+            assetFundingSourceId = parent?.assetFundingSourceId ?? null;
         }
 
         return {

--- a/backend/repositories/forms/aboutKvkRepository.js
+++ b/backend/repositories/forms/aboutKvkRepository.js
@@ -997,13 +997,20 @@ async function create(entityName, data) {
     if (entityName === 'kvk-equipment-details') {
         const parsedReportingYear = parseReportingYearDate(sanitizedData.reportingYear);
         ensureNotFutureDate(parsedReportingYear);
+        const equipmentId = sanitizeInteger(sanitizedData.equipmentId);
+        // Funding source is never taken from the client — it always mirrors the
+        // parent equipment's source of funding.
+        const parentEquip = equipmentId != null
+            ? await prisma.kvkEquipment.findUnique({
+                where: { equipmentId },
+                select: { assetFundingSourceId: true },
+            })
+            : null;
         const finalData = {
             kvkId: sanitizeInteger(sanitizedData.kvkId),
-            equipmentId: sanitizeInteger(sanitizedData.equipmentId),
+            equipmentId,
             reportingYear: parsedReportingYear,
-            assetFundingSourceId: sanitizedData.assetFundingSourceId != null
-                ? sanitizeInteger(sanitizedData.assetFundingSourceId)
-                : null,
+            assetFundingSourceId: parentEquip?.assetFundingSourceId ?? null,
             equipmentStatusId: sanitizeInteger(sanitizedData.equipmentStatusId),
         };
 
@@ -1140,12 +1147,26 @@ async function update(entityName, id, data) {
             ensureNotFutureDate(parsedReportingYear);
             finalUpdateData.reportingYear = parsedReportingYear;
         }
-        if (sanitizedData.assetFundingSourceId !== undefined) {
-            finalUpdateData.assetFundingSourceId = sanitizedData.assetFundingSourceId == null
-                ? null
-                : sanitizeInteger(sanitizedData.assetFundingSourceId);
-        }
         if (sanitizedData.equipmentStatusId !== undefined) finalUpdateData.equipmentStatusId = sanitizeInteger(sanitizedData.equipmentStatusId);
+
+        // Funding source is never taken from the client — it always mirrors the
+        // parent equipment. Recompute from the effective equipmentId (the updated
+        // one, or the existing record's if equipment isn't being changed).
+        let effectiveEquipmentId = finalUpdateData.equipmentId;
+        if (effectiveEquipmentId == null) {
+            const existing = await prisma.kvkEquipmentDetail.findUnique({
+                where: { [config.idField]: resolvedId },
+                select: { equipmentId: true },
+            });
+            effectiveEquipmentId = existing?.equipmentId ?? null;
+        }
+        if (effectiveEquipmentId != null) {
+            const parentEquip = await prisma.kvkEquipment.findUnique({
+                where: { equipmentId: effectiveEquipmentId },
+                select: { assetFundingSourceId: true },
+            });
+            finalUpdateData.assetFundingSourceId = parentEquip?.assetFundingSourceId ?? null;
+        }
 
         return executePrismaWrite(entityName, 'update', async () => {
             return await prisma[config.model].update({
@@ -1493,8 +1514,11 @@ async function getEquipmentsForDropdown(kvkId, reportingYear) {
             identifierCode: true,
             equipmentTypeId: true,
             equipmentMasterId: true,
+            // Equipment Details inherits its funding source from the equipment.
+            assetFundingSourceId: true,
             equipmentType: { select: { equipmentTypeId: true, name: true } },
             equipmentMaster: { select: { equipmentMasterId: true, name: true } },
+            assetFundingSource: { select: { assetFundingSourceId: true, name: true } },
         },
         orderBy: [{ equipmentTypeId: 'asc' }, { equipmentMasterId: 'asc' }, { equipmentName: 'asc' }],
     });

--- a/frontend/src/hooks/useOtherMastersData.ts
+++ b/frontend/src/hooks/useOtherMastersData.ts
@@ -537,8 +537,11 @@ export function useEquipmentMasters() {
     const queryClient = useQueryClient();
 
     const query = useQuery({
-        queryKey: ['equipment-masters'],
-        queryFn: () => otherMastersApi.getEquipmentMasters().then((res) => res.data),
+        // No-arg list endpoint caps at the backend default (100), which can drop
+        // whole equipment types from dependent dropdowns. Request the full set —
+        // these master tables are small.
+        queryKey: ['equipment-masters', 'all'],
+        queryFn: () => otherMastersApi.getEquipmentMasters({ limit: 5000 }).then((res) => res.data),
         staleTime: 5 * 60 * 1000,
     });
 

--- a/frontend/src/pages/dashboard/shared/DataManagementView.tsx
+++ b/frontend/src/pages/dashboard/shared/DataManagementView.tsx
@@ -238,6 +238,22 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
         | { total: number; totalPages: number }
         | undefined
 
+    // Server-paginated masters only return the current page, so search and the
+    // column-filter value lists would be limited to those ~10 rows. These master
+    // tables are small, so also fetch the WHOLE dataset and run the normal
+    // client-side pipeline (search + column filters + their unique-value lists +
+    // pagination) over it. Falls back to the server page until the full set loads.
+    const fullDataHook = useEntityHook(entityType, {
+        page: 1,
+        limit: 5000,
+        search: '',
+    })
+    const fullItems = Array.isArray((fullDataHook as any)?.data)
+        ? (fullDataHook as any).data
+        : []
+    // Use the server page only while the full dataset is still loading.
+    const useServerPaging = !!serverPagination && fullItems.length === 0
+
     // Check if this is Employee Details view
     const isEmployeeDetails = entityType === ENTITY_TYPES.KVK_EMPLOYEES
 
@@ -387,6 +403,9 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     // successful mutation/invalidation, so the table re-renders automatically without
     // needing a manual local state layer or a page refresh.
     const items = Array.isArray(activeHook?.data) ? activeHook.data : []
+    // Base dataset for the client-side pipeline: the full set for server-paginated
+    // entities (once loaded), otherwise the hook's already-complete data.
+    const baseItems = serverPagination && fullItems.length > 0 ? fullItems : items
 
     // Resolve fields using centralized utility function
     // This ensures fields are always available even when there's no data
@@ -444,7 +463,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     // When serverPagination is active the hook already returns the right page
     // slice + handles search on the backend, so skip client-side filtering.
     const filteredData = useMemo(() => {
-        if (serverPagination) return items
+        if (useServerPaging) return items
         const maxDate = new Date()
         maxDate.setHours(23, 59, 59, 999)
         const rawFromDate = reportingYearFrom
@@ -465,7 +484,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                     ? rawToDate
                     : rawFromDate
                 : rawToDate
-        const yearFiltered = items.filter((item: any) =>
+        const yearFiltered = baseItems.filter((item: any) =>
             itemMatchesDateRangeFilter(item, fromDate, toDate, maxDate)
         )
 
@@ -478,14 +497,14 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                 return value && String(value).toLowerCase().includes(query)
             })
         })
-    }, [items, debouncedSearch, fields, reportingYearFrom, reportingYearTo, serverPagination])
+    }, [baseItems, items, debouncedSearch, fields, reportingYearFrom, reportingYearTo, useServerPaging])
 
     // Apply per-column filters (Excel-style: sort + text + multi-select) on top
     // of the search/year-filtered set. The column-filter dropdown's unique-value
     // list is computed from `filteredData` so it represents the full visible
     // dataset before column filters narrow it further.
     const columnFilteredData = useMemo(() => {
-        if (serverPagination) return items
+        if (useServerPaging) return items
         const result = applyColumnFilters(filteredData, fields, columnFilters)
         // Default alphabetical order (by the first column) unless the user has
         // applied an explicit column sort.
@@ -505,11 +524,11 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                 sensitivity: 'base',
             })
         })
-    }, [filteredData, fields, columnFilters, serverPagination, items])
+    }, [filteredData, fields, columnFilters, useServerPaging, items])
 
     // Pagination calculations - memoized for performance
     const paginationData = useMemo(() => {
-        if (serverPagination) {
+        if (useServerPaging && serverPagination) {
             const totalPages = serverPagination.totalPages || 1
             const safePage = Math.min(currentPage, totalPages)
             const startIndex = (safePage - 1) * itemsPerPage
@@ -527,7 +546,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
         const paginatedData = columnFilteredData.slice(startIndex, endIndex)
 
         return { totalPages, safePage, startIndex, endIndex, paginatedData }
-    }, [columnFilteredData, currentPage, itemsPerPage, serverPagination, items])
+    }, [columnFilteredData, currentPage, itemsPerPage, useServerPaging, serverPagination, items])
 
     const { totalPages, safePage, startIndex, endIndex, paginatedData } =
         paginationData
@@ -1348,6 +1367,11 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
     }, [isMobileRouteMenuOpen, isExportMenuOpen, isOftFldTabMenuOpen])
 
     const loading = getHookLoading(activeHook)
+    // Server-paginated hooks (e.g. Equipment Master) keep the previous page via
+    // placeholderData, so isLoading is false during a search/page change — only
+    // isFetching flips. Surface that as an overlay spinner so the user sees the
+    // table is refreshing without the rows vanishing.
+    const isFetching = Boolean((activeHook as any)?.isFetching)
 
     return (
         <div className="flex flex-col h-full bg-white sm:rounded-2xl p-1 overflow-hidden">
@@ -1903,7 +1927,12 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                             </div>
                         </div>
 
-                        <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+                        <div className="relative flex-1 flex flex-col min-h-0 overflow-hidden">
+                            {isFetching && !loading && (
+                                <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60 backdrop-blur-[1px]">
+                                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#487749]"></div>
+                                </div>
+                            )}
                             {loading ? (
                                 <LoadingState />
                             ) : isKvkRoleWithoutKvk ? (
@@ -1987,7 +2016,7 @@ export const DataManagementView: React.FC<DataManagementViewProps> = ({
                                         totalPages={totalPages}
                                         startIndex={startIndex}
                                         endIndex={endIndex}
-                                        totalItems={serverPagination ? serverPagination.total : columnFilteredData.length}
+                                        totalItems={useServerPaging && serverPagination ? serverPagination.total : columnFilteredData.length}
                                         onPageChange={setCurrentPage}
                                     />
                                 </>

--- a/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
@@ -64,7 +64,14 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
     const { data: fundingSources = [] } = useFundingSources()
     const { data: assetFundingSources = [] } = useAssetFundingSources()
     const { data: equipmentTypes = [] } = useEquipmentTypes()
-    const { data: equipmentMasters = [] } = useEquipmentMasters()
+    const {
+        data: equipmentMasters = [],
+        isLoading: isLoadingEquipmentMasters,
+        error: equipmentMastersError,
+    } = useEquipmentMasters()
+    const equipmentMastersErrorText = equipmentMastersError
+        ? 'Failed to load equipment. Please try again.'
+        : undefined
     const { data: bankAccountTypes = [] } = useBankAccountTypes()
     const { data: jobTypes = [] } = useJobTypes()
 
@@ -225,6 +232,50 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
         )
         return toOptions(filtered, 'equipmentId', equipmentOptionLabel)
     }, [equipments, formData._filterEquipmentTypeId, formData._filterEquipmentMasterId])
+
+    // Backfill the Equipment Details "Equipment Type" / "Equipment (Model/Brand)"
+    // filter selects when editing. These are UI-only helper fields (not stored on
+    // the detail record), so on edit they start empty even though the underlying
+    // equipment IS selected. Derive them from the selected equipment so both
+    // dropdowns show the right value. If the equipment itself has no type/master
+    // (e.g. some migrated rows), they stay empty — there's nothing to show.
+    React.useEffect(() => {
+        if (entityType !== ENTITY_TYPES.KVK_EQUIPMENT_DETAILS) return
+        if (formData.equipmentId == null) return
+        if (
+            formData._filterEquipmentTypeId != null ||
+            formData._filterEquipmentMasterId != null
+        )
+            return
+        const eq = (equipments as any[]).find(
+            (e) => Number(e.equipmentId) === Number(formData.equipmentId),
+        )
+        if (!eq) return
+        if (eq.equipmentTypeId == null && eq.equipmentMasterId == null) return
+        setFormData((prev: any) => ({
+            ...prev,
+            _filterEquipmentTypeId: eq.equipmentTypeId ?? prev._filterEquipmentTypeId ?? null,
+            _filterEquipmentMasterId: eq.equipmentMasterId ?? prev._filterEquipmentMasterId ?? null,
+        }))
+    }, [entityType, formData.equipmentId, equipments, setFormData])
+
+    // Equipment Details inherits its Source of Funding from the selected equipment
+    // (the backend always derives it). Mirror the selected equipment's funding into
+    // the read-only field so the form shows the correct, consistent value.
+    React.useEffect(() => {
+        if (entityType !== ENTITY_TYPES.KVK_EQUIPMENT_DETAILS) return
+        const eq = formData.equipmentId != null
+            ? (equipments as any[]).find(
+                (e) => Number(e.equipmentId) === Number(formData.equipmentId),
+            )
+            : null
+        const inherited = eq ? eq.assetFundingSourceId ?? null : null
+        setFormData((prev: any) =>
+            prev.assetFundingSourceId === inherited
+                ? prev
+                : { ...prev, assetFundingSourceId: inherited },
+        )
+    }, [entityType, formData.equipmentId, equipments, setFormData])
 
     // Sync kvkId from user when KVK role - use functional update to avoid dependency on formData
     React.useEffect(() => {
@@ -759,7 +810,18 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                             required
                             value={formData.equipmentMasterId != null ? String(formData.equipmentMasterId) : ''}
                             onChange={(e) => setFormData({ ...formData, equipmentMasterId: e.target.value ? parseInt(e.target.value) : null })}
-                            disabled={!formData.equipmentTypeId}
+                            disabled={!formData.equipmentTypeId || isLoadingEquipmentMasters}
+                            error={equipmentMastersErrorText}
+                            placeholder={
+                                isLoadingEquipmentMasters
+                                    ? 'Loading equipment…'
+                                    : equipmentMastersError
+                                        ? 'Failed to load equipment'
+                                        : formData.equipmentTypeId &&
+                                            equipmentMasterOptionsForForm.length === 0
+                                            ? 'No equipment for this type'
+                                            : 'Select'
+                            }
                             options={equipmentMasterOptionsForForm}
                         />
                     </div>
@@ -929,8 +991,10 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                                 equipmentId: null,
                             })}
                             dependsOn={{ value: formData._filterEquipmentTypeId, field: 'equipmentTypeId' }}
+                            isLoading={isLoadingEquipmentMasters}
+                            error={equipmentMastersErrorText}
                             emptyMessage="No equipment models registered for this type"
-                            loadingMessage="Filtering models..."
+                            loadingMessage="Loading equipment…"
                             options={equipmentMasterOptionsForFilter}
                         />
                     </div>
@@ -953,10 +1017,14 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
                         onChange={(e) => setFormData({ ...formData, equipmentStatusId: parseInt(e.target.value) })}
                         options={equipmentStatusOptions}
                     />
+                    {/* Funding source is inherited from the selected equipment — */}
+                    {/* read-only here; the backend always derives it from the parent. */}
                     <FormSelect
-                        label="Source of Funding"
+                        label="Source of Funding (from equipment)"
                         value={formData.assetFundingSourceId != null ? String(formData.assetFundingSourceId) : ''}
-                        onChange={(e) => setFormData({ ...formData, assetFundingSourceId: e.target.value ? parseInt(e.target.value) : null })}
+                        onChange={() => { }}
+                        disabled
+                        placeholder={formData.equipmentId ? '—' : 'Select an equipment first'}
                         options={assetFundingSourceOptions}
                     />
                 </div>


### PR DESCRIPTION
…ters, dropdown loaders

equipment-details migration:
- equipmentId resolves the parent KvkEquipment record (by kvkId + companyBrandModel/equipmentName), not an EquipmentMaster id, fixing the kvk_equipment_detail_equipment_id_fkey violations on push.
- assetFundingSourceId now inherited from the parent equipment instead of the detail row's own source_of_fund.

backend (aboutKvkRepository):
- equipment-details create/update derive assetFundingSourceId from the parent equipment; client value ignored.
- equipments dropdown returns assetFundingSourceId (+ relation).

frontend:
- DataManagementView: server-paginated masters (Equipment Master) fetch the full dataset so column-filter value lists, search and filtering span the whole column, not just the current page; add an isFetching overlay spinner.
- useEquipmentMasters fetches the full set (was capped at 100) so dependent dropdowns don't drop whole equipment types.
- AboutKvkForms: Equipment dropdowns show loading/error states; Equipment Details backfills the Type/Model filter selects on edit and shows a read-only, equipment-inherited Source of Funding.