### PR TITLE
feat(super-migration): curl-driven migration with per-KVK and per-row push filters

### DIFF
--- a/backend/migration/superEngine.js
+++ b/backend/migration/superEngine.js
@@ -1,0 +1,142 @@
+const prisma = require('../config/prisma.js');
+const { MasterResolver, normalize } = require('./masterResolver.js');
+const { getModule } = require('./registry.js');
+const { extractRows } = require('./engine.js');
+const { decodeEntities, cleanText } = require('./util.js');
+
+/**
+ * Super-migration engine. Same pipeline as engine.js, but the target KVK is NOT
+ * chosen up front — a superadmin curl (kvk_id empty) returns rows spanning every
+ * KVK, each row carrying its own `kvk.kvk_name`. For each row we resolve that
+ * name to OUR kvkId and run the module spec with a per-row context, so one paste
+ * fans out across many KVKs. The module specs are reused unchanged: we set
+ * ctx.targetKvkName to the row's own name so their internal KVK guard passes.
+ */
+
+/** A raw `kvk` cell may be a nested object, a JSON string, or a flat dotted key. */
+function asObject(value) {
+    if (value == null) return null;
+    if (typeof value === 'object') return value;
+    if (typeof value === 'string') {
+        try {
+            return JSON.parse(value);
+        } catch {
+            return null;
+        }
+    }
+    return null;
+}
+
+/** Pull the old-site KVK name out of a row, decoded the same way the specs do. */
+function rowKvkName(row) {
+    const kvkObj = asObject(row.kvk);
+    return decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+}
+
+/**
+ * Transform every old row, resolving each row's KVK independently. Rows whose
+ * KVK name is missing or not present in our DB are reported as errors and
+ * skipped (null), exactly like an unmapped row.
+ */
+async function superTransform(moduleKey, raw) {
+    const spec = getModule(moduleKey);
+    const resolver = new MasterResolver();
+    const rows = extractRows(raw);
+
+    const records = [];
+    const rowReports = [];
+    let errorCount = 0;
+    let warnCount = 0;
+
+    for (let index = 0; index < rows.length; index++) {
+        try {
+            const row = rows[index];
+            const oldKvkName = rowKvkName(row);
+            if (!oldKvkName) {
+                errorCount++;
+                records.push(null);
+                rowReports.push({
+                    index,
+                    issues: [{ field: 'kvkId', message: 'No KVK name on old row — cannot resolve target KVK', severity: 'error' }],
+                });
+                continue;
+            }
+            const hit = await resolver.resolve('kvk', 'kvkName', 'kvkId', oldKvkName);
+            if (!hit.matched) {
+                errorCount++;
+                records.push(null);
+                rowReports.push({
+                    index,
+                    issues: [{ field: 'kvkId', message: `KVK "${oldKvkName}" not found in our DB — skipped`, severity: 'error' }],
+                });
+                continue;
+            }
+
+            const ctx = { kvkId: hit.id, targetKvkName: oldKvkName, resolver };
+            const { data, issues } = await spec.transform(row, ctx);
+            records.push(data);
+            for (const it of issues) {
+                if (it.severity === 'error') errorCount++;
+                else warnCount++;
+            }
+            if (issues.length) rowReports.push({ index, issues });
+        } catch (err) {
+            errorCount++;
+            records.push(null);
+            rowReports.push({
+                index,
+                issues: [{ field: '*', message: err.message, severity: 'error' }],
+            });
+        }
+    }
+
+    return {
+        records,
+        report: {
+            total: rows.length,
+            mapped: records.filter(Boolean).length,
+            errorCount,
+            warnCount,
+            seedable: errorCount === 0,
+            rows: rowReports,
+        },
+    };
+}
+
+/**
+ * Insert-only seed. Identical to engine.seed but the kvkId for each record comes
+ * from the record itself (data.kvkId, set during transform), since rows span
+ * multiple KVKs. Skips rows that failed to map (null).
+ */
+async function superSeed(moduleKey, records) {
+    const spec = getModule(moduleKey);
+    const model = prisma[spec.model];
+    const result = { created: 0, updated: 0, skipped: 0, failed: [], actions: [] };
+
+    for (let index = 0; index < records.length; index++) {
+        const data = records[index];
+        if (!data) {
+            result.skipped++;
+            result.actions.push('skipped');
+            continue;
+        }
+        try {
+            if (spec.seedRecord) {
+                const action = await spec.seedRecord(prisma, data, { kvkId: Number(data.kvkId) });
+                const resolved = action === 'updated' ? 'updated' : 'created';
+                result[resolved]++;
+                result.actions.push(resolved);
+                continue;
+            }
+            await model.create({ data });
+            result.created++;
+            result.actions.push('created');
+        } catch (err) {
+            result.failed.push({ index, message: err.message });
+            result.actions.push('failed');
+        }
+    }
+    return result;
+}
+
+module.exports = { superTransform, superSeed };

--- a/backend/migration/superRoutes.js
+++ b/backend/migration/superRoutes.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const router = express.Router();
+const { authenticateToken } = require('../middleware/auth.js');
+const { listModules } = require('./registry.js');
+const { listMasterOptions } = require('./masterCatalog.js');
+const engine = require('./engine.js');
+const superEngine = require('./superEngine.js');
+
+// Super-migration: paste a SUPERADMIN curl (kvk_id empty → all KVKs), pick a
+// module; the target KVK is resolved per-row from the curl. No KVK picker.
+router.use(authenticateToken);
+
+router.get('/modules', (req, res) => {
+    res.json({ modules: listModules() });
+});
+
+// Master options for FK pickers (whitelisted via masterCatalog).
+router.get('/master-options/:master', async (req, res) => {
+    try {
+        res.json({ options: await listMasterOptions(req.params.master) });
+    } catch (err) {
+        res.status(400).json({ error: err.message });
+    }
+});
+
+// Replay a pasted curl against the old site, return its raw JSON. Same as
+// /migration/fetch — enrichment hooks live in the shared engine.
+router.post('/fetch', async (req, res) => {
+    try {
+        const { curl } = req.body;
+        if (!curl) return res.status(400).json({ error: 'curl is required' });
+        const out = await engine.fetchFromCurl(curl);
+        res.json(out);
+    } catch (err) {
+        res.status(400).json({ error: err.message });
+    }
+});
+
+// Map raw rows -> our schema, resolving each row's KVK from the row itself.
+router.post('/transform', async (req, res) => {
+    try {
+        const { module, raw } = req.body;
+        if (!module || raw === undefined) {
+            return res.status(400).json({ error: 'module and raw are required' });
+        }
+        const out = await superEngine.superTransform(module, raw);
+        res.json(out);
+    } catch (err) {
+        res.status(400).json({ error: err.message });
+    }
+});
+
+// Persist mapped records (insert-only); kvkId taken per-record from the data.
+router.post('/seed', async (req, res) => {
+    try {
+        const { module, records } = req.body;
+        if (!module || !Array.isArray(records)) {
+            return res.status(400).json({ error: 'module and records[] are required' });
+        }
+        const out = await superEngine.superSeed(module, records);
+        res.json(out);
+    } catch (err) {
+        res.status(400).json({ error: err.message });
+    }
+});
+
+module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -131,6 +131,10 @@ router.use('/reports', reportRoutes);
 // Data-migration tool (old atariams.org -> this app). Admin-only, self-contained.
 router.use('/migration', require('../migration/routes.js'));
 
+// Super-migration: same tool, but target KVK resolved per-row from a superadmin
+// curl (kvk_id empty → all KVKs) instead of a KVK picker. Admin-only.
+router.use('/super-migration', require('../migration/superRoutes.js'));
+
 // TEMPORARY migration cleanup: per-module "Delete All" for a KVK's own data.
 // Mounted outside /forms so it skips the form-payload middlewares.
 router.use('/maintenance', require('./forms/kvkModuleWipeRoutes.js'));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import { FormSummary } from './pages/features/FormSummary'
 import { TechnicalAchievementSummary } from './pages/dashboard/forms/TechnicalAchievementSummary'
 import { AdminKVKRedirect } from './components/common/AdminKVKRedirect'
 import { MigrationTool } from './pages/migration/MigrationTool'
+import { SuperMigrationTool } from './pages/migration/SuperMigrationTool'
 import {
     projectsRoutes,
     allMastersRoutes,
@@ -214,6 +215,16 @@ function AppRoutes() {
                         element={
                             <ProtectedRoute requiredRole={ADMIN_ROLES}>
                                 <MigrationTool />
+                            </ProtectedRoute>
+                        }
+                    />
+
+                    {/* Super Data Migration — KVK resolved per-row (admin-only) */}
+                    <Route
+                        path="/super-migration"
+                        element={
+                            <ProtectedRoute requiredRole={ADMIN_ROLES}>
+                                <SuperMigrationTool />
                             </ProtectedRoute>
                         }
                     />

--- a/frontend/src/pages/migration/SuperMigrationTool.tsx
+++ b/frontend/src/pages/migration/SuperMigrationTool.tsx
@@ -1,0 +1,558 @@
+import { useCallback, useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from 'react'
+import { Button } from '../../components/ui/button'
+import { superMigrationApi } from '../../services/superMigrationApi'
+import {
+    migrationApi,
+    type MigrationKvk,
+    type ModuleInfo,
+    type TransformResult,
+    type SeedResult,
+    type RowAction,
+} from '../../services/migrationApi'
+import { RecordsViewer } from './components/RecordsViewer'
+import { MigrationReport } from './components/MigrationReport'
+import { SearchableSelect } from './components/SearchableSelect'
+import type { FkEditing } from './views/tableUtils'
+import type { RowSelection } from './views/TableView'
+
+type Busy = '' | 'fetch' | 'transform' | 'seed'
+type Row = Record<string, unknown>
+
+/**
+ * Super-migration workbench. Same flow as MigrationTool but WITHOUT a KVK
+ * picker: paste a superadmin curl (kvk_id empty → all KVKs) -> pick module ->
+ * Fetch -> Transform (each row's KVK is resolved on the backend from the row's
+ * own kvk.kvk_name) -> review + fix FKs inline -> Push to DB.
+ */
+export function SuperMigrationTool() {
+    const [modules, setModules] = useState<ModuleInfo[]>([])
+    const [moduleKey, setModuleKey] = useState<string | ''>('')
+    const [curl, setCurl] = useState('')
+
+    const [raw, setRaw] = useState<unknown>(undefined)
+    const [rowCount, setRowCount] = useState<number | null>(null)
+    const [splitPercent, setSplitPercent] = useState<number>(50)
+    const [verticalSplit, setVerticalSplit] = useState<number>(65)
+    const [showErrorsOnly, setShowErrorsOnly] = useState<boolean>(false)
+
+    const handleMouseDown = (e: ReactMouseEvent) => {
+        e.preventDefault()
+        const startX = e.clientX
+        const startSplit = splitPercent
+
+        const container = e.currentTarget.parentElement
+        const containerWidth = container ? container.getBoundingClientRect().width : window.innerWidth
+
+        const handleMouseMove = (moveEvent: MouseEvent) => {
+            const deltaX = moveEvent.clientX - startX
+            const deltaPercent = (deltaX / containerWidth) * 100
+            const nextPercent = Math.min(Math.max(startSplit + deltaPercent, 15), 85)
+            setSplitPercent(nextPercent)
+        }
+
+        const handleMouseUp = () => {
+            document.removeEventListener('mousemove', handleMouseMove)
+            document.removeEventListener('mouseup', handleMouseUp)
+        }
+
+        document.addEventListener('mousemove', handleMouseMove)
+        document.addEventListener('mouseup', handleMouseUp)
+    }
+
+    const handleVerticalMouseDown = (e: ReactMouseEvent) => {
+        e.preventDefault()
+        const startY = e.clientY
+        const startSplit = verticalSplit
+
+        const container = e.currentTarget.parentElement
+        const containerHeight = container ? container.getBoundingClientRect().height : window.innerHeight
+
+        const handleMouseMove = (moveEvent: MouseEvent) => {
+            const deltaY = moveEvent.clientY - startY
+            const deltaPercent = (deltaY / containerHeight) * 100
+            const nextPercent = Math.min(Math.max(startSplit + deltaPercent, 20), 85)
+            setVerticalSplit(nextPercent)
+        }
+        const handleMouseUp = () => {
+            document.removeEventListener('mousemove', handleMouseMove)
+            document.removeEventListener('mouseup', handleMouseUp)
+        }
+        document.addEventListener('mousemove', handleMouseMove)
+        document.addEventListener('mouseup', handleMouseUp)
+    }
+
+    const [transformed, setTransformed] = useState<TransformResult | null>(null)
+    const [records, setRecords] = useState<Array<Row | null>>([])
+    const [fkOptions, setFkOptions] = useState<Record<string, { value: number; label: string }[]>>(
+        {},
+    )
+    const [seedResult, setSeedResult] = useState<SeedResult | null>(null)
+    const [rowActions, setRowActions] = useState<RowAction[]>([])
+
+    // Push filters: which KVKs and which individual rows to migrate. Populated
+    // (all-selected) after each transform; both gate what gets pushed.
+    const [kvkNames, setKvkNames] = useState<Record<number, string>>({})
+    const [selectedKvkIds, setSelectedKvkIds] = useState<Set<number>>(new Set())
+    const [excludedRows, setExcludedRows] = useState<Set<number>>(new Set())
+
+    const [busy, setBusy] = useState<Busy>('')
+    const [error, setError] = useState('')
+
+    const activeModule = useMemo(
+        () => modules.find(m => m.key === moduleKey) || null,
+        [modules, moduleKey],
+    )
+
+    useEffect(() => {
+        superMigrationApi
+            .getModules()
+            .then(r => setModules(r.modules))
+            .catch(e => setError(e.message))
+        // KVK id → name map, only to label the per-KVK push filter chips.
+        migrationApi
+            .getKvks()
+            .then(r =>
+                setKvkNames(
+                    Object.fromEntries((r.kvks as MigrationKvk[]).map(k => [k.kvkId, k.kvkName])),
+                ),
+            )
+            .catch(() => {})
+    }, [])
+
+    // Load FK master options for the selected module's pickers. `force` refetches
+    // even cached masters — needed after a transform, since find-or-create specs
+    // (e.g. payScale) may have added new master rows we must now show by label.
+    const loadFkOptions = useCallback(
+        (force = false) => {
+            if (!activeModule) return
+            const masters = [...new Set(Object.values(activeModule.foreignKeys).map(f => f.master))]
+            masters.forEach(master => {
+                if (!force && fkOptions[master]) return
+                superMigrationApi
+                    .getMasterOptions(master)
+                    .then(r =>
+                        setFkOptions(prev => ({
+                            ...prev,
+                            [master]: r.options.map(o => ({
+                                value: o.id,
+                                label: `${o.label} (#${o.id})`,
+                            })),
+                        })),
+                    )
+                    .catch(e =>
+                        setError(
+                            `Couldn't load master "${master}" options: ${e.message}. ` +
+                                `If the backend was running before this feature was added, restart it.`,
+                        ),
+                    )
+            })
+        },
+        [activeModule, fkOptions],
+    )
+
+    useEffect(() => {
+        loadFkOptions(false)
+    }, [loadFkOptions])
+
+    const run = async (label: Busy, fn: () => Promise<void>) => {
+        setError('')
+        setBusy(label)
+        try {
+            await fn()
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e))
+        } finally {
+            setBusy('')
+        }
+    }
+
+    const onFetch = () =>
+        run('fetch', async () => {
+            setTransformed(null)
+            setRecords([])
+            setSeedResult(null)
+            setRowActions([])
+            const out = await superMigrationApi.fetchCurl(curl)
+            setRaw(out.raw)
+            setRowCount(out.rowCount)
+        })
+
+    const onTransform = () =>
+        run('transform', async () => {
+            setSeedResult(null)
+            setRowActions([])
+            const out = await superMigrationApi.transform(moduleKey, raw)
+            setTransformed(out)
+            const recs = out.records as Array<Row | null>
+            setRecords(recs)
+            // Default: every KVK present is selected, no rows excluded.
+            const ids = new Set<number>()
+            recs.forEach(r => {
+                const id = r?.kvkId
+                if (typeof id === 'number') ids.add(id)
+            })
+            setSelectedKvkIds(ids)
+            setExcludedRows(new Set())
+            loadFkOptions(true)
+        })
+
+    const onSeed = () =>
+        run('seed', async () => {
+            // Push only selected rows; unselected become null → skipped server-side.
+            // Index positions are preserved so returned actions align with the table.
+            const filtered = records.map((r, i) => (selectedRowIndices.has(i) ? r : null))
+            const out = await superMigrationApi.seed(moduleKey, filtered)
+            setSeedResult(out)
+            setRowActions(out.actions ?? [])
+        })
+
+    const onEditCell = (rowIndex: number, field: string, value: number | null) => {
+        const meta = activeModule?.foreignKeys[field]
+        setRecords(prev =>
+            prev.map((r, i) => {
+                if (i !== rowIndex || !r) return r
+                const next: Row = { ...r, [field]: value }
+                if (meta?.otherField && value != null) next[meta.otherField] = null
+                return next
+            }),
+        )
+    }
+
+    const onEditField = (rowIndex: number, field: string, value: unknown) => {
+        setRecords(prev =>
+            prev.map((r, i) => (i !== rowIndex || !r ? r : { ...r, [field]: value })),
+        )
+    }
+
+    const onFillUnmatched = (field: string, value: number) => {
+        const meta = activeModule?.foreignKeys[field]
+        setRecords(prev =>
+            prev.map(r => {
+                if (!r) return r
+                const cur = r[field]
+                if (cur !== null && cur !== undefined && cur !== '') return r
+                const next: Row = { ...r, [field]: value }
+                if (meta?.otherField) next[meta.otherField] = null
+                return next
+            }),
+        )
+    }
+
+    const liveReport = useMemo(() => {
+        if (!transformed) return null
+        const errorResolved = (field: string, rec: Row | null) => {
+            if (!rec) return false
+            const v = rec[field]
+            return v !== null && v !== undefined && v !== ''
+        }
+        const rows = transformed.report.rows
+            .map(r => {
+                const rec = records[r.index] ?? null
+                const issues = r.issues.filter(
+                    it => !(it.severity === 'error' && errorResolved(it.field, rec)),
+                )
+                return { index: r.index, issues }
+            })
+            .filter(r => r.issues.length > 0)
+        const errorCount = rows.reduce(
+            (n, r) => n + r.issues.filter(i => i.severity === 'error').length,
+            0,
+        )
+        const warnCount = rows.reduce(
+            (n, r) => n + r.issues.filter(i => i.severity === 'warn').length,
+            0,
+        )
+        return { ...transformed.report, rows, errorCount, warnCount, seedable: errorCount === 0 }
+    }, [transformed, records])
+
+    const errorIndices = useMemo(() => {
+        const s = new Set<number>()
+        liveReport?.rows.forEach(r => {
+            if (r.issues.some(i => i.severity === 'error')) s.add(r.index)
+        })
+        return s
+    }, [liveReport])
+
+    // Distinct KVKs present across the mapped records, with per-KVK row counts —
+    // drives the "push these KVKs" filter chips.
+    const kvkGroups = useMemo(() => {
+        const m = new Map<number, number>()
+        records.forEach(r => {
+            const id = r?.kvkId
+            if (typeof id === 'number') m.set(id, (m.get(id) ?? 0) + 1)
+        })
+        return [...m.entries()]
+            .map(([id, count]) => ({ id, count, name: kvkNames[id] ?? `KVK #${id}` }))
+            .sort((a, b) => a.name.localeCompare(b.name))
+    }, [records, kvkNames])
+
+    const allKvkSelected =
+        kvkGroups.length > 0 && kvkGroups.every(g => selectedKvkIds.has(g.id))
+
+    // Rows that CAN be pushed: mapped, no unresolved error, and in a selected KVK.
+    const selectableIndices = useMemo(() => {
+        const s = new Set<number>()
+        records.forEach((r, i) => {
+            if (!r) return
+            const id = r.kvkId
+            if (typeof id !== 'number' || !selectedKvkIds.has(id)) return
+            if (errorIndices.has(i)) return
+            s.add(i)
+        })
+        return s
+    }, [records, selectedKvkIds, errorIndices])
+
+    // Rows actually selected to push = selectable minus the ones the user unchecked.
+    const selectedRowIndices = useMemo(() => {
+        const s = new Set<number>()
+        selectableIndices.forEach(i => {
+            if (!excludedRows.has(i)) s.add(i)
+        })
+        return s
+    }, [selectableIndices, excludedRows])
+
+    const onToggleKvk = (id: number) =>
+        setSelectedKvkIds(prev => {
+            const n = new Set(prev)
+            if (n.has(id)) n.delete(id)
+            else n.add(id)
+            return n
+        })
+
+    const selection: RowSelection = {
+        selected: selectedRowIndices,
+        selectable: selectableIndices,
+        onToggle: index =>
+            setExcludedRows(prev => {
+                const n = new Set(prev)
+                if (n.has(index)) n.delete(index)
+                else n.add(index)
+                return n
+            }),
+        onToggleAll: checked =>
+            setExcludedRows(prev => {
+                const n = new Set(prev)
+                selectableIndices.forEach(i => (checked ? n.delete(i) : n.add(i)))
+                return n
+            }),
+    }
+
+    // Display filter: combine errors-only with the per-KVK filter. Rows without a
+    // kvkId (unmapped/null) are kept so their errors stay visible.
+    const visibleIndices = useMemo(() => {
+        const kvkFilterActive = !allKvkSelected
+        if (!showErrorsOnly && !kvkFilterActive) return undefined
+        const s = new Set<number>()
+        for (let i = 0; i < records.length; i++) {
+            if (showErrorsOnly && !errorIndices.has(i)) continue
+            if (kvkFilterActive) {
+                const id = records[i]?.kvkId
+                if (typeof id === 'number' && !selectedKvkIds.has(id)) continue
+            }
+            s.add(i)
+        }
+        return s
+    }, [showErrorsOnly, allKvkSelected, errorIndices, records, selectedKvkIds])
+
+    const displayRecords = useMemo(() => {
+        const source = records.length > 0 ? records : transformed?.records
+        if (!source) return undefined
+        return source.map((r, index) => {
+            if (r) return r
+            const issueRow = transformed?.report.rows.find(x => x.index === index)
+            const summary =
+                issueRow?.issues
+                    .map(i => `[${i.severity}] ${i.field}: ${i.message}`)
+                    .join(' | ') || 'Transform returned null for this row'
+            return { _status: 'not mapped', _issues: summary }
+        })
+    }, [records, transformed])
+
+    const fk: FkEditing | undefined = activeModule
+        ? { foreignKeys: activeModule.foreignKeys, fkOptions, onEditCell, onEditField, onFillUnmatched }
+        : undefined
+
+    const canTransform = raw !== undefined && moduleKey !== ''
+    // Selective push: enabled as long as at least one row is selected (clean rows
+    // can ship even while others still carry errors).
+    const canSeed = selectedRowIndices.size > 0
+
+    return (
+        <div className="flex h-[calc(100vh-4rem)] flex-col gap-4 p-4">
+            <div>
+                <h1 className="text-xl font-bold text-gray-800">Super Data Migration</h1>
+                <p className="text-sm text-gray-500">
+                    Paste a superadmin curl (kvk_id empty → all KVKs), pick module, transform; each
+                    row's target KVK is resolved automatically from the row. Fix FKs, push.
+                </p>
+            </div>
+
+            {/* Controls — no KVK picker; KVK comes from each row. */}
+            <div className="grid grid-cols-1 gap-3 lg:grid-cols-[240px_1fr_auto]">
+                <SearchableSelect
+                    options={modules.map(m => ({ value: m.key, label: m.label }))}
+                    value={moduleKey}
+                    onChange={v => setModuleKey(v === '' ? '' : String(v))}
+                    placeholder="Search module…"
+                />
+                <textarea
+                    className="min-h-[40px] rounded-md border border-gray-300 px-3 py-2 font-mono text-xs"
+                    placeholder="Paste superadmin curl copied from atariams.org devtools…"
+                    value={curl}
+                    onChange={e => setCurl(e.target.value)}
+                />
+                <div className="flex items-start gap-2">
+                    <Button onClick={onFetch} disabled={!curl || busy !== ''}>
+                        {busy === 'fetch' ? 'Fetching…' : 'Fetch'}
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        onClick={onTransform}
+                        disabled={!canTransform || busy !== ''}
+                    >
+                        {busy === 'transform' ? 'Transforming…' : 'Transform'}
+                    </Button>
+                    <Button
+                        onClick={onSeed}
+                        disabled={!canSeed || busy !== ''}
+                        className="bg-green-600 hover:bg-green-700"
+                    >
+                        {busy === 'seed'
+                            ? 'Pushing…'
+                            : `Push to DB${transformed ? ` (${selectedRowIndices.size})` : ''}`}
+                    </Button>
+                </div>
+            </div>
+
+            {error && (
+                <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                    {error}
+                </div>
+            )}
+
+            {seedResult && (
+                <div className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">
+                    Pushed — created {seedResult.created}, updated {seedResult.updated}, skipped{' '}
+                    {seedResult.skipped}
+                    {seedResult.failed.length > 0 &&
+                        `, failed ${seedResult.failed.length} (${seedResult.failed
+                            .map(f => `#${f.index}: ${f.message}`)
+                            .join('; ')})`}
+                </div>
+            )}
+
+            {/* Per-KVK push filter — pick which KVKs to migrate. */}
+            {transformed && kvkGroups.length > 0 && (
+                <div className="flex flex-wrap items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
+                    <span className="text-xs font-semibold text-gray-600">Push KVKs:</span>
+                    <button
+                        type="button"
+                        onClick={() =>
+                            setSelectedKvkIds(
+                                allKvkSelected ? new Set() : new Set(kvkGroups.map(g => g.id)),
+                            )
+                        }
+                        className="rounded border border-gray-300 bg-white px-2 py-0.5 text-xs font-medium text-gray-600 hover:bg-gray-100"
+                    >
+                        {allKvkSelected ? 'Clear all' : 'Select all'}
+                    </button>
+                    {kvkGroups.map(g => {
+                        const on = selectedKvkIds.has(g.id)
+                        return (
+                            <button
+                                key={g.id}
+                                type="button"
+                                onClick={() => onToggleKvk(g.id)}
+                                className={`rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors ${
+                                    on
+                                        ? 'border-blue-300 bg-blue-50 text-blue-700 hover:bg-blue-100'
+                                        : 'border-gray-300 bg-white text-gray-500 hover:bg-gray-50'
+                                }`}
+                                title={`${g.name} — ${g.count} rows`}
+                            >
+                                {on ? '✓ ' : ''}
+                                {g.name} ({g.count})
+                            </button>
+                        )
+                    })}
+                </div>
+            )}
+
+            {/* Panes */}
+            <div className="flex min-h-0 flex-1 gap-0 overflow-hidden relative">
+                <div style={{ width: `${splitPercent}%` }} className="min-w-0 h-full flex flex-col pr-2">
+                    <RecordsViewer
+                        title="Raw response (old site)"
+                        data={raw}
+                        defaultView="table"
+                        badge={rowCount != null ? `${rowCount} rows` : undefined}
+                        placeholder="Fetch a curl to see the old-site response here."
+                    />
+                </div>
+
+                {/* Draggable Divider */}
+                <div
+                    onMouseDown={handleMouseDown}
+                    className="w-2 hover:w-2.5 bg-gray-100 hover:bg-blue-500 cursor-col-resize self-stretch transition-colors select-none flex items-center justify-center relative z-30"
+                    title="Drag to resize panes"
+                >
+                    <div className="w-0.5 h-12 bg-gray-300 rounded-full"></div>
+                </div>
+
+                <div style={{ width: `${100 - splitPercent}%` }} className="min-w-0 h-full flex flex-col pl-2">
+                    <div style={{ height: `${transformed ? verticalSplit : 100}%` }} className="min-h-0 flex flex-col">
+                        <RecordsViewer
+                            title="Mapped to our schema"
+                            data={displayRecords}
+                            defaultView="table"
+                            fk={fk}
+                            badge={
+                                transformed
+                                    ? `${transformed.report.mapped} mapped · ${selectedRowIndices.size} selected`
+                                    : undefined
+                            }
+                            placeholder="Transform to see records mapped to your DB schema."
+                            rowActions={rowActions}
+                            visibleIndices={visibleIndices}
+                            selection={transformed ? selection : undefined}
+                            headerExtra={
+                                transformed ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowErrorsOnly(v => !v)}
+                                        disabled={!showErrorsOnly && errorIndices.size === 0}
+                                        title="Show only rows that still have unresolved errors"
+                                        className={`rounded border px-2 py-1 text-xs font-medium transition-colors ${
+                                            showErrorsOnly
+                                                ? 'border-red-300 bg-red-50 text-red-700 hover:bg-red-100'
+                                                : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50 disabled:opacity-50'
+                                        }`}
+                                    >
+                                        {showErrorsOnly
+                                            ? 'Show all rows'
+                                            : `Errors only (${errorIndices.size})`}
+                                    </button>
+                                ) : undefined
+                            }
+                        />
+                    </div>
+                    {transformed && (
+                        <>
+                            {/* Vertical draggable divider */}
+                            <div
+                                onMouseDown={handleVerticalMouseDown}
+                                className="h-2 hover:h-2.5 bg-gray-100 hover:bg-blue-500 cursor-row-resize w-full transition-colors select-none flex items-center justify-center"
+                                title="Drag to resize"
+                            >
+                                <div className="h-0.5 w-12 bg-gray-300 rounded-full"></div>
+                            </div>
+                            <div style={{ height: `${100 - verticalSplit}%` }} className="min-h-0 overflow-auto">
+                                <MigrationReport report={liveReport ?? transformed.report} />
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/pages/migration/components/RecordsViewer.tsx
+++ b/frontend/src/pages/migration/components/RecordsViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, type ReactNode } from 'react'
-import { TableView } from '../views/TableView'
+import { TableView, type RowSelection } from '../views/TableView'
 import { MatrixView } from '../views/MatrixView'
 import {
     hasTabularRows,
@@ -26,6 +26,8 @@ interface RecordsViewerProps {
     fk?: FkEditing
     rowActions?: RowAction[]
     visibleIndices?: Set<number>
+    /** Per-row push selection (table view only). */
+    selection?: RowSelection
     /** Extra controls rendered in the header, before the Jump selector. */
     headerExtra?: ReactNode
 }
@@ -46,6 +48,7 @@ export function RecordsViewer({
     fk,
     rowActions,
     visibleIndices,
+    selection,
     headerExtra,
 }: RecordsViewerProps) {
     const [view, setView] = useState<ViewMode>(defaultView)
@@ -180,7 +183,7 @@ export function RecordsViewer({
                         {JSON.stringify(data, null, 2)}
                     </pre>
                 ) : view === 'table' ? (
-                    <TableView data={data} fk={fk} idPrefix={idPrefix} rowActions={rowActions} visibleIndices={visibleIndices} />
+                    <TableView data={data} fk={fk} idPrefix={idPrefix} rowActions={rowActions} visibleIndices={visibleIndices} selection={selection} />
                 ) : (
                     <MatrixView data={data} fk={fk} idPrefix={idPrefix} visibleIndices={visibleIndices} />
                 )}

--- a/frontend/src/pages/migration/views/TableView.tsx
+++ b/frontend/src/pages/migration/views/TableView.tsx
@@ -10,6 +10,15 @@ const ACTION_STYLES: Record<RowAction, { bg: string; text: string; label: string
     failed:  { bg: 'bg-red-100',  text: 'text-red-700',  label: 'failed'  },
 }
 
+/** Optional per-row include/exclude checkbox (push selection). */
+export interface RowSelection {
+    selected: Set<number>
+    onToggle: (index: number) => void
+    /** Selectable original indices — drives the header "select all" checkbox. */
+    selectable: Set<number>
+    onToggleAll: (checked: boolean) => void
+}
+
 interface TableViewProps {
     data: unknown
     fk?: FkEditing
@@ -17,10 +26,11 @@ interface TableViewProps {
     rowActions?: RowAction[]
     /** When set, only rows whose original index is in the set are rendered. */
     visibleIndices?: Set<number>
+    selection?: RowSelection
 }
 
 /** Spreadsheet view: one record per row, one field per column. */
-export function TableView({ data, fk, idPrefix = 'raw', rowActions, visibleIndices }: TableViewProps) {
+export function TableView({ data, fk, idPrefix = 'raw', rowActions, visibleIndices, selection }: TableViewProps) {
     const allRows = toIndexedRows(data)
     if (allRows.length === 0) {
         return <p className="p-3 text-sm text-gray-400">No tabular rows.</p>
@@ -33,12 +43,28 @@ export function TableView({ data, fk, idPrefix = 'raw', rowActions, visibleIndic
     }
     const fkMeta = (c: string) => fk?.foreignKeys[c]
 
+    const allSelected =
+        !!selection && selection.selectable.size > 0 &&
+        [...selection.selectable].every(i => selection.selected.has(i))
+
     return (
         <table className="w-full border-separate border-spacing-0 text-xs">
             <thead className="sticky top-0 z-20 bg-gray-50">
                 <tr>
                     <th className="sticky left-0 z-30 bg-gray-100 border-b border-r border-gray-200 px-3 py-2 text-left font-semibold text-gray-500 shadow-[2px_0_5px_-2px_rgba(0,0,0,0.1)]">
-                        #
+                        <div className="flex items-center gap-2">
+                            {selection && (
+                                <input
+                                    type="checkbox"
+                                    checked={allSelected}
+                                    disabled={selection.selectable.size === 0}
+                                    onChange={e => selection.onToggleAll(e.target.checked)}
+                                    title="Select all pushable rows"
+                                    className="h-3.5 w-3.5 cursor-pointer"
+                                />
+                            )}
+                            <span>#</span>
+                        </div>
                     </th>
                     {cols.map(c => (
                         <th
@@ -68,7 +94,23 @@ export function TableView({ data, fk, idPrefix = 'raw', rowActions, visibleIndic
                                 isPlaceholder ? 'bg-red-50' : 'bg-white'
                             }`}>
                                 <div className="flex flex-col items-start gap-0.5">
-                                    <span className="text-gray-400 text-xs">{index}</span>
+                                    <div className="flex items-center gap-1.5">
+                                        {selection && (
+                                            <input
+                                                type="checkbox"
+                                                checked={selection.selected.has(index)}
+                                                disabled={!selection.selectable.has(index)}
+                                                onChange={() => selection.onToggle(index)}
+                                                title={
+                                                    selection.selectable.has(index)
+                                                        ? 'Include this row in push'
+                                                        : 'Not pushable (unmapped or has errors)'
+                                                }
+                                                className="h-3.5 w-3.5 cursor-pointer disabled:cursor-not-allowed"
+                                            />
+                                        )}
+                                        <span className="text-gray-400 text-xs">{index}</span>
+                                    </div>
                                     {rowActions?.[index] && (() => {
                                         const s = ACTION_STYLES[rowActions[index]]
                                         return (

--- a/frontend/src/services/superMigrationApi.ts
+++ b/frontend/src/services/superMigrationApi.ts
@@ -1,0 +1,30 @@
+import { apiClient } from './api'
+import type {
+    ModuleInfo,
+    MasterOption,
+    FetchResult,
+    TransformResult,
+    SeedResult,
+} from './migrationApi'
+
+/**
+ * Super-migration API. Mirrors migrationApi but has no KVK selection — the
+ * target KVK is resolved per-row on the backend from a superadmin curl.
+ */
+export const superMigrationApi = {
+    getModules: () => apiClient.get<{ modules: ModuleInfo[] }>('/super-migration/modules'),
+
+    getMasterOptions: (master: string) =>
+        apiClient.get<{ options: MasterOption[] }>(
+            `/super-migration/master-options/${encodeURIComponent(master)}`,
+        ),
+
+    fetchCurl: (curl: string) =>
+        apiClient.post<FetchResult>('/super-migration/fetch', { curl }),
+
+    transform: (module: string, raw: unknown) =>
+        apiClient.post<TransformResult>('/super-migration/transform', { module, raw }),
+
+    seed: (module: string, records: unknown[]) =>
+        apiClient.post<SeedResult>('/super-migration/seed', { module, records }),
+}


### PR DESCRIPTION
## What

New `/super-migration` route — same migration workbench, but the target KVK is resolved **per-row** from a superadmin curl (`kvk_id` empty → all KVKs) instead of a KVK picker. Plus push filters to migrate selective KVKs / rows.

## Backend
- `migration/superEngine.js` — `superTransform(module, raw)` resolves each row's KVK from its own `kvk.kvk_name` via MasterResolver, runs the unchanged module spec with a per-row context. `superSeed(module, records)` insert-only; `kvkId` taken per-record.
- `migration/superRoutes.js` — `/modules`, `/master-options/:master`, `/fetch`, `/transform`, `/seed`. Mounted at `/super-migration` in `routes/index.js`.
- Reuses existing registry/specs/curlParser/masterResolver — no module changes.

## Frontend
- `SuperMigrationTool.tsx` + `superMigrationApi.ts` — migration tool minus KVK selector.
- **Push filters**: per-KVK chips (with row counts, select/clear all) and per-row checkboxes. Only selected rows pushed (unselected sent as `null` → skipped server-side); clean subset can ship even if other rows error.
- `TableView` gains optional `RowSelection` prop (checkbox column + select-all), threaded through `RecordsViewer`. `MigrationTool` unaffected.

## Verify
- `bun run type-check` clean, eslint clean on changed files, backend requires load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)