### PR TITLE
fix(super-migration): timeout enrichment fetches so transform can't hang

### DIFF
--- a/backend/migration/modules/fld.js
+++ b/backend/migration/modules/fld.js
@@ -75,6 +75,7 @@ async function fetchStaffMap(headers) {
                 'x-requested-with': 'XMLHttpRequest',
                 referer: 'https://atariams.org/view-staff',
             },
+            signal: AbortSignal.timeout(15000),
         });
         if (!res.ok) {
             console.error(`[fetchStaffMap] HTTP ${res.status}`);
@@ -111,7 +112,7 @@ async function enrichFldRows(rows, headers) {
     // Pre-fetch staff map so numeric staff_id on list rows can be resolved without edit HTML
     const staffMap = await fetchStaffMap(headers);
 
-    const concurrency = 20;
+    const concurrency = 10;
     const enriched = new Array(rows.length);
     
     for (let i = 0; i < rows.length; i += concurrency) {
@@ -134,7 +135,7 @@ async function enrichFldRows(rows, headers) {
             
             // 1. Fetch edit-fld page
             try {
-                const res = await fetch(fldEditPath(id), { headers: fetchHeaders });
+                const res = await fetch(fldEditPath(id), { headers: fetchHeaders, signal: AbortSignal.timeout(8000) });
                 const html = await res.text();
                 if (res.ok && (html.includes('sector_id') || html.includes('start_date') || html.includes('technology_demonstrated'))) {
                     enrichedRow._editHtml = html;
@@ -149,7 +150,7 @@ async function enrichFldRows(rows, headers) {
             const status = normalizeFldStatus(getRawStatusText(row));
             if (status === 'COMPLETED') {
                 try {
-                    const resResult = await fetch(fldResultEditPath(id), { headers: fetchHeaders });
+                    const resResult = await fetch(fldResultEditPath(id), { headers: fetchHeaders, signal: AbortSignal.timeout(8000) });
                     const htmlResult = await resResult.text();
                     if (resResult.ok && htmlResult.includes('demo_yield')) {
                         enrichedRow._resultHtml = htmlResult;

--- a/backend/migration/modules/oft.js
+++ b/backend/migration/modules/oft.js
@@ -202,7 +202,7 @@ async function enrichOftRows(rows, headers) {
         referer: 'https://atariams.org/view-oft',
     };
     
-    const concurrency = 20;
+    const concurrency = 10;
     const enriched = new Array(rows.length);
     
     for (let i = 0; i < rows.length; i += concurrency) {
@@ -219,7 +219,7 @@ async function enrichOftRows(rows, headers) {
             
             // 1. Fetch edit-oft page
             try {
-                const res = await fetch(oftEditPath(id), { headers: fetchHeaders });
+                const res = await fetch(oftEditPath(id), { headers: fetchHeaders, signal: AbortSignal.timeout(8000) });
                 const html = await res.text();
                 if (res.ok && html.includes('technology_treatments')) {
                     const fullTitle = parseTitleFromHtml(html);
@@ -238,7 +238,7 @@ async function enrichOftRows(rows, headers) {
             const status = normalizeOftStatus(getRawStatusText(row));
             if (status === 'COMPLETED') {
                 try {
-                    const resResult = await fetch(oftResultEditPath(id), { headers: fetchHeaders });
+                    const resResult = await fetch(oftResultEditPath(id), { headers: fetchHeaders, signal: AbortSignal.timeout(8000) });
                     const htmlResult = await resResult.text();
                     if (resResult.ok && htmlResult.includes('final_recommendation')) {
                         enrichedRow._resultHtml = htmlResult;

--- a/backend/migration/superEngine.js
+++ b/backend/migration/superEngine.js
@@ -84,7 +84,14 @@ async function superTransform(moduleKey, raw, headers) {
     // headers, passed through from the pasted curl.
     const enricher = ENRICHERS[moduleKey];
     if (enricher && headers && rows.length) {
-        rows = await enricher(rows, headers);
+        try {
+            rows = await enricher(rows, headers);
+        } catch {
+            // Enrichment is best-effort: per-row fetches already degrade to a
+            // warning, but if the whole enrich step throws (e.g. the old site
+            // drops the connection) keep the un-enriched rows so the transform
+            // still completes instead of failing the request.
+        }
     }
 
     const records = [];


### PR DESCRIPTION
Targets **dev**.

## Problem
Transform-time OFT/FLD enrichment fetched each row's edit page with **no timeout**. A single hung old-site page stalled the whole batch past the serverless wall, so the browser's request to our backend died with **"Failed to fetch"**.

## Fix
- **8s per-fetch timeout** on every enrichment fetch (15s for the staff-map pull). A slow/hung page now degrades to the existing `_enrichFailed` warning and the row still transforms.
- **Enrich concurrency 20 → 10** — gentler on the old PHP site (it was dropping connections under 20 parallel hits).
- **Guard** the enrich step in `superTransform` so a thrown enricher keeps the un-enriched rows instead of failing the whole transform request.

Backend-only.

## Test
- backend modules load OK