### PR TITLE
fix(about-kvk): module-wise report data, headers & equipment edit form

### DIFF
--- a/backend/config/reportConfig.js
+++ b/backend/config/reportConfig.js
@@ -80,6 +80,7 @@ const reportConfig = {
         {
             id: '1.4',
             title: 'All KVK staff Details',
+            exportTitle: 'Employee Details',
             description: 'All active employees/staff of the KVK',
             subsection: true,
             parentSectionId: '1',
@@ -149,6 +150,7 @@ const reportConfig = {
         {
             id: '1.7',
             title: 'Vehicle Status',
+            exportTitle: 'Vehicle Details',
             description: 'Vehicle reporting-year status (run, present status, repairing cost)',
             subsection: true,
             parentSectionId: '1',
@@ -174,6 +176,7 @@ const reportConfig = {
         {
             id: '1.8',
             title: 'Equipment Details',
+            exportTitle: 'Equipment Details',
             description: 'All equipments and their static details',
             subsection: true,
             parentSectionId: '1',
@@ -194,6 +197,7 @@ const reportConfig = {
         {
             id: '1.9',
             title: 'Equipment Status',
+            exportTitle: 'Equipment Status',
             description: 'Equipment reporting-year status (present status by year)',
             subsection: true,
             parentSectionId: '1',

--- a/backend/controllers/exportController.js
+++ b/backend/controllers/exportController.js
@@ -99,6 +99,69 @@ const DRMR_ACTIVITY_ROW_CONFIG = [
     { activityType: 'OTHER', itemLabel: 'Any other (specify)', unitFallback: 'N/A', valueKey: 'any_other_count', prefix: 'any_other_count_' },
 ];
 
+// Frontend posts staff rows with the job type as a relation (jobTypeMaster.name)
+// or an "Other" free-text (jobTypeOther) — but the report config / template read a
+// flat `jobType`. Flatten it here so PDF, Excel and Word all show the same value.
+function enrichEmployeesExport(rawData) {
+    const rows = Array.isArray(rawData) ? rawData : (rawData ? [rawData] : []);
+    return rows.map((row) => ({
+        ...row,
+        jobType: row?.jobType
+            || row?.jobTypeMaster?.name
+            || row?.jobTypeOther
+            || '',
+    }));
+}
+
+// Frontend posts vehicle-status rows with the static vehicle fields nested under
+// `vehicle`, status under `vehicleStatus`, funding under `assetFundingSource` —
+// but the report config / template read flat keys. Flatten so PDF, Excel and Word
+// all show the same values. Existing flat values (comprehensive shape) win.
+function enrichVehicleDetailsExport(rawData) {
+    const rows = Array.isArray(rawData) ? rawData : (rawData ? [rawData] : []);
+    const pick = (flat, nested) => (flat !== undefined && flat !== null && flat !== '' ? flat : (nested ?? ''));
+    return rows.map((row) => ({
+        ...row,
+        vehicleName: pick(row?.vehicleName, row?.vehicle?.vehicleName),
+        registrationNo: pick(row?.registrationNo, row?.vehicle?.registrationNo),
+        yearOfPurchase: pick(row?.yearOfPurchase, row?.vehicle?.yearOfPurchase),
+        totalCost: pick(row?.totalCost, row?.vehicle?.totalCost),
+        presentStatus: pick(row?.presentStatus, row?.vehicleStatus?.statusLabel),
+        sourceOfFunding: pick(row?.sourceOfFunding, row?.assetFundingSource?.name),
+    }));
+}
+
+const pickVal = (...vals) => {
+    for (const v of vals) if (v !== undefined && v !== null && v !== '') return v;
+    return '';
+};
+
+// Equipment Status (1.9): frontend posts the static fields nested under `equipment`,
+// status under `equipmentStatus`, funding under `assetFundingSource`. Flatten so
+// PDF, Excel and Word all show the same values.
+function enrichEquipmentRecordsExport(rawData) {
+    const rows = Array.isArray(rawData) ? rawData : (rawData ? [rawData] : []);
+    return rows.map((row) => ({
+        ...row,
+        equipmentName: pickVal(row?.equipmentName, row?.equipment?.equipmentName, row?.equipment?.equipmentMaster?.name),
+        yearOfPurchase: pickVal(row?.yearOfPurchase, row?.equipment?.yearOfPurchase),
+        totalCost: pickVal(row?.totalCost, row?.equipment?.totalCost),
+        sourceOfFunding: pickVal(row?.sourceOfFunding, row?.assetFundingSource?.name, row?.equipment?.assetFundingSource?.name),
+        presentStatus: pickVal(row?.presentStatus, row?.equipmentStatus?.statusLabel),
+    }));
+}
+
+// Equipment Details (1.8): static equipment rows. Only funding is nested
+// (assetFundingSource.name) — flatten it; name/year/cost are already flat.
+function enrichEquipmentDetailsExport(rawData) {
+    const rows = Array.isArray(rawData) ? rawData : (rawData ? [rawData] : []);
+    return rows.map((row) => ({
+        ...row,
+        equipmentName: pickVal(row?.equipmentName, row?.equipmentMaster?.name),
+        sourceOfFunding: pickVal(row?.sourceOfFunding, row?.assetFundingSource?.name),
+    }));
+}
+
 const exportData = async (req, res) => {
     try {
         const {
@@ -120,6 +183,18 @@ const exportData = async (req, res) => {
         let fileName = `${title.toLowerCase().replace(/\s+/g, '-')}-${new Date().getTime()}`;
 
         let effectiveRawData = rawData;
+        if (templateKey === 'about-kvk-employees-full' && rawData) {
+            effectiveRawData = enrichEmployeesExport(rawData);
+        }
+        if (templateKey === 'about-kvk-vehicle-details' && rawData) {
+            effectiveRawData = enrichVehicleDetailsExport(rawData);
+        }
+        if (templateKey === 'about-kvk-equipment-records' && rawData) {
+            effectiveRawData = enrichEquipmentRecordsExport(rawData);
+        }
+        if (templateKey === 'about-kvk-equipment-details-table' && rawData) {
+            effectiveRawData = enrichEquipmentDetailsExport(rawData);
+        }
         if (templateKey === 'nf-soil-data-information' && rawData) {
             effectiveRawData = await prepareNfSoilExportPayload(rawData);
         }

--- a/backend/repositories/forms/aboutKvkRepository.js
+++ b/backend/repositories/forms/aboutKvkRepository.js
@@ -243,6 +243,74 @@ async function resolveDetailEntityId(entityName, parsedId) {
     return parsedId;
 }
 
+// Legacy KvkEquipment rows can have null equipmentTypeId/equipmentMasterId (the
+// curated parents). The raw model name lives on companyBrandModel and maps back
+// to its parent EquipmentMaster + EquipmentType via EquipmentModelMaster. Recover
+// those ids/names so the Equipment Details edit form's Type / Model (Model/Brand)
+// dropdowns prefill even when the equipment row never stored the FKs.
+const EQUIPMENT_MASTER_SELECT = {
+    equipmentMasterId: true,
+    name: true,
+    equipmentTypeId: true,
+    equipmentType: { select: { equipmentTypeId: true, name: true } },
+};
+
+async function recoverEquipmentParents(entityName, rows) {
+    if (entityName !== 'kvk-equipment-details' && entityName !== 'kvk-equipments') return;
+    const list = Array.isArray(rows) ? rows : (rows ? [rows] : []);
+    const getEq = (r) => (entityName === 'kvk-equipments' ? r : r?.equipment);
+    const rawName = (eq) => String(eq.companyBrandModel || eq.equipmentName || '').trim();
+    const targets = list
+        .map(getEq)
+        .filter((eq) => eq && eq.equipmentMasterId == null && rawName(eq));
+    if (targets.length === 0) return;
+
+    const names = [...new Set(targets.map(rawName))];
+
+    // 1) exact match on the migration reverse-lookup table.
+    const exact = await prisma.equipmentModelMaster.findMany({
+        where: { name: { in: names } },
+        select: { name: true, equipmentMaster: { select: EQUIPMENT_MASTER_SELECT } },
+    });
+    const byName = new Map();
+    for (const m of exact) {
+        if (m.equipmentMaster && !byName.has(m.name)) byName.set(m.name, m.equipmentMaster);
+    }
+
+    // 2) prefix fallback: some raw names carry extra suffixes ("… with accessories
+    //    including installation") not present in the table. Match the longest model
+    //    name that the raw name starts with.
+    const unmatched = names.filter((n) => !byName.has(n));
+    if (unmatched.length > 0) {
+        const allModels = await prisma.equipmentModelMaster.findMany({
+            select: { name: true, equipmentMaster: { select: EQUIPMENT_MASTER_SELECT } },
+        });
+        const cleaned = allModels
+            .filter((m) => m.equipmentMaster && m.name)
+            .map((m) => ({ lower: m.name.trim().toLowerCase(), master: m.equipmentMaster }))
+            .sort((a, b) => b.lower.length - a.lower.length);
+        for (const n of unmatched) {
+            const lower = n.toLowerCase();
+            const hit = cleaned.find((m) => lower.startsWith(m.lower) || m.lower.startsWith(lower));
+            if (hit) byName.set(n, hit.master);
+        }
+    }
+
+    for (const eq of targets) {
+        const master = byName.get(rawName(eq));
+        if (!master) continue;
+        eq.equipmentMasterId = master.equipmentMasterId;
+        eq.equipmentTypeId = master.equipmentTypeId;
+        eq.equipmentMaster = { equipmentMasterId: master.equipmentMasterId, name: master.name };
+        if (master.equipmentType) {
+            eq.equipmentType = {
+                equipmentTypeId: master.equipmentType.equipmentTypeId,
+                name: master.equipmentType.name,
+            };
+        }
+    }
+}
+
 async function findAll(entityName, options = {}, user = null) {
     const config = getEntityConfig(entityName);
     const model = prisma[config.model];
@@ -408,6 +476,8 @@ async function findAll(entityName, options = {}, user = null) {
 
     }
 
+    await recoverEquipmentParents(entityName, data);
+
     return { data, total };
 }
 
@@ -429,10 +499,12 @@ async function findById(entityName, id) {
         return null;
     }
 
-    return await prisma[config.model].findUnique({
+    const record = await prisma[config.model].findUnique({
         where: { [config.idField]: resolvedId },
         include: config.includes,
     });
+    await recoverEquipmentParents(entityName, record);
+    return record;
 }
 
 /**

--- a/backend/services/reports/formsTemplate/aboutkvkTemplates/employeesFullTemplate.js
+++ b/backend/services/reports/formsTemplate/aboutkvkTemplates/employeesFullTemplate.js
@@ -1,4 +1,14 @@
-function renderEmployeesFullSection(section, data, sectionId, isFirstSection) {
+// Scale the table font down as the column count grows so wide tables fit the
+// A4 page width instead of cropping. Mirrors fitFont() in the FLD templates.
+function fitFont(colCount) {
+    if (colCount <= 8) return 7.5
+    if (colCount <= 12) return 6.5
+    if (colCount <= 16) return 5.5
+    if (colCount <= 22) return 4.6
+    return 4
+}
+
+function renderEmployeesFullSection(section, data, sectionId, isFirstSection, reportContext = {}) {
     if (!data || (Array.isArray(data) && data.length === 0)) {
         return this._generateEmptySection(section, null, sectionId, isFirstSection)
     }
@@ -6,10 +16,41 @@ function renderEmployeesFullSection(section, data, sectionId, isFirstSection) {
     const records = Array.isArray(data) ? data : [data]
     const pageClass = isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued'
 
+    // 12 data columns → scale font to fit page.
+    const fs = fitFont(12)
+
+    // Module name. Module-wise export (standalone) uses the friendly name with no
+    // section number ("Employee Details"); the comprehensive report keeps the
+    // numbered title ("1.4 All KVK staff Details") for TOC consistency.
+    const moduleLabel = reportContext.isStandalone
+        ? (section.exportTitle || section.title)
+        : `${section.id} ${this._escapeHtml(section.title)}`
+
+    // KVK this report belongs to. KVK download → single KVK; admin grouped
+    // download → many, so summarise the count.
+    const kvkNames = Array.from(new Set(
+        records
+            .map(r => this._pickValue(r, ['KVK', 'kvk.kvkName']))
+            .filter(v => v && v !== '-')
+            .map(v => String(v))
+    ))
+    const kvkLabel = kvkNames.length === 1
+        ? kvkNames[0]
+        : (kvkNames.length === 0 ? '-' : `${kvkNames.length} KVKs`)
+
+    // Standalone gets a single clean header block (one underline); comprehensive
+    // report keeps its existing numbered section title.
+    const header = reportContext.isStandalone
+        ? `<div class="module-report-header">
+        <h1 class="module-report-title">${this._escapeHtml(moduleLabel)}</h1>
+        <div class="module-report-sub"><strong>KVK:</strong> ${this._escapeHtml(kvkLabel)}</div>
+    </div>`
+        : `<h1 class="section-title">${moduleLabel}</h1>`
+
     let html = `
 <div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>
-    <table class="data-table">
+    ${header}
+    <table class="data-table report-fit" style="font-size:${fs}pt;">
         <thead>
             <tr>
                 <th class="s-no">Sl. No.</th>
@@ -23,7 +64,7 @@ function renderEmployeesFullSection(section, data, sectionId, isFirstSection) {
                 <th>Category (SC/ST/ OBC/ General)</th>
                 <th>Job Type</th>
                 <th>Mobile</th>
-                <th>Email</th>
+                <th class="emp-email">Email</th>
             </tr>
         </thead>
         <tbody>`
@@ -46,7 +87,10 @@ function renderEmployeesFullSection(section, data, sectionId, isFirstSection) {
             row,
             ['Category (SC/ST/ OBC/ General)', 'staffCategory.categoryName']
         ) || '-'
-        const jobType = this._pickValue(row, ['Job Type', 'jobType']) || '-'
+        const jobType = this._pickValue(
+            row,
+            ['Job Type', 'jobType', 'jobTypeMaster.name', 'jobTypeOther']
+        ) || '-'
         const mobile = this._pickValue(row, ['Mobile', 'mobile']) || '-'
         const email = this._pickValue(row, ['Email', 'email']) || '-'
 
@@ -63,7 +107,7 @@ function renderEmployeesFullSection(section, data, sectionId, isFirstSection) {
                 <td>${this._escapeHtml(String(category))}</td>
                 <td>${this._escapeHtml(String(jobType))}</td>
                 <td>${this._escapeHtml(String(mobile))}</td>
-                <td>${this._escapeHtml(String(email))}</td>
+                <td class="emp-email">${this._escapeHtml(String(email))}</td>
             </tr>`
     })
 
@@ -78,4 +122,3 @@ function renderEmployeesFullSection(section, data, sectionId, isFirstSection) {
 module.exports = {
     renderEmployeesFullSection,
 }
-

--- a/backend/services/reports/formsTemplate/aboutkvkTemplates/equipmentDetailsTemplate.js
+++ b/backend/services/reports/formsTemplate/aboutkvkTemplates/equipmentDetailsTemplate.js
@@ -6,7 +6,7 @@
  * totalCost, sourceOfFunding }.
  * Bound to reportTemplateService (`this`).
  */
-function renderEquipmentDetailsSection(section, data, sectionId, isFirstSection) {
+function renderEquipmentDetailsSection(section, data, sectionId, isFirstSection, reportContext = {}) {
     const records = Array.isArray(data) ? data : (data ? [data] : [])
     if (records.length === 0) {
         return this._generateEmptySection(section, null, sectionId, isFirstSection)
@@ -15,12 +15,31 @@ function renderEquipmentDetailsSection(section, data, sectionId, isFirstSection)
     const pageClass = isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued'
     const dash = (v) => (v === null || v === undefined || v === '' ? '-' : v)
 
+    const moduleLabel = reportContext.isStandalone
+        ? (section.exportTitle || section.title)
+        : `${section.id} ${this._escapeHtml(section.title)}`
+    const kvkNames = Array.from(new Set(
+        records
+            .map(r => this._pickValue(r, ['KVK', 'kvk.kvkName']))
+            .filter(v => v && v !== '-')
+            .map(v => String(v))
+    ))
+    const kvkLabel = kvkNames.length === 1
+        ? kvkNames[0]
+        : (kvkNames.length === 0 ? '-' : `${kvkNames.length} KVKs`)
+    const header = reportContext.isStandalone
+        ? `<div class="module-report-header">
+        <h1 class="module-report-title">${this._escapeHtml(moduleLabel)}</h1>
+        <div class="module-report-sub"><strong>KVK:</strong> ${this._escapeHtml(kvkLabel)}</div>
+    </div>`
+        : `<h1 class="section-title">${moduleLabel}</h1>`
+
     const rows = records.map((row, index) => {
         const kvk = this._pickValue(row, ['KVK', 'kvk.kvkName']) || '-'
-        const name = this._pickValue(row, ['Equipment Name', 'equipmentName']) || '-'
+        const name = this._pickValue(row, ['Equipment Name', 'equipmentName', 'equipmentMaster.name']) || '-'
         const year = dash(this._pickValue(row, ['Year of Purchase', 'yearOfPurchase']))
         const cost = dash(this._pickValue(row, ['Cost (Rs.)', 'totalCost']))
-        const funding = this._pickValue(row, ['Source of Funding', 'sourceOfFunding']) || '-'
+        const funding = this._pickValue(row, ['Source of Funding', 'sourceOfFunding', 'assetFundingSource.name']) || '-'
         return `
             <tr class="${index % 2 === 0 ? 'even' : 'odd'}">
                 <td class="s-no">${index + 1}</td>
@@ -34,7 +53,7 @@ function renderEquipmentDetailsSection(section, data, sectionId, isFirstSection)
 
     return `
 <div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>
+    ${header}
     <table class="data-table">
         <thead>
             <tr>

--- a/backend/services/reports/formsTemplate/aboutkvkTemplates/equipmentRecordsTemplate.js
+++ b/backend/services/reports/formsTemplate/aboutkvkTemplates/equipmentRecordsTemplate.js
@@ -1,10 +1,29 @@
-function renderEquipmentRecordsSection(section, data, sectionId, isFirstSection) {
+function renderEquipmentRecordsSection(section, data, sectionId, isFirstSection, reportContext = {}) {
     if (!data || (Array.isArray(data) && data.length === 0)) {
         return this._generateEmptySection(section, null, sectionId, isFirstSection);
     }
 
     const records = Array.isArray(data) ? data : [data];
     const pageClass = isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued';
+
+    const moduleLabel = reportContext.isStandalone
+        ? (section.exportTitle || section.title)
+        : `${section.id} ${this._escapeHtml(section.title)}`;
+    const kvkNames = Array.from(new Set(
+        records
+            .map(r => this._pickValue(r, ['KVK', 'kvk.kvkName', 'kvkName']))
+            .filter(v => v && v !== '-')
+            .map(v => String(v))
+    ));
+    const kvkLabel = kvkNames.length === 1
+        ? kvkNames[0]
+        : (kvkNames.length === 0 ? '-' : `${kvkNames.length} KVKs`);
+    const header = reportContext.isStandalone
+        ? `<div class="module-report-header">
+        <h1 class="module-report-title">${this._escapeHtml(moduleLabel)}</h1>
+        <div class="module-report-sub"><strong>KVK:</strong> ${this._escapeHtml(kvkLabel)}</div>
+    </div>`
+        : `<h1 class="section-title">${moduleLabel}</h1>`;
 
     const normalizeDisplay = (value, { isYear = false } = {}) => {
         if (value === null || value === undefined || value === '') return '-';
@@ -34,7 +53,7 @@ function renderEquipmentRecordsSection(section, data, sectionId, isFirstSection)
 
     let html = `
 <div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>
+    ${header}
     <table class="data-table">
         <thead>
             <tr>
@@ -53,11 +72,11 @@ function renderEquipmentRecordsSection(section, data, sectionId, isFirstSection)
     records.forEach((row, index) => {
         const year = normalizeDisplay(this._pickValue(row, ['Year', 'reportingYear']), { isYear: true });
         const kvk = normalizeDisplay(this._pickValue(row, ['KVK', 'kvk.kvkName', 'kvkName']));
-        const equipmentName = normalizeDisplay(this._pickValue(row, ['Equipment Name', 'equipmentName']));
-        const yearOfPurchase = normalizeDisplay(this._pickValue(row, ['Year of purchase', 'yearOfPurchase']));
-        const cost = normalizeDisplay(this._pickValue(row, ['Cost (Rs.)', 'totalCost']));
-        const sourceOfFund = normalizeDisplay(this._pickValue(row, ['Source of fund', 'sourceOfFunding']));
-        const presentStatus = normalizeDisplay(this._pickValue(row, ['Present status', 'presentStatus']));
+        const equipmentName = normalizeDisplay(this._pickValue(row, ['Equipment Name', 'equipmentName', 'equipment.equipmentName', 'equipment.equipmentMaster.name']));
+        const yearOfPurchase = normalizeDisplay(this._pickValue(row, ['Year of purchase', 'yearOfPurchase', 'equipment.yearOfPurchase']));
+        const cost = normalizeDisplay(this._pickValue(row, ['Cost (Rs.)', 'totalCost', 'equipment.totalCost']));
+        const sourceOfFund = normalizeDisplay(this._pickValue(row, ['Source of fund', 'sourceOfFunding', 'assetFundingSource.name', 'equipment.assetFundingSource.name']));
+        const presentStatus = normalizeDisplay(this._pickValue(row, ['Present status', 'presentStatus', 'equipmentStatus.statusLabel']));
 
         html += `
             <tr class="${index % 2 === 0 ? 'even' : 'odd'}">

--- a/backend/services/reports/formsTemplate/aboutkvkTemplates/vehicleDetailsTemplate.js
+++ b/backend/services/reports/formsTemplate/aboutkvkTemplates/vehicleDetailsTemplate.js
@@ -1,4 +1,4 @@
-function renderVehicleDetailsSection(section, data, sectionId, isFirstSection) {
+function renderVehicleDetailsSection(section, data, sectionId, isFirstSection, reportContext = {}) {
     if (!data || (Array.isArray(data) && data.length === 0)) {
         return this._generateEmptySection(section, null, sectionId, isFirstSection)
     }
@@ -6,9 +6,32 @@ function renderVehicleDetailsSection(section, data, sectionId, isFirstSection) {
     const records = Array.isArray(data) ? data : [data]
     const pageClass = isFirstSection ? 'section-page section-page-first' : 'section-page section-page-continued'
 
+    // Module-wise (standalone) export: friendly title, no section number, single
+    // clean header with the KVK. Comprehensive report keeps its numbered title.
+    const moduleLabel = reportContext.isStandalone
+        ? (section.exportTitle || section.title)
+        : `${section.id} ${this._escapeHtml(section.title)}`
+
+    const kvkNames = Array.from(new Set(
+        records
+            .map(r => this._pickValue(r, ['KVK', 'kvk.kvkName']))
+            .filter(v => v && v !== '-')
+            .map(v => String(v))
+    ))
+    const kvkLabel = kvkNames.length === 1
+        ? kvkNames[0]
+        : (kvkNames.length === 0 ? '-' : `${kvkNames.length} KVKs`)
+
+    const header = reportContext.isStandalone
+        ? `<div class="module-report-header">
+        <h1 class="module-report-title">${this._escapeHtml(moduleLabel)}</h1>
+        <div class="module-report-sub"><strong>KVK:</strong> ${this._escapeHtml(kvkLabel)}</div>
+    </div>`
+        : `<h1 class="section-title">${moduleLabel}</h1>`
+
     let html = `
 <div id="${sectionId}" class="${pageClass}">
-    <h1 class="section-title">${section.id} ${this._escapeHtml(section.title)}</h1>
+    ${header}
     <table class="data-table">
         <thead>
             <tr>
@@ -43,15 +66,15 @@ function renderVehicleDetailsSection(section, data, sectionId, isFirstSection) {
     records.forEach((row, index) => {
         const year = normalizeDisplay(this._pickValue(row, ['Year', 'reportingYear']))
         const kvk = this._pickValue(row, ['KVK', 'kvk.kvkName']) || '-'
-        const vehicle = this._pickValue(row, ['Vehicle', 'vehicleName']) || '-'
-        const registrationNo = this._pickValue(row, ['Registration No.', 'registrationNo']) || '-'
-        const yearOfPurchase = this._pickValue(row, ['Year of purchase', 'yearOfPurchase']) || '-'
+        const vehicle = this._pickValue(row, ['Vehicle', 'vehicleName', 'vehicle.vehicleName']) || '-'
+        const registrationNo = this._pickValue(row, ['Registration No.', 'registrationNo', 'vehicle.registrationNo']) || '-'
+        const yearOfPurchase = this._pickValue(row, ['Year of purchase', 'yearOfPurchase', 'vehicle.yearOfPurchase']) || '-'
         const dash = (v) => (v === null || v === undefined || v === '' ? '-' : v)
-        const cost = dash(this._pickValue(row, ['Cost (Rs.)', 'totalCost']))
+        const cost = dash(this._pickValue(row, ['Cost (Rs.)', 'totalCost', 'vehicle.totalCost']))
         const totalRun = dash(this._pickValue(row, ['Total Run(km/hrs)', 'totalRun']))
-        const presentStatus = this._pickValue(row, ['Present status', 'presentStatus']) || '-'
+        const presentStatus = this._pickValue(row, ['Present status', 'presentStatus', 'vehicleStatus.statusLabel']) || '-'
         const repairingCost = dash(this._pickValue(row, ['Repairing Cost', 'repairingCost']))
-        const fundingSource = this._pickValue(row, ['Funding Source', 'sourceOfFunding']) || '-'
+        const fundingSource = this._pickValue(row, ['Funding Source', 'sourceOfFunding', 'assetFundingSource.name']) || '-'
 
         html += `
             <tr class="${index % 2 === 0 ? 'even' : 'odd'}">

--- a/backend/services/reports/reportTemplateService.js
+++ b/backend/services/reports/reportTemplateService.js
@@ -359,6 +359,7 @@ class ReportTemplateService {
         const pseudoSection = {
             id: sectionId,
             title,
+            ...(fullSection?.exportTitle ? { exportTitle: fullSection.exportTitle } : {}),
             ...(fullSection?.fields?.length ? { fields: fullSection.fields } : {}),
         };
         const sectionConfig = { customTemplate: templateKey };
@@ -1324,6 +1325,26 @@ class ReportTemplateService {
         page-break-after: avoid;
     }
 
+    /* Module-wise (standalone) export header: title + KVK, one clean underline. */
+    .module-report-header {
+        margin: 0 0 10px 0;
+        padding-bottom: 6px;
+        border-bottom: 1px solid #000000;
+        page-break-after: avoid;
+    }
+
+    .module-report-title {
+        font-size: 13pt;
+        font-weight: bold;
+        color: #000000;
+        margin: 0 0 4px 0;
+    }
+
+    .module-report-sub {
+        font-size: 8.5pt;
+        color: #000000;
+    }
+
     .data-table,
     .grouped-table {
         width: 100%;
@@ -1388,6 +1409,14 @@ class ReportTemplateService {
     .oft-statewise td:first-child,
     .report-fit th:first-child,
     .report-fit td:first-child {
+        text-align: left;
+    }
+
+    /* Email is a long unbroken token — allow it to wrap so it never crops. */
+    .report-fit th.emp-email,
+    .report-fit td.emp-email {
+        word-break: break-all;
+        overflow-wrap: anywhere;
         text-align: left;
     }
 

--- a/frontend/src/pages/dashboard/shared/dataManagementExportTemplateKeys.ts
+++ b/frontend/src/pages/dashboard/shared/dataManagementExportTemplateKeys.ts
@@ -11,6 +11,7 @@ export const ENTITY_TYPE_EXPORT_TEMPLATE_MAP: Partial<
     [ENTITY_TYPES.KVK_EMPLOYEES]: 'about-kvk-employees-full',
     [ENTITY_TYPES.KVK_VEHICLES]: 'about-kvk-vehicles',
     [ENTITY_TYPES.KVK_VEHICLE_DETAILS]: 'about-kvk-vehicle-details',
+    [ENTITY_TYPES.KVK_EQUIPMENTS]: 'about-kvk-equipment-details-table',
     [ENTITY_TYPES.KVK_EQUIPMENT_DETAILS]: 'about-kvk-equipment-records',
     [ENTITY_TYPES.ACHIEVEMENT_OFT]: 'oft-combined',
     [ENTITY_TYPES.ACHIEVEMENT_FLD]: 'fld-page-report',

--- a/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
+++ b/frontend/src/pages/dashboard/shared/forms/AboutKvkForms.tsx
@@ -247,9 +247,16 @@ export const AboutKvkForms: React.FC<AboutKvkFormsProps> = ({
             formData._filterEquipmentMasterId != null
         )
             return
-        const eq = (equipments as any[]).find(
+        // Prefer the record's own nested equipment (loaded with the detail on edit) —
+        // the equipments dropdown list is filtered/paginated and may omit this row or
+        // its type/master ids. Fall back to the list lookup for newly-picked items.
+        const eqFromList = (equipments as any[]).find(
             (e) => Number(e.equipmentId) === Number(formData.equipmentId),
         )
+        const nested = formData.equipment
+        const eq = (nested && (nested.equipmentTypeId != null || nested.equipmentMasterId != null))
+            ? nested
+            : eqFromList
         if (!eq) return
         if (eq.equipmentTypeId == null && eq.equipmentMasterId == null) return
         setFormData((prev: any) => ({


### PR DESCRIPTION
## Summary
Module-wise report (PDF/Excel/Word) fixes for the **About KVK** module, plus an Equipment Details edit-form fix. Module-wise exports render from the frontend-posted `rawData` (not the backend report repo), whose nested relations didn't match the flat keys read by the report config/templates — so several columns rendered as `-`. Flattened the shapes once in `exportController` so all three formats match.

## Data fixes (the `-` columns)
- **Employees (1.4):** `jobType` ← `jobTypeMaster.name` / `jobTypeOther`
- **Vehicle Status (1.7):** `vehicle.*`, `vehicleStatus.statusLabel`, `assetFundingSource.name`
- **Equipment Status (1.9):** `equipment.*`, `equipmentStatus.statusLabel`, `assetFundingSource.name`
- **Equipment Details (1.8):** `assetFundingSource.name`; also wired `KVK_EQUIPMENTS` → export template key (was exporting generic, no template/header)

## Report presentation
- Module exports drop the section number — new `exportTitle` config field + `reportContext.isStandalone` branch (comprehensive report keeps numbered titles).
- Clean single-underline `module-report-header` (title + KVK; KVK download shows name, admin grouped shows "N KVKs").
- Wide employees table fit to page (`report-fit` + scaled font + email wrap).

## Equipment Details edit form
- Equipment Type / Equipment (Model/Brand) dropdowns were empty on edit: legacy `KvkEquipment` rows have null type/master FKs.
- Recover them from `EquipmentModelMaster` by `companyBrandModel` (exact, then prefix match) in `findAll`/`findById`, and prefer the record's own nested `equipment` when backfilling the form selects.

## Testing
- Render checks for all four modules confirm columns + headers populate from frontend-shaped nested data.
- Read-only DB check confirms equipment-parent recovery (eq 1698 → type 12 *Cooling Equipment*, master 170 *Air Conditioner*).
- Frontend `type-check` passes; backend files syntax-checked.