### PR TITLE
chore(migration): raise enrichment budget + serverless maxDuration

### DIFF
--- a/backend/migration/engine.js
+++ b/backend/migration/engine.js
@@ -21,7 +21,7 @@ function extractRows(raw) {
  * (inline list fields + a warning), so callers still get usable data instead of
  * a hard failure. Budget is env-tunable (MIGRATION_ENRICH_BUDGET_MS).
  */
-const ENRICH_BUDGET_MS = Number(process.env.MIGRATION_ENRICH_BUDGET_MS) || 45000;
+const ENRICH_BUDGET_MS = Number(process.env.MIGRATION_ENRICH_BUDGET_MS) || 280000;
 
 async function enrichWithinBudget(rawRows, enrichFn, headers) {
     let timer;

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -8,7 +8,7 @@
     ],
     "functions": {
         "index.js": {
-            "maxDuration": 60
+            "maxDuration": 300
         }
     },
     "env": {


### PR DESCRIPTION
## What

Super Data Migration all-KVK FLD pulls hit the edit-page enrichment time budget (45s) and fell back to inline list fields — leaving some detail columns incomplete (the "Edit-page enrichment hit its time budget" banner).

Raise the limits so large multi-KVK pulls finish enrichment:

- `MIGRATION_ENRICH_BUDGET_MS` default **45000 → 280000** (`backend/migration/engine.js`)
- Vercel function `maxDuration` **60 → 300** (`backend/vercel.json`)

Budget stays well under `maxDuration` (~20s margin for the rest of the request), so it degrades gracefully instead of the function hard-timing-out.

## Note

`maxDuration: 300` requires **Vercel Pro**. On Hobby (60s cap) the deploy is rejected and enrichment can't run past ~55s anyway. Both stay env/-config tunable.