### PR TITLE
feat(super-migration): KVK-scoped curl migration + full about-kvk lists

### DIFF
--- a/frontend/src/hooks/forms/useAboutKvkData.ts
+++ b/frontend/src/hooks/forms/useAboutKvkData.ts
@@ -462,17 +462,23 @@ export type AboutKvkEntity =
     | typeof ENTITY_TYPES.KVK_EQUIPMENT_DETAILS;
 
 export function useAboutKvkData(entityType: AboutKvkEntity | null) {
-    // We must call all hooks unconditionally to satisfy React rules
-    const kvks = useKvks();
-    const accounts = useKvkBankAccounts();
-    const employees = useKvkEmployees();
-    const transferred = useKvkStaffTransferred();
-    const infra = useKvkInfrastructure();
-    const landDetails = useKvkLandDetails();
-    const vehicles = useKvkVehicles();
-    const vehicleDetails = useKvkVehicleDetails();
-    const equipments = useKvkEquipments();
-    const equipmentDetails = useKvkEquipmentDetails();
+    // We must call all hooks unconditionally to satisfy React rules.
+    // DataManagementView runs its own client-side search/filter/pagination over
+    // the FULL dataset, so each list must return every row — not the backend's
+    // default first page (limit 100, see aboutKvkController). Request the repo's
+    // hard cap (Math.min(limit, 10000)) so cross-KVK views (e.g. super-admin
+    // seeing 1500+ equipments) aren't silently truncated to 100.
+    const FULL = { limit: 10000 };
+    const kvks = useKvks(FULL);
+    const accounts = useKvkBankAccounts(FULL);
+    const employees = useKvkEmployees(FULL);
+    const transferred = useKvkStaffTransferred(FULL);
+    const infra = useKvkInfrastructure(FULL);
+    const landDetails = useKvkLandDetails(FULL);
+    const vehicles = useKvkVehicles(FULL);
+    const vehicleDetails = useKvkVehicleDetails(FULL);
+    const equipments = useKvkEquipments(FULL);
+    const equipmentDetails = useKvkEquipmentDetails(FULL);
 
     if (!entityType) {
         return {

--- a/frontend/src/pages/migration/SuperMigrationTool.tsx
+++ b/frontend/src/pages/migration/SuperMigrationTool.tsx
@@ -94,6 +94,36 @@ function rowKvkName(row: Row): string {
     return decodeEntities(cleaned)
 }
 
+// KVKs pre-checked in the picker on each fetch. Old-site names vary in form
+// ("Krishi Vigyan Kendra, Dumka", "KVK DHANBAD", "KVK Manpur Gaya", "kvkpatna"),
+// so match on a stripped core (drop the "KVK"/"Krishi Vigyan Kendra" prefix and
+// all punctuation) rather than the literal string.
+const DEFAULT_KVKS = [
+    'KVK Begusarai',
+    'KVK Chatra',
+    'KVK Darbhanga',
+    'KVK Dhanbad',
+    'KVK Dumka',
+    'KVK Gumla',
+    'KVK Manpur, Gaya',
+    'KVK Nalanda',
+    'KVK Nawada',
+    'KVK Pakur',
+    'KVK Patna',
+    'KVK Sahibganj',
+]
+
+function kvkCore(name: string): string {
+    const n = name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+    return n.replace(/^krishi vigyan kendra\s*/, '').replace(/^kvk\s*/, '').trim()
+}
+
+const DEFAULT_KVK_CORES = new Set(DEFAULT_KVKS.map(kvkCore))
+
 /**
  * Super-migration workbench. Same flow as MigrationTool but WITHOUT a KVK
  * picker: paste a superadmin curl (kvk_id empty → all KVKs) -> pick module ->
@@ -193,14 +223,23 @@ export function SuperMigrationTool() {
             const name = rowKvkName(r)
             m.set(name, (m.get(name) ?? 0) + 1)
         })
+        // Priority (default) KVKs float to the top, then the rest alphabetical.
         return [...m.entries()]
             .map(([name, count]) => ({ name, count }))
-            .sort((a, b) => a.name.localeCompare(b.name))
+            .sort((a, b) => {
+                const pa = DEFAULT_KVK_CORES.has(kvkCore(a.name)) ? 0 : 1
+                const pb = DEFAULT_KVK_CORES.has(kvkCore(b.name)) ? 0 : 1
+                return pa - pb || a.name.localeCompare(b.name)
+            })
     }, [raw])
 
-    // Default to every KVK selected each time a fresh pull arrives.
+    // On each fresh pull, pre-check the default KVKs (matched by stripped core).
+    // Fall back to selecting all if the pull contains none of them, so an
+    // unrelated dataset isn't left with an empty (un-transformable) selection.
     useEffect(() => {
-        setSelectedRawKvks(new Set(rawKvkGroups.map(g => g.name)))
+        const matched = rawKvkGroups.filter(g => DEFAULT_KVK_CORES.has(kvkCore(g.name)))
+        const chosen = matched.length > 0 ? matched : rawKvkGroups
+        setSelectedRawKvks(new Set(chosen.map(g => g.name)))
     }, [rawKvkGroups])
 
     useEffect(() => {

--- a/frontend/src/pages/migration/SuperMigrationTool.tsx
+++ b/frontend/src/pages/migration/SuperMigrationTool.tsx
@@ -12,6 +12,7 @@ import {
 import { RecordsViewer } from './components/RecordsViewer'
 import { MigrationReport } from './components/MigrationReport'
 import { SearchableSelect } from './components/SearchableSelect'
+import { KvkSelectDropdown, type KvkOption } from './components/KvkSelectDropdown'
 import type { FkEditing } from './views/tableUtils'
 import type { RowSelection } from './views/TableView'
 
@@ -40,6 +41,59 @@ function extractRows(raw: unknown): Row[] {
     return []
 }
 
+// Mirror backend superEngine.rowKvkName so we can group/filter the raw rows by
+// KVK BEFORE transform (the backend resolves each row's KVK from its own
+// `kvk_name`, which may sit nested or under a flat dotted key). Keeping the same
+// extraction rules means the names we filter on match the names the backend
+// resolves, so a selected subset transforms exactly the rows we expect.
+function asRowObject(value: unknown): Record<string, unknown> | null {
+    if (value == null) return null
+    if (typeof value === 'object') return value as Record<string, unknown>
+    if (typeof value === 'string') {
+        try {
+            return JSON.parse(value)
+        } catch {
+            return null
+        }
+    }
+    return null
+}
+
+function findKvkName(obj: unknown, depth = 0): string {
+    const o = asRowObject(obj)
+    if (!o || depth > 2) return ''
+    if (typeof o.kvk_name === 'string' && o.kvk_name.trim()) return o.kvk_name
+    for (const key of Object.keys(o)) {
+        const v = o[key]
+        if (key.endsWith('.kvk_name') && typeof v === 'string' && v.trim()) return v
+        const child = asRowObject(v)
+        if (child) {
+            const found = findKvkName(child, depth + 1)
+            if (found) return found
+        }
+    }
+    return ''
+}
+
+function decodeEntities(value: string): string {
+    return value
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#0?39;/g, "'")
+        .trim()
+}
+
+// Empty string = no resolvable KVK name on the row (backend reports these as
+// errors); we keep them as a distinct, selectable group.
+function rowKvkName(row: Row): string {
+    const found = findKvkName(row)
+    const cleaned = found ? String(found).trim() : ''
+    if (!cleaned || cleaned.toLowerCase() === 'n/a') return ''
+    return decodeEntities(cleaned)
+}
+
 /**
  * Super-migration workbench. Same flow as MigrationTool but WITHOUT a KVK
  * picker: paste a superadmin curl (kvk_id empty → all KVKs) -> pick module ->
@@ -53,6 +107,9 @@ export function SuperMigrationTool() {
 
     const [raw, setRaw] = useState<unknown>(undefined)
     const [rowCount, setRowCount] = useState<number | null>(null)
+    // Pre-transform KVK filter: distinct old-site KVK names the user wants to
+    // migrate. Empty set = none; defaults to all after each fetch.
+    const [selectedRawKvks, setSelectedRawKvks] = useState<Set<string>>(new Set())
     const [enrichTruncated, setEnrichTruncated] = useState(false)
     const [splitPercent, setSplitPercent] = useState<number>(50)
     const [verticalSplit, setVerticalSplit] = useState<number>(65)
@@ -127,6 +184,24 @@ export function SuperMigrationTool() {
         () => modules.find(m => m.key === moduleKey) || null,
         [modules, moduleKey],
     )
+
+    // Distinct KVKs in the raw pull (name → row count) — drives the pre-transform
+    // picker. Recomputed whenever a new curl is fetched.
+    const rawKvkGroups = useMemo<KvkOption[]>(() => {
+        const m = new Map<string, number>()
+        extractRows(raw).forEach(r => {
+            const name = rowKvkName(r)
+            m.set(name, (m.get(name) ?? 0) + 1)
+        })
+        return [...m.entries()]
+            .map(([name, count]) => ({ name, count }))
+            .sort((a, b) => a.name.localeCompare(b.name))
+    }, [raw])
+
+    // Default to every KVK selected each time a fresh pull arrives.
+    useEffect(() => {
+        setSelectedRawKvks(new Set(rawKvkGroups.map(g => g.name)))
+    }, [rawKvkGroups])
 
     useEffect(() => {
         superMigrationApi
@@ -208,7 +283,13 @@ export function SuperMigrationTool() {
         run('transform', async () => {
             setSeedResult(null)
             setRowActions([])
-            const allRows = extractRows(raw)
+            // Only transform rows whose KVK the user picked — a 900+ row
+            // superadmin pull can be migrated a few KVKs at a time, keeping each
+            // run small and fast. Filtering here means the unselected rows are
+            // never sent or processed at all.
+            const allRows = extractRows(raw).filter(r =>
+                selectedRawKvks.has(rowKvkName(r)),
+            )
 
             // Accumulate batch results in original row order. Report row indices
             // are batch-local, so shift them by the batch offset to stay aligned
@@ -455,7 +536,7 @@ export function SuperMigrationTool() {
         ? { foreignKeys: activeModule.foreignKeys, fkOptions, onEditCell, onEditField, onFillUnmatched }
         : undefined
 
-    const canTransform = raw !== undefined && moduleKey !== ''
+    const canTransform = raw !== undefined && moduleKey !== '' && selectedRawKvks.size > 0
     // Selective push: enabled as long as at least one row is selected (clean rows
     // can ship even while others still carry errors).
     const canSeed = selectedRowIndices.size > 0
@@ -512,6 +593,23 @@ export function SuperMigrationTool() {
                     </Button>
                 </div>
             </div>
+
+            {/* Pre-transform KVK filter — restrict the transform to a subset of
+                KVKs so a large superadmin pull can be migrated in batches. */}
+            {rawKvkGroups.length > 0 && (
+                <div className="flex flex-wrap items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
+                    <KvkSelectDropdown
+                        options={rawKvkGroups}
+                        selected={selectedRawKvks}
+                        onChange={setSelectedRawKvks}
+                    />
+                    {selectedRawKvks.size === 0 && (
+                        <span className="text-xs text-amber-700">
+                            Select at least one KVK to transform.
+                        </span>
+                    )}
+                </div>
+            )}
 
             {error && (
                 <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">

--- a/frontend/src/pages/migration/SuperMigrationTool.tsx
+++ b/frontend/src/pages/migration/SuperMigrationTool.tsx
@@ -18,6 +18,28 @@ import type { RowSelection } from './views/TableView'
 type Busy = '' | 'fetch' | 'transform' | 'seed'
 type Row = Record<string, unknown>
 
+// A superadmin pull is hundreds/thousands of rows, and both transform (per-row
+// DB lookups) and seed (per-row insert) run serially server-side — one giant
+// request blows the 60s serverless wall (Vercel maxDuration) and the client
+// sees "NetworkError". Instead we slice the rows into batches and call the
+// backend once per batch, accumulating results in order. Each batch stays well
+// under the limit. ~200 rows/batch balances round-trips against per-call cost.
+const BATCH_SIZE = 200
+
+// Mirror backend engine.extractRows: pull the row array out of a raw response
+// (DataTables `data`, nested `data.data`, or a bare array) so we can batch it.
+// Backend transform accepts a bare array (extractRows handles it), so each
+// batch is sent as a plain slice.
+function extractRows(raw: unknown): Row[] {
+    if (Array.isArray(raw)) return raw as Row[]
+    const r = raw as { data?: unknown } | null
+    if (r && Array.isArray(r.data)) return r.data as Row[]
+    if (r && r.data && Array.isArray((r.data as { data?: unknown }).data)) {
+        return (r.data as { data: Row[] }).data
+    }
+    return []
+}
+
 /**
  * Super-migration workbench. Same flow as MigrationTool but WITHOUT a KVK
  * picker: paste a superadmin curl (kvk_id empty → all KVKs) -> pick module ->
@@ -98,6 +120,8 @@ export function SuperMigrationTool() {
 
     const [busy, setBusy] = useState<Busy>('')
     const [error, setError] = useState('')
+    // Batch progress for the chunked transform/seed (null when idle).
+    const [progress, setProgress] = useState<{ done: number; total: number } | null>(null)
 
     const activeModule = useMemo(
         () => modules.find(m => m.key === moduleKey) || null,
@@ -164,6 +188,7 @@ export function SuperMigrationTool() {
             setError(e instanceof Error ? e.message : String(e))
         } finally {
             setBusy('')
+            setProgress(null)
         }
     }
 
@@ -183,13 +208,46 @@ export function SuperMigrationTool() {
         run('transform', async () => {
             setSeedResult(null)
             setRowActions([])
-            const out = await superMigrationApi.transform(moduleKey, raw)
-            setTransformed(out)
-            const recs = out.records as Array<Row | null>
-            setRecords(recs)
+            const allRows = extractRows(raw)
+
+            // Accumulate batch results in original row order. Report row indices
+            // are batch-local, so shift them by the batch offset to stay aligned
+            // with the flat `records` array the UI keys everything off.
+            const records: Array<Row | null> = []
+            const reportRows: TransformResult['report']['rows'] = []
+            let errorCount = 0
+            let warnCount = 0
+
+            setProgress({ done: 0, total: allRows.length })
+            for (let off = 0; off < allRows.length; off += BATCH_SIZE) {
+                const slice = allRows.slice(off, off + BATCH_SIZE)
+                const out = await superMigrationApi.transform(moduleKey, slice)
+                ;(out.records as Array<Row | null>).forEach(r => records.push(r))
+                out.report.rows.forEach(rr =>
+                    reportRows.push({ ...rr, index: rr.index + off }),
+                )
+                errorCount += out.report.errorCount
+                warnCount += out.report.warnCount
+                setProgress({ done: Math.min(off + slice.length, allRows.length), total: allRows.length })
+            }
+            setProgress(null)
+
+            const merged: TransformResult = {
+                records,
+                report: {
+                    total: allRows.length,
+                    mapped: records.filter(Boolean).length,
+                    errorCount,
+                    warnCount,
+                    seedable: errorCount === 0,
+                    rows: reportRows,
+                },
+            }
+            setTransformed(merged)
+            setRecords(records)
             // Default: every KVK present is selected, no rows excluded.
             const ids = new Set<number>()
-            recs.forEach(r => {
+            records.forEach(r => {
                 const id = r?.kvkId
                 if (typeof id === 'number') ids.add(id)
             })
@@ -203,9 +261,32 @@ export function SuperMigrationTool() {
             // Push only selected rows; unselected become null → skipped server-side.
             // Index positions are preserved so returned actions align with the table.
             const filtered = records.map((r, i) => (selectedRowIndices.has(i) ? r : null))
-            const out = await superMigrationApi.seed(moduleKey, filtered)
-            setSeedResult(out)
-            setRowActions(out.actions ?? [])
+
+            // Batch the insert the same way as transform so a large push can't
+            // overrun the serverless wall. Accumulate counts, and concat the
+            // per-row actions in order; failed indices are batch-local, so shift
+            // them by the batch offset to point at the real table row.
+            const merged: SeedResult = {
+                created: 0,
+                updated: 0,
+                skipped: 0,
+                failed: [],
+                actions: [],
+            }
+            setProgress({ done: 0, total: filtered.length })
+            for (let off = 0; off < filtered.length; off += BATCH_SIZE) {
+                const slice = filtered.slice(off, off + BATCH_SIZE)
+                const out = await superMigrationApi.seed(moduleKey, slice)
+                merged.created += out.created
+                merged.updated += out.updated
+                merged.skipped += out.skipped
+                out.failed.forEach(f => merged.failed.push({ ...f, index: f.index + off }))
+                ;(out.actions ?? []).forEach(a => merged.actions.push(a))
+                setProgress({ done: Math.min(off + slice.length, filtered.length), total: filtered.length })
+            }
+            setProgress(null)
+            setSeedResult(merged)
+            setRowActions(merged.actions)
         })
 
     const onEditCell = (rowIndex: number, field: string, value: number | null) => {
@@ -412,7 +493,11 @@ export function SuperMigrationTool() {
                         onClick={onTransform}
                         disabled={!canTransform || busy !== ''}
                     >
-                        {busy === 'transform' ? 'Transforming…' : 'Transform'}
+                        {busy === 'transform'
+                            ? progress
+                                ? `Transforming ${progress.done}/${progress.total}…`
+                                : 'Transforming…'
+                            : 'Transform'}
                     </Button>
                     <Button
                         onClick={onSeed}
@@ -420,7 +505,9 @@ export function SuperMigrationTool() {
                         className="bg-green-600 hover:bg-green-700"
                     >
                         {busy === 'seed'
-                            ? 'Pushing…'
+                            ? progress
+                                ? `Pushing ${progress.done}/${progress.total}…`
+                                : 'Pushing…'
                             : `Push to DB${transformed ? ` (${selectedRowIndices.size})` : ''}`}
                     </Button>
                 </div>

--- a/frontend/src/pages/migration/components/KvkSelectDropdown.tsx
+++ b/frontend/src/pages/migration/components/KvkSelectDropdown.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown, Search, X } from 'lucide-react'
+
+export interface KvkOption {
+    // Distinct old-site KVK name from the raw pull. Empty string = rows that
+    // carry no resolvable KVK name (shown as "(No KVK name)").
+    name: string
+    count: number
+}
+
+interface Props {
+    options: KvkOption[]
+    selected: Set<string>
+    onChange: (next: Set<string>) => void
+}
+
+const BLANK_LABEL = '(No KVK name)'
+
+/**
+ * Pre-transform KVK picker. Lists every distinct KVK present in the raw pull
+ * with its row count and lets the user restrict the transform to a subset, so a
+ * 900+ row superadmin pull can be migrated KVK-by-KVK in effective time. Styled
+ * to match the app's table column-filter panel (select-all + value search +
+ * scrollable checkbox list + Clear/Done).
+ */
+export function KvkSelectDropdown({ options, selected, onChange }: Props) {
+    const [open, setOpen] = useState(false)
+    const [valueSearch, setValueSearch] = useState('')
+    const wrapRef = useRef<HTMLDivElement | null>(null)
+
+    useEffect(() => {
+        if (!open) return
+        const onDocClick = (e: MouseEvent) => {
+            if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
+        }
+        const onEsc = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setOpen(false)
+        }
+        document.addEventListener('mousedown', onDocClick)
+        document.addEventListener('keydown', onEsc)
+        return () => {
+            document.removeEventListener('mousedown', onDocClick)
+            document.removeEventListener('keydown', onEsc)
+        }
+    }, [open])
+
+    const filtered = useMemo(() => {
+        const q = valueSearch.trim().toLowerCase()
+        if (!q) return options
+        return options.filter(o => (o.name || BLANK_LABEL).toLowerCase().includes(q))
+    }, [options, valueSearch])
+
+    const allVisibleSelected = filtered.length > 0 && filtered.every(o => selected.has(o.name))
+    const someVisibleSelected = filtered.some(o => selected.has(o.name))
+
+    const toggle = (name: string) => {
+        const next = new Set(selected)
+        if (next.has(name)) next.delete(name)
+        else next.add(name)
+        onChange(next)
+    }
+
+    const toggleAllVisible = () => {
+        const next = new Set(selected)
+        if (allVisibleSelected) filtered.forEach(o => next.delete(o.name))
+        else filtered.forEach(o => next.add(o.name))
+        onChange(next)
+    }
+
+    const totalRows = options.reduce((n, o) => n + o.count, 0)
+    const selectedRows = options
+        .filter(o => selected.has(o.name))
+        .reduce((n, o) => n + o.count, 0)
+
+    return (
+        <div ref={wrapRef} className="relative">
+            <button
+                type="button"
+                onClick={() => setOpen(o => !o)}
+                className="inline-flex items-center gap-2 rounded-md border border-[#E0E0E0] bg-white px-3 py-2 text-sm text-[#212121] hover:bg-gray-50"
+            >
+                <span className="font-medium">KVKs to transform:</span>
+                <span className="font-semibold text-[#487749]">
+                    {selected.size}/{options.length}
+                </span>
+                <span className="text-xs text-[#9E9E9E]">
+                    ({selectedRows}/{totalRows} rows)
+                </span>
+                <ChevronDown className="h-4 w-4 text-[#9E9E9E]" />
+            </button>
+
+            {open && (
+                <div className="absolute z-[100] mt-1 w-[280px] overflow-hidden rounded-xl border border-[#E0E0E0] bg-white text-[#212121] shadow-2xl">
+                    <div className="flex items-center justify-between gap-2 border-b border-[#E0E0E0] px-3 py-2">
+                        <span className="truncate text-xs font-semibold uppercase tracking-wide text-[#487749]">
+                            KVKs
+                        </span>
+                        <button
+                            type="button"
+                            onClick={() => setOpen(false)}
+                            className="rounded p-0.5 text-gray-500 hover:bg-gray-100"
+                            aria-label="Close"
+                        >
+                            <X className="h-3.5 w-3.5" />
+                        </button>
+                    </div>
+
+                    <div className="px-3 py-2">
+                        <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[#9E9E9E]">
+                            Values
+                        </div>
+                        <div className="relative mb-2">
+                            <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[#9E9E9E]" />
+                            <input
+                                type="text"
+                                value={valueSearch}
+                                onChange={e => setValueSearch(e.target.value)}
+                                placeholder="Search KVKs..."
+                                className="w-full rounded-md border border-[#E0E0E0] py-1 pl-7 pr-2 text-xs focus:border-[#487749] focus:outline-none focus:ring-1 focus:ring-[#487749]"
+                            />
+                        </div>
+                        <label className="mb-1 flex cursor-pointer items-center gap-2 border-b border-gray-100 px-1 py-1 text-xs hover:bg-gray-50">
+                            <input
+                                type="checkbox"
+                                checked={allVisibleSelected}
+                                ref={el => {
+                                    if (el) el.indeterminate = !allVisibleSelected && someVisibleSelected
+                                }}
+                                onChange={toggleAllVisible}
+                                className="accent-[#487749]"
+                            />
+                            <span className="font-medium">(Select all)</span>
+                        </label>
+                        <div className="max-h-56 overflow-y-auto pr-1">
+                            {filtered.length === 0 ? (
+                                <div className="py-2 text-center text-xs text-[#9E9E9E]">No KVKs</div>
+                            ) : (
+                                filtered.map(o => (
+                                    <label
+                                        key={o.name || BLANK_LABEL}
+                                        className="flex cursor-pointer items-center gap-2 rounded px-1 py-1 text-xs hover:bg-gray-50"
+                                    >
+                                        <input
+                                            type="checkbox"
+                                            checked={selected.has(o.name)}
+                                            onChange={() => toggle(o.name)}
+                                            className="accent-[#487749]"
+                                        />
+                                        <span
+                                            className="flex-1 truncate"
+                                            title={o.name || BLANK_LABEL}
+                                        >
+                                            {o.name || <em className="text-[#9E9E9E]">{BLANK_LABEL}</em>}
+                                        </span>
+                                        <span className="shrink-0 rounded-full bg-gray-100 px-1.5 text-[10px] font-medium text-[#616161]">
+                                            {o.count}
+                                        </span>
+                                    </label>
+                                ))
+                            )}
+                        </div>
+                    </div>
+
+                    <div className="flex items-center justify-between border-t border-[#E0E0E0] bg-[#FAF9F6] px-3 py-2">
+                        <button
+                            type="button"
+                            onClick={() => onChange(new Set())}
+                            disabled={selected.size === 0}
+                            className="text-xs text-[#487749] hover:underline disabled:cursor-not-allowed disabled:text-[#9E9E9E] disabled:no-underline"
+                        >
+                            Clear all
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setOpen(false)}
+                            className="rounded-md bg-[#487749] px-3 py-1 text-xs text-white hover:bg-[#3d6540]"
+                        >
+                            Done
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}


### PR DESCRIPTION
Targets **dev**. Bundles the super-migration improvements on this branch.

## Highlights

### Pre-transform KVK filter (new)
A superadmin pull spans every KVK (900+ rows) and transforming all at once is slow. Added a picker to restrict the run to a subset of KVKs — only those rows are batched and sent, so a large pull migrates a few KVKs at a time. Client mirrors the backend's per-row KVK-name extraction (`superEngine.findKvkName/rowKvkName`) so filtered names match what the backend resolves. UI matches the app's table column-filter panel (select-all + value search + counts + Clear/Done).

### Batched transform/seed
Single-request transform/seed on a large pull overran the 60s serverless wall (`vercel.json maxDuration`) → `NetworkError`. Now sliced into 200-row batches, results merged in order (report row + `failed` indices offset per batch). Buttons show batch progress.

### About-KVK lists no longer truncated to 100
The about-kvk list hooks were called param-less → backend default `limit 100` → only the first page returned while `DataManagementView` paginates the full set client-side. Now request the repo cap (`limit 10000`) so the whole dataset loads (e.g. 1533 equipments, not 100).

## Test
- `bun run type-check` ✅
- `eslint` on changed files ✅