### PR TITLE
perf(super-migration): defer OFT/FLD enrichment to selected-KVK rows

### DIFF
--- a/backend/migration/engine.js
+++ b/backend/migration/engine.js
@@ -44,7 +44,7 @@ async function enrichWithinBudget(rawRows, enrichFn, headers) {
  * Replay a pasted curl command server-side (browser can't — cross-origin +
  * the old site's session cookie). Returns the parsed JSON body.
  */
-async function fetchFromCurl(curl) {
+async function fetchFromCurl(curl, opts = {}) {
     const req = parseCurl(curl);
     const res = await fetch(req.url, {
         method: req.method,
@@ -66,7 +66,11 @@ async function fetchFromCurl(curl) {
     let enrichTruncated = false;
 
     // oft-data list JSON lacks technology options — enrich from each edit page.
-    if (req.url.includes('oft-data') && rows.length) {
+    // Super-migration defers this to transform-time (opts.deferOftEnrich) so only
+    // the rows for the user's SELECTED KVKs are enriched, not all 500+ — the
+    // edit-page fetch is the slow part. Per-KVK migration still enriches here
+    // (its pull is already one KVK, so the row count is small).
+    if (!opts.deferOftEnrich && req.url.includes('oft-data') && rows.length) {
         const { enrichOftRows } = require('./modules/oft.js');
         const out = await enrichWithinBudget(rows, enrichOftRows, req.headers);
         rows = out.rows;
@@ -75,7 +79,9 @@ async function fetchFromCurl(curl) {
     }
 
     // fld-data list JSON lacks full details — enrich from each edit page.
-    if (req.url.includes('fld-data') && rows.length) {
+    // Like OFT, super-migration defers this to transform-time (opts.deferFldEnrich)
+    // so only the selected-KVK rows are enriched, not all 800+.
+    if (!opts.deferFldEnrich && req.url.includes('fld-data') && rows.length) {
         const { enrichFldRows } = require('./modules/fld.js');
         const out = await enrichWithinBudget(rows, enrichFldRows, req.headers);
         rows = out.rows;

--- a/backend/migration/modules/fld.js
+++ b/backend/migration/modules/fld.js
@@ -111,7 +111,7 @@ async function enrichFldRows(rows, headers) {
     // Pre-fetch staff map so numeric staff_id on list rows can be resolved without edit HTML
     const staffMap = await fetchStaffMap(headers);
 
-    const concurrency = 5;
+    const concurrency = 20;
     const enriched = new Array(rows.length);
     
     for (let i = 0; i < rows.length; i += concurrency) {

--- a/backend/migration/modules/oft.js
+++ b/backend/migration/modules/oft.js
@@ -202,7 +202,7 @@ async function enrichOftRows(rows, headers) {
         referer: 'https://atariams.org/view-oft',
     };
     
-    const concurrency = 5;
+    const concurrency = 20;
     const enriched = new Array(rows.length);
     
     for (let i = 0; i < rows.length; i += concurrency) {

--- a/backend/migration/superEngine.js
+++ b/backend/migration/superEngine.js
@@ -58,15 +58,34 @@ function rowKvkName(row) {
     return decodeEntities(cleanText(findKvkName(row))) || '';
 }
 
+// Module key -> transform-time row enricher (edit-page fetches), for modules
+// whose list JSON omits detail fields. Mirrors the fetch-time enrichers, but
+// runs over the selected-KVK batch only. Keep in sync with the defer*Enrich
+// flags passed by superRoutes /fetch.
+const ENRICHERS = {
+    oft: (rows, headers) => require('./modules/oft.js').enrichOftRows(rows, headers),
+    fld: (rows, headers) => require('./modules/fld.js').enrichFldRows(rows, headers),
+};
+
 /**
  * Transform every old row, resolving each row's KVK independently. Rows whose
  * KVK name is missing or not present in our DB are reported as errors and
  * skipped (null), exactly like an unmapped row.
  */
-async function superTransform(moduleKey, raw) {
+async function superTransform(moduleKey, raw, headers) {
     const spec = getModule(moduleKey);
     const resolver = new MasterResolver();
-    const rows = extractRows(raw);
+    let rows = extractRows(raw);
+
+    // Some modules' full detail lives only on each row's edit page, not the list
+    // JSON. Fetch defers that enrichment (see engine.fetchFromCurl defer*Enrich)
+    // so we do it HERE — over just the rows in this transform batch, which are
+    // already filtered to the user's selected KVKs. Needs the old-site session
+    // headers, passed through from the pasted curl.
+    const enricher = ENRICHERS[moduleKey];
+    if (enricher && headers && rows.length) {
+        rows = await enricher(rows, headers);
+    }
 
     const records = [];
     const rowReports = [];

--- a/backend/migration/superRoutes.js
+++ b/backend/migration/superRoutes.js
@@ -5,6 +5,7 @@ const { listModules } = require('./registry.js');
 const { listMasterOptions } = require('./masterCatalog.js');
 const engine = require('./engine.js');
 const superEngine = require('./superEngine.js');
+const { parseCurl } = require('./curlParser.js');
 
 // Super-migration: paste a SUPERADMIN curl (kvk_id empty → all KVKs), pick a
 // module; the target KVK is resolved per-row from the curl. No KVK picker.
@@ -29,7 +30,12 @@ router.post('/fetch', async (req, res) => {
     try {
         const { curl } = req.body;
         if (!curl) return res.status(400).json({ error: 'curl is required' });
-        const out = await engine.fetchFromCurl(curl);
+        // Defer OFT/FLD edit-page enrichment to transform-time — it then runs
+        // over only the rows for the user's selected KVKs instead of every KVK.
+        const out = await engine.fetchFromCurl(curl, {
+            deferOftEnrich: true,
+            deferFldEnrich: true,
+        });
         res.json(out);
     } catch (err) {
         res.status(400).json({ error: err.message });
@@ -39,11 +45,14 @@ router.post('/fetch', async (req, res) => {
 // Map raw rows -> our schema, resolving each row's KVK from the row itself.
 router.post('/transform', async (req, res) => {
     try {
-        const { module, raw } = req.body;
+        const { module, raw, curl } = req.body;
         if (!module || raw === undefined) {
             return res.status(400).json({ error: 'module and raw are required' });
         }
-        const out = await superEngine.superTransform(module, raw);
+        // Headers (old-site session cookie) let OFT enrich each row's edit page
+        // here, over just this batch's selected-KVK rows.
+        const headers = curl ? parseCurl(curl).headers : undefined;
+        const out = await superEngine.superTransform(module, raw, headers);
         res.json(out);
     } catch (err) {
         res.status(400).json({ error: err.message });

--- a/frontend/src/pages/migration/SuperMigrationTool.tsx
+++ b/frontend/src/pages/migration/SuperMigrationTool.tsx
@@ -27,6 +27,12 @@ type Row = Record<string, unknown>
 // under the limit. ~200 rows/batch balances round-trips against per-call cost.
 const BATCH_SIZE = 200
 
+// OFT/FLD transform enriches each row from its edit page (extra HTTP per row),
+// so they need a smaller batch than the insert-only modules to stay under the
+// wall. Keep in sync with the backend ENRICHERS map.
+const ENRICH_BATCH_SIZE = 60
+const ENRICH_MODULES = new Set(['oft', 'fld'])
+
 // Mirror backend engine.extractRows: pull the row array out of a raw response
 // (DataTables `data`, nested `data.data`, or a bare array) so we can batch it.
 // Backend transform accepts a bare array (extractRows handles it), so each
@@ -330,6 +336,11 @@ export function SuperMigrationTool() {
                 selectedRawKvks.has(rowKvkName(r)),
             )
 
+            // Enrichment modules (OFT/FLD) fetch each row's edit page server-side
+            // during transform — a 200-row batch could approach the 60s serverless
+            // wall, so use a smaller batch. Other modules stay at BATCH_SIZE.
+            const batchSize = ENRICH_MODULES.has(moduleKey) ? ENRICH_BATCH_SIZE : BATCH_SIZE
+
             // Accumulate batch results in original row order. Report row indices
             // are batch-local, so shift them by the batch offset to stay aligned
             // with the flat `records` array the UI keys everything off.
@@ -339,9 +350,9 @@ export function SuperMigrationTool() {
             let warnCount = 0
 
             setProgress({ done: 0, total: allRows.length })
-            for (let off = 0; off < allRows.length; off += BATCH_SIZE) {
-                const slice = allRows.slice(off, off + BATCH_SIZE)
-                const out = await superMigrationApi.transform(moduleKey, slice)
+            for (let off = 0; off < allRows.length; off += batchSize) {
+                const slice = allRows.slice(off, off + batchSize)
+                const out = await superMigrationApi.transform(moduleKey, slice, curl)
                 ;(out.records as Array<Row | null>).forEach(r => records.push(r))
                 out.report.rows.forEach(rr =>
                     reportRows.push({ ...rr, index: rr.index + off }),

--- a/frontend/src/services/superMigrationApi.ts
+++ b/frontend/src/services/superMigrationApi.ts
@@ -22,8 +22,10 @@ export const superMigrationApi = {
     fetchCurl: (curl: string) =>
         apiClient.post<FetchResult>('/super-migration/fetch', { curl }),
 
-    transform: (module: string, raw: unknown) =>
-        apiClient.post<TransformResult>('/super-migration/transform', { module, raw }),
+    // `curl` is forwarded so the backend can enrich OFT rows from their edit
+    // pages at transform-time (over the selected-KVK rows only).
+    transform: (module: string, raw: unknown, curl?: string) =>
+        apiClient.post<TransformResult>('/super-migration/transform', { module, raw, curl }),
 
     seed: (module: string, records: unknown[]) =>
         apiClient.post<SeedResult>('/super-migration/seed', { module, records }),


### PR DESCRIPTION
Targets **dev**.

## Problem
Super-migration fetch for OFT/FLD took minutes. The list JSON omits detail fields (technologies, performance, result tables, full FLD details) that live only on each row's edit page, so fetch enriched **every** row — 500–800+ edit-page fetches across all KVKs — even though the user only migrates a few KVKs.

## Fix
Move enrichment from fetch → transform for super-migration:
- `/fetch` returns the raw list instantly (`deferOftEnrich`/`deferFldEnrich`).
- KVK picker builds from the inline `kvks.kvk_name`.
- `superTransform` enriches only each batch's rows — already filtered to the **selected** KVKs — via an `ENRICHERS` map (`oft`, `fld`).
- The old-site session headers are forwarded from the pasted curl to the transform call so edit pages can be fetched.
- Per-KVK migration unchanged (its pull is already one KVK, enriches at fetch).

Also:
- Enrich concurrency 5 → 20.
- Smaller transform batch (60) for enrichment modules so each request stays under the 60s serverless wall; insert-only modules stay at 200.

## Test
- backend modules load OK
- `bun run type-check` ✅
- `eslint` on changed files ✅