### PR TITLE
fix(super-migration): KVK nesting variants + time-boxed enrichment

### DIFF
--- a/backend/migration/engine.js
+++ b/backend/migration/engine.js
@@ -12,6 +12,35 @@ function extractRows(raw) {
 }
 
 /**
+ * Per-row edit-page enrichment is fine for a single-KVK pull (tens of rows) but
+ * a superadmin all-KVK pull is hundreds/thousands of rows × multiple slow PHP
+ * fetches each — that overruns the serverless wall-clock and the whole fetch
+ * fails ("Failed to fetch"). Cap enrichment by a wall-clock budget: if it wins
+ * the race we use the enriched rows; if it overruns we fall back to the raw
+ * list rows. The specs already degrade gracefully on a missing edit page
+ * (inline list fields + a warning), so callers still get usable data instead of
+ * a hard failure. Budget is env-tunable (MIGRATION_ENRICH_BUDGET_MS).
+ */
+const ENRICH_BUDGET_MS = Number(process.env.MIGRATION_ENRICH_BUDGET_MS) || 45000;
+
+async function enrichWithinBudget(rawRows, enrichFn, headers) {
+    let timer;
+    const budget = new Promise(resolve => {
+        timer = setTimeout(() => resolve({ rows: rawRows, truncated: true }), ENRICH_BUDGET_MS);
+    });
+    // Resolve (never reject) so a late failure after the budget fires can't
+    // surface as an unhandled rejection; an enrich error degrades to the raw
+    // list rows (specs fall back to inline fields) instead of failing the fetch.
+    const work = Promise.resolve()
+        .then(() => enrichFn(rawRows, headers))
+        .then(rows => ({ rows, truncated: false }))
+        .catch(() => ({ rows: rawRows, truncated: true }));
+    const out = await Promise.race([work, budget]);
+    clearTimeout(timer);
+    return out;
+}
+
+/**
  * Replay a pasted curl command server-side (browser can't — cross-origin +
  * the old site's session cookie). Returns the parsed JSON body.
  */
@@ -34,32 +63,52 @@ async function fetchFromCurl(curl) {
         );
     }
     let rows = extractRows(json);
+    let enrichTruncated = false;
 
     // oft-data list JSON lacks technology options — enrich from each edit page.
     if (req.url.includes('oft-data') && rows.length) {
         const { enrichOftRows } = require('./modules/oft.js');
-        rows = await enrichOftRows(rows, req.headers);
+        const out = await enrichWithinBudget(rows, enrichOftRows, req.headers);
+        rows = out.rows;
+        enrichTruncated = enrichTruncated || out.truncated;
         if (Array.isArray(json.data)) json.data = rows;
     }
 
     // fld-data list JSON lacks full details — enrich from each edit page.
     if (req.url.includes('fld-data') && rows.length) {
         const { enrichFldRows } = require('./modules/fld.js');
-        rows = await enrichFldRows(rows, req.headers);
+        const out = await enrichWithinBudget(rows, enrichFldRows, req.headers);
+        rows = out.rows;
+        enrichTruncated = enrichTruncated || out.truncated;
         if (Array.isArray(json.data)) json.data = rows;
     }
 
-    // cfld technical parameter list lacks detail fields — enrich from each edit page.
+    // cfld technical parameter list: enrich from each edit page ONLY when the
+    // list JSON is the thin variant. The current `/project/cfld` response already
+    // embeds every detail field inline (existing_yield, total_produce, …) — for
+    // those, per-row edit-page fetches are redundant and (over hundreds of rows
+    // on a superadmin pull) blow the serverless time limit → "Failed to fetch".
     if (req.url.includes('/project/cfld') && !req.url.includes('cfld-extension') && !req.url.includes('cfld-budget') && rows.length) {
-        const { enrichCfldRows } = require('./modules/cfldTechnicalParameter.js');
-        rows = await enrichCfldRows(rows, req.headers);
-        if (Array.isArray(json.data)) json.data = rows;
+        const sample = rows[0] || {};
+        const hasInlineDetail =
+            sample.existing_yield !== undefined ||
+            sample.total_produce !== undefined ||
+            sample.variety_name !== undefined;
+        if (!hasInlineDetail) {
+            const { enrichCfldRows } = require('./modules/cfldTechnicalParameter.js');
+            const out = await enrichWithinBudget(rows, enrichCfldRows, req.headers);
+            rows = out.rows;
+            enrichTruncated = enrichTruncated || out.truncated;
+            if (Array.isArray(json.data)) json.data = rows;
+        }
     }
 
     // cfld extension activity list lacks demographic fields — enrich from each edit page.
     if (req.url.includes('cfld-extension-activity') && rows.length) {
         const { enrichCfldExtRows } = require('./modules/cfldExtensionActivity.js');
-        rows = await enrichCfldExtRows(rows, req.headers);
+        const out = await enrichWithinBudget(rows, enrichCfldExtRows, req.headers);
+        rows = out.rows;
+        enrichTruncated = enrichTruncated || out.truncated;
         if (Array.isArray(json.data)) json.data = rows;
     }
 
@@ -70,7 +119,7 @@ async function fetchFromCurl(curl) {
         if (Array.isArray(json.data)) json.data = rows;
     }
 
-    return { raw: json, rowCount: rows.length };
+    return { raw: json, rowCount: rows.length, enrichTruncated };
 }
 
 /**

--- a/backend/migration/modules/cfldTechnicalParameter.js
+++ b/backend/migration/modules/cfldTechnicalParameter.js
@@ -375,8 +375,10 @@ module.exports = {
                 else seasonOther = sel.name;
             }
         }
-        if (!seasonId && row.crop?.season_id) {
-            const nm = SEASON_MAP[row.crop.season_id];
+        if (!seasonId) {
+            // List JSON carries season_id inline; crop.season_id is the fallback.
+            const oldSeason = row.season_id ?? row.crop?.season_id;
+            const nm = SEASON_MAP[oldSeason];
             if (nm) {
                 const s = await r.resolve('season', 'seasonName', 'seasonId', nm);
                 if (s.matched) seasonId = s.id;
@@ -462,8 +464,11 @@ module.exports = {
         if (!technologyDemonstrated) err('technologyDemonstrated', 'Missing technology demonstrated');
 
         // ── Variety name ─────────────────────────────────────────────────
-        let varietyName = '';
-        if (html) varietyName = decodeEntities(cleanText(parseInputValue(html, 'variety_name'))) || '';
+        let varietyName = decodeEntities(cleanText(row.variety_name)) || '';
+        if (html) {
+            const v = decodeEntities(cleanText(parseInputValue(html, 'variety_name'))) || '';
+            if (v) varietyName = v;
+        }
         if (!varietyName) {
             varietyName = 'Not specified';
             warn('varietyName', 'Missing variety_name — defaulted to "Not specified"');
@@ -472,9 +477,10 @@ module.exports = {
         // ── Existing farmer practice ──────────────────────────────────────
         // Old site stores this as "existing_variety_name" (misleadingly named —
         // it's the existing farmer practice / variety in farmer's field).
-        let existingFarmerPractice = '';
+        let existingFarmerPractice =
+            decodeEntities(cleanText(row.existing_variety_name)) || '';
         if (html) {
-            existingFarmerPractice =
+            const v =
                 decodeEntities(
                     cleanText(
                         parseInputValue(html, 'existing_variety_name') ||
@@ -483,6 +489,7 @@ module.exports = {
                         parseInputValue(html, 'existing_farmer_practice'),
                     ),
                 ) || '';
+            if (v) existingFarmerPractice = v;
         }
         if (!existingFarmerPractice) warn('existingFarmerPractice', 'Missing — stored as empty string');
 
@@ -509,14 +516,16 @@ module.exports = {
         let districtYield = floatOrZero(row.district_yield);
         let stateYield = floatOrZero(row.state_yield);
         let potentialYield = floatOrZero(row.potential_yield);
-        let farmerYield = 0;
-        let demoYieldMax = 0;
-        let demoYieldMin = 0;
-        let demoYieldAvg = 0;
-        let percentIncrease = 0;
-        let yieldGapDistrictMinimized = 0;
-        let yieldGapStateMinimized = 0;
-        let yieldGapPotentialMinimized = 0;
+        // List JSON carries these inline (same field names as the edit form);
+        // seed from the row, let html override when an edit page is present.
+        let farmerYield = floatOrZero(row.existing_yield);
+        let demoYieldMax = floatOrZero(row.yield_max);
+        let demoYieldMin = floatOrZero(row.yield_min);
+        let demoYieldAvg = floatOrZero(row.yield_avg);
+        let percentIncrease = floatOrZero(row.yield_increase);
+        let yieldGapDistrictMinimized = floatOrZero(row.yield_gap_d);
+        let yieldGapStateMinimized = floatOrZero(row.yield_gap_s);
+        let yieldGapPotentialMinimized = floatOrZero(row.yield_gap_p);
 
         if (html) {
             farmerYield = floatOrZero(parseInputValue(html, 'existing_yield') || parseInputValue(html, 'farmer_yield'));
@@ -536,8 +545,12 @@ module.exports = {
         }
 
         // ── Farmer demographics ───────────────────────────────────────────
-        let generalM = 0, generalF = 0, obcM = 0, obcF = 0;
-        let scM = 0, scF = 0, stM = 0, stF = 0;
+        // Inline list fields carry the caste/gender split directly (general_m …
+        // st_f); seed from them, let an edit page override when present.
+        let generalM = intOrZero(row.general_m), generalF = intOrZero(row.general_f);
+        let obcM = intOrZero(row.obc_m), obcF = intOrZero(row.obc_f);
+        let scM = intOrZero(row.sc_m), scF = intOrZero(row.sc_f);
+        let stM = intOrZero(row.st_m), stF = intOrZero(row.st_f);
         if (html) {
             generalM = intOrZero(parseInputValue(html, 'general_m'));
             generalF = intOrZero(parseInputValue(html, 'general_f'));
@@ -547,13 +560,6 @@ module.exports = {
             scF = intOrZero(parseInputValue(html, 'sc_f'));
             stM = intOrZero(parseInputValue(html, 'st_m'));
             stF = intOrZero(parseInputValue(html, 'st_f'));
-        } else {
-            // No edit HTML: put list sub_total into generalM as best-effort
-            const listTotal = intOrZero(row.sub_total);
-            if (listTotal > 0) {
-                generalM = listTotal;
-                warn('generalM', `No edit page — placed sub_total (${listTotal}) into generalM`);
-            }
         }
 
         // ── Photo paths ───────────────────────────────────────────────────

--- a/backend/migration/superEngine.js
+++ b/backend/migration/superEngine.js
@@ -27,10 +27,35 @@ function asObject(value) {
     return null;
 }
 
-/** Pull the old-site KVK name out of a row, decoded the same way the specs do. */
+/**
+ * Pull the old-site KVK name out of a row, decoded the same way the specs do.
+ * The KVK object lives under different keys per endpoint — `kvk`, `kvks`
+ * (infra/equipment), or nested under a parent relation (`equipment.kvks`,
+ * `agri_drone.kvk`). Rather than hard-code every variant, search the row (and
+ * its nested objects, depth-bounded) for any `kvk_name`, plus any flat dotted
+ * key ending in `.kvk_name`. One row only ever carries its own KVK, so the
+ * first match is the right one.
+ */
+function findKvkName(obj, depth = 0) {
+    const o = asObject(obj);
+    if (!o || depth > 2) return '';
+    if (typeof o.kvk_name === 'string' && o.kvk_name.trim()) return o.kvk_name;
+    for (const key of Object.keys(o)) {
+        // flat dotted key, e.g. 'equipment.kvks.kvk_name'
+        if (key.endsWith('.kvk_name') && typeof o[key] === 'string' && o[key].trim()) {
+            return o[key];
+        }
+        const child = asObject(o[key]);
+        if (child) {
+            const found = findKvkName(child, depth + 1);
+            if (found) return found;
+        }
+    }
+    return '';
+}
+
 function rowKvkName(row) {
-    const kvkObj = asObject(row.kvk);
-    return decodeEntities(cleanText(kvkObj?.kvk_name || row['kvk.kvk_name'])) || '';
+    return decodeEntities(cleanText(findKvkName(row))) || '';
 }
 
 /**

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -6,6 +6,11 @@
             "destination": "/index.js"
         }
     ],
+    "functions": {
+        "index.js": {
+            "maxDuration": 60
+        }
+    },
     "env": {
         "NODE_ENV": "production"
     }

--- a/frontend/src/pages/migration/SuperMigrationTool.tsx
+++ b/frontend/src/pages/migration/SuperMigrationTool.tsx
@@ -31,6 +31,7 @@ export function SuperMigrationTool() {
 
     const [raw, setRaw] = useState<unknown>(undefined)
     const [rowCount, setRowCount] = useState<number | null>(null)
+    const [enrichTruncated, setEnrichTruncated] = useState(false)
     const [splitPercent, setSplitPercent] = useState<number>(50)
     const [verticalSplit, setVerticalSplit] = useState<number>(65)
     const [showErrorsOnly, setShowErrorsOnly] = useState<boolean>(false)
@@ -175,6 +176,7 @@ export function SuperMigrationTool() {
             const out = await superMigrationApi.fetchCurl(curl)
             setRaw(out.raw)
             setRowCount(out.rowCount)
+            setEnrichTruncated(out.enrichTruncated === true)
         })
 
     const onTransform = () =>
@@ -427,6 +429,15 @@ export function SuperMigrationTool() {
             {error && (
                 <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
                     {error}
+                </div>
+            )}
+
+            {enrichTruncated && (
+                <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                    Edit-page enrichment hit its time budget and was cut short —
+                    later rows fall back to inline list fields, so some detail
+                    columns may be incomplete. Push what maps cleanly, then re-run
+                    the affected KVKs via the per-KVK migration tool for full detail.
                 </div>
             )}
 

--- a/frontend/src/services/migrationApi.ts
+++ b/frontend/src/services/migrationApi.ts
@@ -25,6 +25,10 @@ export interface MasterOption {
 export interface FetchResult {
     raw: unknown
     rowCount: number
+    // True when per-row edit-page enrichment hit its wall-clock budget and was
+    // cut short — affected rows fall back to inline list fields (some detail
+    // columns may be incomplete). Re-run those KVKs via the per-KVK tool.
+    enrichTruncated?: boolean
 }
 
 export type IssueSeverity = 'error' | 'warn'


### PR DESCRIPTION
## Problem
On the Super Data Migration tool, two failure classes blocked migration:

1. **"No KVK name on old row — cannot resolve target KVK"** (all rows errored) for **Infrastructure** and **Equipment**. The per-row KVK resolver only read top-level `row.kvk`, but those endpoints nest the KVK object under `kvks` (plural) — and `equipmentDetails` / `agriDroneDemonstration` nest it under a parent relation (`equipment.kvks`, `agri_drone.kvk`).
2. **"Failed to fetch"** for **CFLD Technical Parameters**. The list response already carries every detail field inline, but the engine still ran per-row edit + sub-form page fetches (up to 4 slow PHP requests × hundreds of rows), overrunning the serverless wall-clock.

## Fix
- **superEngine**: generic depth-bounded `findKvkName` locates `kvk_name` anywhere in a row (top-level `kvk`/`kvks`, nested parent relations, flat dotted keys). Covers all current + future modules.
- **engine**: skip the redundant CFLD-technical enrichment when the list already has inline detail.
- **engine**: wrap `oft` / `fld` / `cfld-technical` / `cfld-extension` enrichment in a wall-clock budget (`MIGRATION_ENRICH_BUDGET_MS`, default 45s). On overrun or error it degrades to raw list rows (specs already fall back to inline fields + per-row warnings) instead of hard-failing. `training` does a single bulk fetch — untouched.
- **cfldTechnicalParameter**: read yields, demographics, variety, existing-practice and season from inline list fields; HTML overrides only when an edit page is present.
- **vercel**: `index.js` `maxDuration: 60` so the budget can fire before the platform kills the function.
- **UI**: `enrichTruncated` flows through `FetchResult`; the super tool shows an amber banner advising a per-KVK re-run for affected KVKs.

## Per-KVK migration — unaffected
- `enrichWithinBudget` is shared, but per-KVK pulls are small and always win the race → identical full-enrichment behavior.
- CFLD inline-field reads apply to both paths (same `/project/cfld` columns whether `kvk_id` is empty or set).
- `enrichTruncated` is optional and ignored by the per-KVK tool.
- Budget helper never rejects → no unhandled rejections in the long-lived dev server.

## Verification
- Backend `node -c` on all changed modules — OK.
- Budget helper unit-tested: fast→full, slow→raw+truncated, error→raw+truncated, no unhandled rejection.
- `findKvkName` tested against all 6 nesting shapes.
- Frontend `tsc --noEmit` — clean.